### PR TITLE
Types: Add method overload for transform & bundle functions

### DIFF
--- a/node/index.d.ts
+++ b/node/index.d.ts
@@ -22,7 +22,7 @@ export interface TransformOptions {
    * urls later (after bundling). Dependencies are returned as part of the result.
    */
   analyzeDependencies?: boolean,
-  /** 
+  /**
    * Replaces user action pseudo classes with class names that can be applied from JavaScript.
    * This is useful for polyfills, for example.
    */
@@ -56,13 +56,13 @@ export interface TransformResult {
   /** The transformed code. */
   code: Buffer,
   /** The generated source map, if enabled. */
-  map: Buffer | void,
+  map: Buffer | undefined,
   /** CSS module exports, if enabled. */
-  exports: CSSModuleExports | void,
+  exports: CSSModuleExports | undefined,
   /** CSS module references, if `dashedIdents` is enabled. */
   references: CSSModuleReferences,
   /** `@import` and `url()` dependencies, if enabled. */
-  dependencies: Dependency[] | void
+  dependencies: Dependency[] | undefined
 }
 
 export interface CSSModulesConfig {
@@ -157,6 +157,13 @@ export interface Location {
  * Compiles a CSS file, including optionally minifying and lowering syntax to the given
  * targets. A source map may also be generated, but this is not enabled by default.
  */
+export declare function transform(options: TransformOptions & { sourceMap: true, cssModules: true, analyzeDependencies: true }): TransformResult & { map: Buffer, exports: CSSModuleExports, dependencies: Dependency[] };
+export declare function transform(options: TransformOptions & { sourceMap: true, analyzeDependencies: true }): TransformResult & { map: Buffer,dependencies: Dependency[] };
+export declare function transform(options: TransformOptions & { sourceMap: true, cssModules: true }): TransformResult & { map: Buffer, exports: CSSModuleExports };
+export declare function transform(options: TransformOptions & { cssModules: true, analyzeDependencies: true }): TransformResult & { exports: CSSModuleExports,dependencies: Dependency[] };
+export declare function transform(options: TransformOptions & { sourceMap: true }): TransformResult & { map: Buffer };
+export declare function transform(options: TransformOptions & { cssModules: true }): TransformResult & { exports: CSSModuleExports };
+export declare function transform(options: TransformOptions & { analyzeDependencies: true }): TransformResult & { dependencies: Dependency[] };
 export declare function transform(options: TransformOptions): TransformResult;
 
 export interface TransformAttributeOptions {
@@ -168,7 +175,7 @@ export interface TransformAttributeOptions {
   targets?: Targets,
   /**
    * Whether to analyze `url()` dependencies.
-   * When enabled, `url()` dependencies are replaced with hashed placeholders 
+   * When enabled, `url()` dependencies are replaced with hashed placeholders
    * that can be replaced with the final urls later (after bundling).
    * Dependencies are returned as part of the result.
    */
@@ -179,12 +186,13 @@ export interface TransformAttributeResult {
   /** The transformed code. */
   code: Buffer,
   /** `@import` and `url()` dependencies, if enabled. */
-  dependencies: Dependency[] | void
+  dependencies: Dependency[] | undefined
 }
 
 /**
  * Compiles a single CSS declaration list, such as an inline style attribute in HTML.
  */
+export declare function transformStyleAttribute(options: TransformAttributeOptions & { analyzeDependencies: true }): TransformAttributeResult & { dependencies: Dependency[] };
 export declare function transformStyleAttribute(options: TransformAttributeOptions): TransformAttributeResult;
 
 /**
@@ -196,4 +204,11 @@ export declare function browserslistToTargets(browserslist: string[]): Targets;
 /**
  * Bundles a CSS file and its dependencies, inlining @import rules.
  */
+export declare function bundle(options: BundleOptions & { sourceMap: true, cssModules: true, analyzeDependencies: true }): TransformResult & { map: Buffer, exports: CSSModuleExports, dependencies: Dependency[] };
+export declare function bundle(options: BundleOptions & { sourceMap: true, analyzeDependencies: true }): TransformResult & { map: Buffer,dependencies: Dependency[] };
+export declare function bundle(options: BundleOptions & { sourceMap: true, cssModules: true }): TransformResult & { map: Buffer, exports: CSSModuleExports };
+export declare function bundle(options: BundleOptions & { cssModules: true, analyzeDependencies: true }): TransformResult & { exports: CSSModuleExports,dependencies: Dependency[] };
+export declare function bundle(options: BundleOptions & { sourceMap: true }): TransformResult & { map: Buffer };
+export declare function bundle(options: BundleOptions & { cssModules: true }): TransformResult & { exports: CSSModuleExports };
+export declare function bundle(options: BundleOptions & { analyzeDependencies: true }): TransformResult & { dependencies: Dependency[] };
 export declare function bundle(options: BundleOptions): TransformResult;

--- a/scripts/build-flow.js
+++ b/scripts/build-flow.js
@@ -5,6 +5,7 @@ let index = fs.readFileSync(dir + '/node/index.d.ts', 'utf8');
 index = '// @flow\n' + index;
 index = index.replace(/export interface (.*?) \{((?:.|\n)*?)\}/g, 'export type $1 = {|$2|};');
 index = index.replace(/export declare function/g, 'declare export function');
+index = index.replace(/\| undefined/g, '| void');
 index = index.replace("Omit<TransformOptions, 'code'>", "$Rest<TransformOptions, {|code: TransformOptions['code']|}>");
 
 let targets = fs.readFileSync(dir + '/node/targets.d.ts', 'utf8');


### PR DESCRIPTION
supersede #91 

Here is a simpler version for functions overloads (like [esbuild](https://github.com/evanw/esbuild/blob/master/lib/shared/types.ts#L466-L470)) that seems to be a valid flow syntax (But I'm not sure it would provide as much type information than TS). 

I'm using `| undefined` because it very uncommon to use void in that case and creates false positive with eslint rules that uses type information.