### PR TITLE
fix: Correctly enclose negated downleveled interval media queries in parens (Alternative B)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6820,7 +6820,7 @@ mod tests {
         }
       "#,
       indoc! { r#"
-        @media (min-width: 100px) and (max-width: 200px) {
+        @media ((min-width: 100px) and (max-width: 200px)) {
           .foo {
             color: #7fff00;
           }
@@ -6841,7 +6841,7 @@ mod tests {
         }
       "#,
       indoc! { r#"
-        @media (min-width: 100.001px) and (max-width: 199.999px) {
+        @media ((min-width: 100.001px) and (max-width: 199.999px)) {
           .foo {
             color: #7fff00;
           }
@@ -6862,7 +6862,7 @@ mod tests {
         }
       "#,
       indoc! { r#"
-        @media (max-width: 200px) and (min-width: 100px) {
+        @media ((max-width: 200px) and (min-width: 100px)) {
           .foo {
             color: #7fff00;
           }

--- a/src/media_query.rs
+++ b/src/media_query.rs
@@ -991,7 +991,7 @@ fn process_condition<'i>(
 #[cfg(test)]
 mod tests {
   use super::*;
-  use crate::stylesheet::PrinterOptions;
+  use crate::{stylesheet::PrinterOptions, targets::Browsers};
 
   fn parse(s: &str) -> MediaQuery {
     let mut input = ParserInput::new(&s);
@@ -1037,5 +1037,15 @@ mod tests {
     assert_eq!(and("all", "only screen"), "only screen");
     assert_eq!(and("only screen", "all"), "only screen");
     assert_eq!(and("print", "print"), "print");
+  }
+
+  #[test]
+  fn test_negated_interval_parens() {
+    let media_query = parse("screen and not (200px <= width < 500px)");
+    let printer_options = PrinterOptions {
+      targets: Browsers::from_browserslist(["chrome 95"]).unwrap(),
+      ..Default::default()
+    };
+    assert_eq!(media_query.to_css_string(printer_options).unwrap(), "screen and not ((min-width: 200px) and (max-width: 499.999px))");
   }
 }


### PR DESCRIPTION
This is alternative A to https://github.com/parcel-bundler/lightningcss/pull/332 for fixing https://github.com/parcel-bundler/lightningcss/issues/320.

See #332 for the main proposal. To me, the main proposal is preferable.

This alternative approach encloses all expanded media feature intervals in parens, even if they are not negated and do not need additional parentheses.

The solution is very simple, but superfluous parens are the result. See the changed tests, where formerly `@media (min-width: 100px) and (max-width: 200px)` now `@media ((min-width: 100px) and (max-width: 200px))` is output.

The solution is not optimal but at least it is not incorrect.

Depending on your taste, you might find this approach preferable over the original approach at #332, as it adds very little code (complexity) and produces only slightly subobtimal output.

The original approach at #332, on the other hand, is logically correct and produces optimal output, but is slightly complex. It also touches on #331, due to its replacing interval enum variants by a set of range enum variants, where lightningcss currently (maybe incorrectly?) discriminates between the two as it comes to browser support.
