### PR TITLE
Fix flipped `border-bottom-right` and `border-bottom-left`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2131,8 +2131,8 @@ mod tests {
         border-top-left-radius: 10px 120px;
         border-top-right-radius: 100px 120px;
         border-start-start-radius: 10px;
-        border-bottom-left-radius: 10px 120px;
         border-bottom-right-radius: 100px 120px;
+        border-bottom-left-radius: 10px 120px;
       }
     "#,
       indoc! {r#"
@@ -2140,8 +2140,8 @@ mod tests {
         border-top-left-radius: 10px 120px;
         border-top-right-radius: 100px 120px;
         border-start-start-radius: 10px;
-        border-bottom-left-radius: 10px 120px;
         border-bottom-right-radius: 100px 120px;
+        border-bottom-left-radius: 10px 120px;
       }
     "#
       },
@@ -2342,16 +2342,16 @@ mod tests {
       .foo {
         -webkit-border-top-left-radius: 30px;
         -moz-border-top-right-radius: 30px;
-        border-bottom-left-radius: 30px;
         border-bottom-right-radius: 30px;
+        border-bottom-left-radius: 30px;
       }
     "#,
       indoc! {r#"
       .foo {
         -webkit-border-top-left-radius: 30px;
         -moz-border-top-right-radius: 30px;
-        border-bottom-left-radius: 30px;
         border-bottom-right-radius: 30px;
+        border-bottom-left-radius: 30px;
       }
     "#
       },
@@ -2433,19 +2433,19 @@ mod tests {
     prefix_test(
       r#"
       .foo {
-        border-end-start-radius: 5px;
         border-end-end-radius: 10px;
+        border-end-start-radius: 5px;
       }
     "#,
       indoc! {r#"
       .foo:not(:lang(ae, ar, arc, bcc, bqi, ckb, dv, fa, glk, he, ku, mzn, nqo, pnb, ps, sd, ug, ur, yi)) {
-        border-bottom-left-radius: 5px;
         border-bottom-right-radius: 10px;
+        border-bottom-left-radius: 5px;
       }
 
       .foo:lang(ae, ar, arc, bcc, bqi, ckb, dv, fa, glk, he, ku, mzn, nqo, pnb, ps, sd, ug, ur, yi) {
-        border-bottom-left-radius: 10px;
         border-bottom-right-radius: 5px;
+        border-bottom-left-radius: 10px;
       }
     "#
       },

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2048,13 +2048,13 @@ mod tests {
       .foo {
         border-top-left-radius: 10px 120px;
         border-top-right-radius: 100px 120px;
-        border-bottom-left-radius: 10px 120px;
         border-bottom-right-radius: 100px 120px;
+        border-bottom-left-radius: 10px 120px;
       }
     "#,
       indoc! {r#"
       .foo {
-        border-radius: 10px 100px / 120px;
+        border-radius: 10px 100px 100px 10px / 120px;
       }
     "#
       },

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2063,6 +2063,23 @@ mod tests {
     test(
       r#"
       .foo {
+        border-top-left-radius: 4px 2px;
+        border-top-right-radius: 3px 4px;
+        border-bottom-right-radius: 6px 2px;
+        border-bottom-left-radius: 3px 4px;
+      }
+    "#,
+      indoc! {r#"
+      .foo {
+        border-radius: 4px 3px 6px / 2px 4px;
+      }
+    "#
+      },
+    );
+
+    test(
+      r#"
+      .foo {
         border-top-left-radius: 1% 2%;
         border-top-right-radius: 3% 4%;
         border-bottom-right-radius: 5% 6%;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1414,7 +1414,7 @@ mod tests {
         border-right-color: #b32323;
         border-right-color: lab(40% 56.6 39);
       }
-      
+
       .foo:is(:lang(ae), :lang(ar), :lang(arc), :lang(bcc), :lang(bqi), :lang(ckb), :lang(dv), :lang(fa), :lang(glk), :lang(he), :lang(ku), :lang(mzn), :lang(nqo), :lang(pnb), :lang(ps), :lang(sd), :lang(ug), :lang(ur), :lang(yi)) {
         border-right-color: #b32323;
         border-right-color: lab(40% 56.6 39);
@@ -1442,7 +1442,7 @@ mod tests {
         border-left-color: #b32323;
         border-left-color: lab(40% 56.6 39);
       }
-      
+
       .foo:is(:lang(ae), :lang(ar), :lang(arc), :lang(bcc), :lang(bqi), :lang(ckb), :lang(dv), :lang(fa), :lang(glk), :lang(he), :lang(ku), :lang(mzn), :lang(nqo), :lang(pnb), :lang(ps), :lang(sd), :lang(ug), :lang(ur), :lang(yi)) {
         border-left-color: #b32323;
         border-left-color: lab(40% 56.6 39);
@@ -1475,7 +1475,7 @@ mod tests {
         border-right-color: #b32323;
         border-right-color: lab(40% 56.6 39);
       }
-      
+
       .foo:is(:lang(ae), :lang(ar), :lang(arc), :lang(bcc), :lang(bqi), :lang(ckb), :lang(dv), :lang(fa), :lang(glk), :lang(he), :lang(ku), :lang(mzn), :lang(nqo), :lang(pnb), :lang(ps), :lang(sd), :lang(ug), :lang(ur), :lang(yi)) {
         border-left-color: #ee00be;
         border-left-color: lch(50.998% 135.363 338);
@@ -1505,7 +1505,7 @@ mod tests {
         border-right-color: color(display-p3 .972962 -.362078 .804206);
         border-right-color: lch(50.998% 135.363 338);
       }
-      
+
       .foo:is(:lang(ae), :lang(ar), :lang(arc), :lang(bcc), :lang(bqi), :lang(ckb), :lang(dv), :lang(fa), :lang(glk), :lang(he), :lang(ku), :lang(mzn), :lang(nqo), :lang(pnb), :lang(ps), :lang(sd), :lang(ug), :lang(ur), :lang(yi)) {
         border-left-color: #ee00be;
         border-left-color: color(display-p3 .972962 -.362078 .804206);
@@ -1538,7 +1538,7 @@ mod tests {
         border-right: 2px solid #b32323;
         border-right: 2px solid lab(40% 56.6 39);
       }
-      
+
       .foo:is(:lang(ae), :lang(ar), :lang(arc), :lang(bcc), :lang(bqi), :lang(ckb), :lang(dv), :lang(fa), :lang(glk), :lang(he), :lang(ku), :lang(mzn), :lang(nqo), :lang(pnb), :lang(ps), :lang(sd), :lang(ug), :lang(ur), :lang(yi)) {
         border-right: 2px solid #b32323;
         border-right: 2px solid lab(40% 56.6 39);
@@ -1566,7 +1566,7 @@ mod tests {
         border-left: 2px solid #b32323;
         border-left: 2px solid lab(40% 56.6 39);
       }
-      
+
       .foo:is(:lang(ae), :lang(ar), :lang(arc), :lang(bcc), :lang(bqi), :lang(ckb), :lang(dv), :lang(fa), :lang(glk), :lang(he), :lang(ku), :lang(mzn), :lang(nqo), :lang(pnb), :lang(ps), :lang(sd), :lang(ug), :lang(ur), :lang(yi)) {
         border-left: 2px solid #b32323;
         border-left: 2px solid lab(40% 56.6 39);
@@ -1598,7 +1598,7 @@ mod tests {
       .foo:-webkit-any(:lang(ae), :lang(ar), :lang(arc), :lang(bcc), :lang(bqi), :lang(ckb), :lang(dv), :lang(fa), :lang(glk), :lang(he), :lang(ku), :lang(mzn), :lang(nqo), :lang(pnb), :lang(ps), :lang(sd), :lang(ug), :lang(ur), :lang(yi)) {
         border-left: var(--border-width) solid #b32323;
       }
-      
+
       .foo:is(:lang(ae), :lang(ar), :lang(arc), :lang(bcc), :lang(bqi), :lang(ckb), :lang(dv), :lang(fa), :lang(glk), :lang(he), :lang(ku), :lang(mzn), :lang(nqo), :lang(pnb), :lang(ps), :lang(sd), :lang(ug), :lang(ur), :lang(yi)) {
         border-left: var(--border-width) solid #b32323;
       }
@@ -2055,6 +2055,23 @@ mod tests {
       indoc! {r#"
       .foo {
         border-radius: 10px 100px / 120px;
+      }
+    "#
+      },
+    );
+
+    test(
+      r#"
+      .foo {
+        border-top-left-radius: 1% 2%;
+        border-top-right-radius: 3% 4%;
+        border-bottom-right-radius: 5% 6%;
+        border-bottom-left-radius: 7% 8%;
+      }
+    "#,
+      indoc! {r#"
+      .foo {
+        border-radius: 1% 3% 5% 7% / 2% 4% 6% 8%;
       }
     "#
       },
@@ -2623,7 +2640,7 @@ mod tests {
         margin-inline-end: 15px;
         margin-top: 20px;
         margin-bottom: 20px;
-      
+
       }
     "#,
       indoc! {r#"
@@ -2900,7 +2917,7 @@ mod tests {
         padding-inline-end: 15px;
         padding-top: 20px;
         padding-bottom: 20px;
-      
+
       }
     "#,
       indoc! {r#"
@@ -7029,7 +7046,7 @@ mod tests {
       .baz {
         color: #00f;
       }
-      
+
       .bar {
         color: red;
       }
@@ -7131,7 +7148,7 @@ mod tests {
       [foo="bar"] {
         color: red;
       }
-      
+
       .bar {
         color: red;
       }
@@ -7180,7 +7197,7 @@ mod tests {
       .foo:-moz-read-only {
         color: red;
       }
-      
+
       .foo:read-only {
         color: red;
       }
@@ -7189,7 +7206,7 @@ mod tests {
       .foo:-moz-read-only {
         color: red;
       }
-      
+
       .foo:read-only {
         color: red;
       }
@@ -7201,7 +7218,7 @@ mod tests {
       .foo:-moz-read-only {
         color: red;
       }
-      
+
       .foo:read-only {
         color: red;
       }
@@ -7226,7 +7243,7 @@ mod tests {
       .bar {
         color: yellow;
       }
-      
+
       .foo:read-only {
         color: red;
       }
@@ -7239,7 +7256,7 @@ mod tests {
       .bar {
         color: #ff0;
       }
-      
+
       .foo:read-only {
         color: red;
       }
@@ -7255,7 +7272,7 @@ mod tests {
       .foo:-moz-read-only {
         color: red;
       }
-      
+
       .foo:read-only {
         color: red;
       }
@@ -7264,7 +7281,7 @@ mod tests {
       .foo:-moz-read-only {
         color: red;
       }
-      
+
       .foo:read-only {
         color: red;
       }
@@ -7285,7 +7302,7 @@ mod tests {
       .foo:-moz-read-only {
         color: red;
       }
-      
+
       .foo:read-only {
         color: red;
       }
@@ -7505,7 +7522,7 @@ mod tests {
           color: red;
         }
       }
-      
+
       @media (min-width: 250px) {
         .foo {
           background: #fff;
@@ -7575,7 +7592,7 @@ mod tests {
           color: red;
         }
       }
-      
+
       @supports (display: grid) {
         .foo {
           background: #fff;
@@ -10185,7 +10202,7 @@ mod tests {
     "#,
       indoc! {r#"
       @namespace toto "http://toto.example.org";
-      
+
       toto|x {
         color: red;
       }
@@ -10210,7 +10227,7 @@ mod tests {
     "#,
       indoc! {r#"
       @namespace "http://example.com/foo";
-      
+
       |x {
         color: red;
       }
@@ -10235,7 +10252,7 @@ mod tests {
     "#,
       indoc! {r#"
       @namespace "http://example.com/foo";
-      
+
       *|x {
         color: red;
       }
@@ -18012,7 +18029,7 @@ mod tests {
           from {
             --custom: lab(40% 56.6 39);
           }
-  
+
           to {
             --custom: lab(50.998% 125.506 -50.7078);
           }
@@ -18053,7 +18070,7 @@ mod tests {
           from {
             --custom: color(display-p3 .643308 .192455 .167712);
           }
-  
+
           to {
             --custom: color(display-p3 .972962 -.362078 .804206);
           }
@@ -18065,7 +18082,7 @@ mod tests {
           from {
             --custom: lab(40% 56.6 39);
           }
-  
+
           to {
             --custom: lab(50.998% 125.506 -50.7078);
           }
@@ -18112,7 +18129,7 @@ mod tests {
             --custom: #ff0;
             opacity: 0;
           }
-  
+
           to {
             --custom: lab(50.998% 125.506 -50.7078);
             opacity: 1;
@@ -18366,10 +18383,10 @@ mod tests {
       r#"
         figure {
           margin: 0;
-        
+
           & > figcaption {
             background: hsl(0 0% 0% / 50%);
-        
+
             & > p {
               font-size: .9rem;
             }
@@ -18482,7 +18499,7 @@ mod tests {
       r#"
         .foo {
           display: grid;
-        
+
           @media (orientation: landscape) {
             grid-auto-flow: column;
           }
@@ -18505,10 +18522,10 @@ mod tests {
       r#"
         .foo {
           display: grid;
-        
+
           @media (orientation: landscape) {
             grid-auto-flow: column;
-        
+
             @media (width > 1024px) {
               max-inline-size: 1024px;
             }
@@ -18538,7 +18555,7 @@ mod tests {
       r#"
         .foo {
           display: grid;
-        
+
           @supports (foo: bar) {
             grid-auto-flow: column;
           }
@@ -18975,7 +18992,7 @@ mod tests {
       .foo {
         color: red;
       }
-      
+
       #id {
         animation: 2s test;
       }
@@ -19649,7 +19666,7 @@ mod tests {
       .baz:is(.bar) {
         background: green;
       }
-      
+
       #id {
         animation: 2s test;
       }
@@ -19677,7 +19694,7 @@ mod tests {
       .foo {
         color: red;
       }
-      
+
       #id {
         animation: 2s test;
       }
@@ -21642,12 +21659,12 @@ mod tests {
       @layer base {
         p { max-width: 70ch; }
       }
-      
+
       @layer framework {
         @layer base {
           p { margin-block: 0.75em; }
         }
-      
+
         @layer theme {
           p { color: #222; }
         }
@@ -21933,16 +21950,16 @@ mod tests {
     let source = r#".imported {
       content: "yay, file support!";
     }
-    
+
     .selector {
       margin: 1em;
       background-color: #f60;
     }
-    
+
     .selector .nested {
       margin: 0.5em;
     }
-    
+
     /*# sourceMappingURL=data:application/json;base64,ewoJInZlcnNpb24iOiAzLAoJInNvdXJjZVJvb3QiOiAicm9vdCIsCgkiZmlsZSI6ICJzdGRvdXQiLAoJInNvdXJjZXMiOiBbCgkJInN0ZGluIiwKCQkic2Fzcy9fdmFyaWFibGVzLnNjc3MiLAoJCSJzYXNzL19kZW1vLnNjc3MiCgldLAoJInNvdXJjZXNDb250ZW50IjogWwoJCSJAaW1wb3J0IFwiX3ZhcmlhYmxlc1wiO1xuQGltcG9ydCBcIl9kZW1vXCI7XG5cbi5zZWxlY3RvciB7XG4gIG1hcmdpbjogJHNpemU7XG4gIGJhY2tncm91bmQtY29sb3I6ICRicmFuZENvbG9yO1xuXG4gIC5uZXN0ZWQge1xuICAgIG1hcmdpbjogJHNpemUgLyAyO1xuICB9XG59IiwKCQkiJGJyYW5kQ29sb3I6ICNmNjA7XG4kc2l6ZTogMWVtOyIsCgkJIi5pbXBvcnRlZCB7XG4gIGNvbnRlbnQ6IFwieWF5LCBmaWxlIHN1cHBvcnQhXCI7XG59IgoJXSwKCSJtYXBwaW5ncyI6ICJBRUFBLFNBQVMsQ0FBQztFQUNSLE9BQU8sRUFBRSxvQkFBcUI7Q0FDL0I7O0FGQ0QsU0FBUyxDQUFDO0VBQ1IsTUFBTSxFQ0hELEdBQUc7RURJUixnQkFBZ0IsRUNMTCxJQUFJO0NEVWhCOztBQVBELFNBQVMsQ0FJUCxPQUFPLENBQUM7RUFDTixNQUFNLEVDUEgsS0FBRztDRFFQIiwKCSJuYW1lcyI6IFtdCn0= */"#;
 
     let mut stylesheet = StyleSheet::parse(&source, ParserOptions::default()).unwrap();

--- a/src/properties/border_radius.rs
+++ b/src/properties/border_radius.rs
@@ -68,14 +68,14 @@ impl ToCss for BorderRadius {
     let widths = Rect::new(
       &self.top_left.0,
       &self.top_right.0,
-      &self.bottom_left.0,
       &self.bottom_right.0,
+      &self.bottom_left.0,
     );
     let heights = Rect::new(
       &self.top_left.1,
       &self.top_right.1,
-      &self.bottom_left.1,
       &self.bottom_right.1,
+      &self.bottom_left.1,
     );
 
     widths.to_css(dest)?;

--- a/src/properties/border_radius.rs
+++ b/src/properties/border_radius.rs
@@ -23,10 +23,10 @@ define_shorthand! {
     top_left: BorderTopLeftRadius(Size2D<LengthPercentage>, VendorPrefix),
     /// The x and y radius values for the top right corner.
     top_right: BorderTopRightRadius(Size2D<LengthPercentage>, VendorPrefix),
-    /// The x and y radius values for the bottom left corner.
-    bottom_left: BorderBottomLeftRadius(Size2D<LengthPercentage>, VendorPrefix),
     /// The x and y radius values for the bottom right corner.
     bottom_right: BorderBottomRightRadius(Size2D<LengthPercentage>, VendorPrefix),
+    /// The x and y radius values for the bottom left corner.
+    bottom_left: BorderBottomLeftRadius(Size2D<LengthPercentage>, VendorPrefix),
   }
 }
 
@@ -36,8 +36,8 @@ impl Default for BorderRadius {
     BorderRadius {
       top_left: zero.clone(),
       top_right: zero.clone(),
-      bottom_left: zero.clone(),
-      bottom_right: zero,
+      bottom_right: zero.clone(),
+      bottom_left: zero,
     }
   }
 }
@@ -54,8 +54,8 @@ impl<'i> Parse<'i> for BorderRadius {
     Ok(BorderRadius {
       top_left: Size2D(widths.0, heights.0),
       top_right: Size2D(widths.1, heights.1),
-      bottom_left: Size2D(widths.2, heights.2),
-      bottom_right: Size2D(widths.3, heights.3),
+      bottom_right: Size2D(widths.2, heights.2),
+      bottom_left: Size2D(widths.3, heights.3),
     })
   }
 }
@@ -93,12 +93,12 @@ pub(crate) struct BorderRadiusHandler<'i> {
   targets: Option<Browsers>,
   top_left: Option<(Size2D<LengthPercentage>, VendorPrefix)>,
   top_right: Option<(Size2D<LengthPercentage>, VendorPrefix)>,
-  bottom_left: Option<(Size2D<LengthPercentage>, VendorPrefix)>,
   bottom_right: Option<(Size2D<LengthPercentage>, VendorPrefix)>,
+  bottom_left: Option<(Size2D<LengthPercentage>, VendorPrefix)>,
   start_start: Option<Property<'i>>,
   start_end: Option<Property<'i>>,
-  end_start: Option<Property<'i>>,
   end_end: Option<Property<'i>>,
+  end_start: Option<Property<'i>>,
   category: PropertyCategory,
   has_any: bool,
 }
@@ -169,25 +169,25 @@ impl<'i> PropertyHandler<'i> for BorderRadiusHandler<'i> {
     match property {
       BorderTopLeftRadius(val, vp) => property!(top_left, val, vp),
       BorderTopRightRadius(val, vp) => property!(top_right, val, vp),
-      BorderBottomLeftRadius(val, vp) => property!(bottom_left, val, vp),
       BorderBottomRightRadius(val, vp) => property!(bottom_right, val, vp),
+      BorderBottomLeftRadius(val, vp) => property!(bottom_left, val, vp),
       BorderStartStartRadius(_) => logical_property!(start_start),
       BorderStartEndRadius(_) => logical_property!(start_end),
-      BorderEndStartRadius(_) => logical_property!(end_start),
       BorderEndEndRadius(_) => logical_property!(end_end),
+      BorderEndStartRadius(_) => logical_property!(end_start),
       BorderRadius(val, vp) => {
         self.start_start = None;
         self.start_end = None;
-        self.end_start = None;
         self.end_end = None;
+        self.end_start = None;
         maybe_flush!(top_left, &val.top_left, vp);
         maybe_flush!(top_right, &val.top_right, vp);
-        maybe_flush!(bottom_left, &val.bottom_left, vp);
         maybe_flush!(bottom_right, &val.bottom_right, vp);
+        maybe_flush!(bottom_left, &val.bottom_left, vp);
         property!(top_left, &val.top_left, vp);
         property!(top_right, &val.top_right, vp);
-        property!(bottom_left, &val.bottom_left, vp);
         property!(bottom_right, &val.bottom_right, vp);
+        property!(bottom_left, &val.bottom_left, vp);
       }
       Unparsed(val) if is_border_radius_property(&val.property_id) => {
         // Even if we weren't able to parse the value (e.g. due to var() references),
@@ -195,8 +195,8 @@ impl<'i> PropertyHandler<'i> for BorderRadiusHandler<'i> {
         match &val.property_id {
           PropertyId::BorderStartStartRadius => logical_property!(start_start),
           PropertyId::BorderStartEndRadius => logical_property!(start_end),
-          PropertyId::BorderEndStartRadius => logical_property!(end_start),
           PropertyId::BorderEndEndRadius => logical_property!(end_end),
+          PropertyId::BorderEndStartRadius => logical_property!(end_start),
           _ => {
             self.flush(dest, context);
             dest.push(Property::Unparsed(
@@ -226,21 +226,21 @@ impl<'i> BorderRadiusHandler<'i> {
 
     let mut top_left = std::mem::take(&mut self.top_left);
     let mut top_right = std::mem::take(&mut self.top_right);
-    let mut bottom_left = std::mem::take(&mut self.bottom_left);
     let mut bottom_right = std::mem::take(&mut self.bottom_right);
+    let mut bottom_left = std::mem::take(&mut self.bottom_left);
     let start_start = std::mem::take(&mut self.start_start);
     let start_end = std::mem::take(&mut self.start_end);
-    let end_start = std::mem::take(&mut self.end_start);
     let end_end = std::mem::take(&mut self.end_end);
+    let end_start = std::mem::take(&mut self.end_start);
 
     if let (
       Some((top_left, tl_prefix)),
       Some((top_right, tr_prefix)),
-      Some((bottom_left, bl_prefix)),
       Some((bottom_right, br_prefix)),
-    ) = (&mut top_left, &mut top_right, &mut bottom_left, &mut bottom_right)
+      Some((bottom_left, bl_prefix)),
+    ) = (&mut top_left, &mut top_right, &mut bottom_right, &mut bottom_left)
     {
-      let intersection = *tl_prefix & *tr_prefix & *bl_prefix & *br_prefix;
+      let intersection = *tl_prefix & *tr_prefix & *br_prefix & *bl_prefix;
       if !intersection.is_empty() {
         let mut prefix = intersection;
         if prefix.contains(VendorPrefix::None) {
@@ -252,15 +252,15 @@ impl<'i> BorderRadiusHandler<'i> {
           BorderRadius {
             top_left: top_left.clone(),
             top_right: top_right.clone(),
-            bottom_left: bottom_left.clone(),
             bottom_right: bottom_right.clone(),
+            bottom_left: bottom_left.clone(),
           },
           prefix,
         ));
         tl_prefix.remove(intersection);
         tr_prefix.remove(intersection);
-        bl_prefix.remove(intersection);
         br_prefix.remove(intersection);
+        bl_prefix.remove(intersection);
       }
     }
 
@@ -296,8 +296,8 @@ impl<'i> BorderRadiusHandler<'i> {
             match val {
               Property::BorderStartStartRadius(val)
               | Property::BorderStartEndRadius(val)
-              | Property::BorderEndStartRadius(val)
-              | Property::BorderEndEndRadius(val) => {
+              | Property::BorderEndEndRadius(val)
+              | Property::BorderEndStartRadius(val) => {
                 context.add_logical_rule(Property::$ltr(val.clone(), vp), Property::$rtl(val, vp));
               }
               Property::Unparsed(val) => {
@@ -315,8 +315,8 @@ impl<'i> BorderRadiusHandler<'i> {
 
     single_property!(BorderTopLeftRadius, top_left);
     single_property!(BorderTopRightRadius, top_right);
-    single_property!(BorderBottomLeftRadius, bottom_left);
     single_property!(BorderBottomRightRadius, bottom_right);
+    single_property!(BorderBottomLeftRadius, bottom_left);
     logical_property!(
       BorderStartStartRadius,
       start_start,
@@ -330,16 +330,16 @@ impl<'i> BorderRadiusHandler<'i> {
       BorderTopLeftRadius
     );
     logical_property!(
-      BorderEndStartRadius,
-      end_start,
-      BorderBottomLeftRadius,
-      BorderBottomRightRadius
-    );
-    logical_property!(
       BorderEndEndRadius,
       end_end,
       BorderBottomRightRadius,
       BorderBottomLeftRadius
+    );
+    logical_property!(
+      BorderEndStartRadius,
+      end_start,
+      BorderBottomLeftRadius,
+      BorderBottomRightRadius
     );
   }
 }
@@ -353,8 +353,8 @@ fn is_border_radius_property(property_id: &PropertyId) -> bool {
   match property_id {
     PropertyId::BorderTopLeftRadius(_)
     | PropertyId::BorderTopRightRadius(_)
-    | PropertyId::BorderBottomLeftRadius(_)
     | PropertyId::BorderBottomRightRadius(_)
+    | PropertyId::BorderBottomLeftRadius(_)
     | PropertyId::BorderRadius(_) => true,
     _ => false,
   }
@@ -365,8 +365,8 @@ fn is_logical_border_radius_property(property_id: &PropertyId) -> bool {
   match property_id {
     PropertyId::BorderStartStartRadius
     | PropertyId::BorderStartEndRadius
-    | PropertyId::BorderEndStartRadius
-    | PropertyId::BorderEndEndRadius => true,
+    | PropertyId::BorderEndEndRadius
+    | PropertyId::BorderEndStartRadius => true,
     _ => false,
   }
 }


### PR DESCRIPTION
Fixes  #307

This pull request:

- Adds https://github.com/parcel-bundler/lightningcss/issues/307 as test case and fixes it.
- Adds another test case (for `<first> <second> <third> / <first> <second>` syntax) from MDN.
- Fixes a previously false-positive test, caused by consistently placing `bottom-left` (or `start-end`) before `bottom-right` (or `end-end`)
- Prevents future similar bugs and reduces confusion by consistently re-sorting bottom right before bottom left (matching CSS syntax) across the border radius module and tests.

A note about white space: 
Some white space was inconsistent, but that was not meant to be subject of this PR. I accidentally committed the removal of spaces from otherwise empty lines, causing diff noise. With this accidental change, the post-merge code is more white-space-consistent, but nevertheless please let me know if I should revert these accidental white space changes.