### PR TITLE
fix: Correctly enclose negated downleveled interval media queries in parens

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6806,7 +6806,7 @@ mod tests {
         }
       "#},
       Browsers {
-        firefox: Some(60 << 16),
+        firefox: Some(62 << 16),
         ..Browsers::default()
       },
     );
@@ -6827,7 +6827,28 @@ mod tests {
         }
       "#},
       Browsers {
-        firefox: Some(85 << 16),
+        firefox: Some(62 << 16),
+        ..Browsers::default()
+      },
+    );
+
+    prefix_test(
+      r#"
+        @media (100px <= width <= 200px) {
+          .foo {
+            color: chartreuse;
+          }
+        }
+      "#,
+      indoc! { r#"
+        @media (width >= 100px) and (width <= 200px) {
+          .foo {
+            color: #7fff00;
+          }
+        }
+      "#},
+      Browsers {
+        firefox: Some(63 << 16),
         ..Browsers::default()
       },
     );
@@ -6848,7 +6869,28 @@ mod tests {
         }
       "#},
       Browsers {
-        firefox: Some(85 << 16),
+        firefox: Some(62 << 16),
+        ..Browsers::default()
+      },
+    );
+
+    prefix_test(
+      r#"
+        @media (100px < width < 200px) {
+          .foo {
+            color: chartreuse;
+          }
+        }
+      "#,
+      indoc! { r#"
+        @media (width > 100px) and (width < 200px) {
+          .foo {
+            color: #7fff00;
+          }
+        }
+      "#},
+      Browsers {
+        firefox: Some(63 << 16),
         ..Browsers::default()
       },
     );
@@ -6869,7 +6911,28 @@ mod tests {
         }
       "#},
       Browsers {
-        firefox: Some(85 << 16),
+        firefox: Some(62 << 16),
+        ..Browsers::default()
+      },
+    );
+
+    prefix_test(
+      r#"
+        @media (200px >= width >= 100px) {
+          .foo {
+            color: chartreuse;
+          }
+        }
+      "#,
+      indoc! { r#"
+        @media (width <= 200px) and (width >= 100px) {
+          .foo {
+            color: #7fff00;
+          }
+        }
+      "#},
+      Browsers {
+        firefox: Some(63 << 16),
         ..Browsers::default()
       },
     );

--- a/src/media_query.rs
+++ b/src/media_query.rs
@@ -459,7 +459,7 @@ impl<'i> ToCss for MediaCondition<'i> {
     where
       W: std::fmt::Write,
     {
-      // Media interval syntax is expanded to an `and` operation of two parenthized plain media features,
+      // Media interval syntax is expanded to an `and` operation of two parenthesized plain media features,
       // which has an effect on negated vs plain syntax on root level.
       // The operation must be enclosed in parens when negated, but left plain otherwise.
       // Positive syntax: `@media screen and (...) and (...)`

--- a/src/media_query.rs
+++ b/src/media_query.rs
@@ -991,7 +991,7 @@ fn process_condition<'i>(
 #[cfg(test)]
 mod tests {
   use super::*;
-  use crate::stylesheet::PrinterOptions;
+  use crate::{stylesheet::PrinterOptions, targets::Browsers};
 
   fn parse(s: &str) -> MediaQuery {
     let mut input = ParserInput::new(&s);
@@ -1037,5 +1037,15 @@ mod tests {
     assert_eq!(and("all", "only screen"), "only screen");
     assert_eq!(and("only screen", "all"), "only screen");
     assert_eq!(and("print", "print"), "print");
+  }
+
+  #[test]
+  fn test_negated_interval_parens() {
+    let media_query = parse("screen and not (200px <= width < 500px)");
+    let printer_options = PrinterOptions {
+      targets: Browsers::from_browserslist(["chrome 95"]).unwrap(),
+      ..Default::default()
+    };
+    assert_eq!(media_query.to_css_string(printer_options).unwrap(), "screen and not ((min-width: 200px) and (max-width: 499.999px))");
   }
 }


### PR DESCRIPTION
Fixes https://github.com/parcel-bundler/lightningcss/issues/320

# Changes

## Tests

### Targets and range syntax

I changed relevant tests in `lib.rs` from firefox 60 and 85 to firefox 62 and 63, as media feature range syntax was introduced with firefox 63.
This takes into account that lightningcss currently treats range syntax and interval syntax as two different features. See also https://github.com/parcel-bundler/lightningcss/issues/331 

It might be that some browsers first implemented range syntax without interval syntax, and added interval syntax later. However, this is not documented in the compatibility tables. Lightningcss considers interval syntax as not supported anywhere, even though, in reality, current Gecko and Blink (but not WebKit, apparently) do support interval syntax today.

As interval syntax is now (if this PR be merged) implemented by rendering a `MediaCondition::Operation` of two `MediaFeature::Range` features, the output depends on the range syntax target support. Therefore, there are now two versions of each interval media feature query test - one using range syntax (firefox >= 63) and one using traditional syntax (firefox <= 62).

### Test placement

I had been unsure where to put the new, initially failing test reproducing https://github.com/parcel-bundler/lightningcss/issues/320. Placing it right in the `media_query` module seemed to be the right thing, but there is otherwise only a test for `and()`. All other tests - including media query tests - appear to be located in `lib.rs`. Should my added tests from `media_query.rs` be migrated over into `lib.rs`?

## Complex implementation, benefits and possible alternatives

The implementation of the fix might appear somewhat contrived at first sight. Yet in terms of behavior it seems to me to be the cleanest solution.

The issue is that if the downleveling only happens in `impl<'i> ToCss for MediaFeature<'i>` (as before the PR), then we cannot know if the feature is negated, the trait contract does not offer passing further options, except for the printer `dest`.

### Alternatives

#### A) [Add a field to Printer](https://github.com/parcel-bundler/lightningcss/pull/333)

The `Printer` struct does have an `in_calc`  boolean already - would it be the right thing to add an `in_negated_media_condition` field? This looks a little like abuse to me. However, is the implementation in this PR the better choice?

Adding `in_negated_media_condition` to `struct Printer` would be an option. Feels wrong, but less complex. 

#### B) [Always wrap expanded interval in parens in `impl<'i> ToCss for MediaFeature<'i>`](https://github.com/parcel-bundler/lightningcss/pull/334)

Any expanded media feature interval could be enclosed in parens.
However: This outputs unnecessary parens for non-negated queries. 

E.g. `@media (200px >= width >= 100px)` would result in `@media ((max-width: 200px) and (min-width: 100px))`, where `@media (max-width: 200px) and (min-width: 100px)` would be sufficient.

#### C) [Using the solution provided in the PR you are currently looking at](https://github.com/parcel-bundler/lightningcss/pull/332)

Complex code, but clean output. 
