### PR TITLE
fix: Correctly enclose negated downleveled interval media queries in parens (Alternative A)

### DIFF
--- a/src/media_query.rs
+++ b/src/media_query.rs
@@ -991,7 +991,7 @@ fn process_condition<'i>(
 #[cfg(test)]
 mod tests {
   use super::*;
-  use crate::stylesheet::PrinterOptions;
+  use crate::{stylesheet::PrinterOptions, targets::Browsers};
 
   fn parse(s: &str) -> MediaQuery {
     let mut input = ParserInput::new(&s);
@@ -1037,5 +1037,15 @@ mod tests {
     assert_eq!(and("all", "only screen"), "only screen");
     assert_eq!(and("only screen", "all"), "only screen");
     assert_eq!(and("print", "print"), "print");
+  }
+
+  #[test]
+  fn test_negated_interval_parens() {
+    let media_query = parse("screen and not (200px <= width < 500px)");
+    let printer_options = PrinterOptions {
+      targets: Browsers::from_browserslist(["chrome 95"]).unwrap(),
+      ..Default::default()
+    };
+    assert_eq!(media_query.to_css_string(printer_options).unwrap(), "screen and not ((min-width: 200px) and (max-width: 499.999px))");
   }
 }

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -72,6 +72,7 @@ pub struct Printer<'a, 'b, 'c, W> {
   /// the vendor prefix of whatever is being printed.
   pub(crate) vendor_prefix: VendorPrefix,
   pub(crate) in_calc: bool,
+  pub(crate) in_negated_media_feature: bool,
   pub(crate) css_module: Option<CssModule<'a, 'b, 'c>>,
   pub(crate) dependencies: Option<Vec<Dependency>>,
   pub(crate) remove_imports: bool,
@@ -98,6 +99,7 @@ impl<'a, 'b, 'c, W: std::fmt::Write + Sized> Printer<'a, 'b, 'c, W> {
       targets: options.targets,
       vendor_prefix: VendorPrefix::empty(),
       in_calc: false,
+      in_negated_media_feature: false,
       css_module: None,
       dependencies: if options.analyze_dependencies.is_some() {
         Some(Vec::new())


### PR DESCRIPTION
This is alternative A to https://github.com/parcel-bundler/lightningcss/pull/332 for fixing https://github.com/parcel-bundler/lightningcss/issues/320.

See #332 for the main proposal. To me, the main proposal is preferable.

This alternative approach uses a boolean flag on the `Printer`. This is sound here, as the flag is only applied when rendering `MediaCondition::Feature` inside a `MediaCondition::Not`. The former does not currently contain nested items which would interact with the flag.
However, the solution could easily become unsound when code is changed such that the code path recurses. In that case, a stack of flags for each layer would be required, as not all nested items should automatically be considered (direct) children of a negated media condition.
Soundness is not enforced by the type system.

To my mind, the original approach at #332 is preferable, as it leverages the existing types for expanding the media feature interval.
