### PR TITLE
Pin debian docker image to fix ARM linux GLIBC requirement

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,6 @@
 name: release
 on:
   workflow_dispatch:
-  push:
 
 jobs:
   build:
@@ -134,8 +133,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Debug
-        run: ldd --version
       - name: Install Node.JS
         uses: actions/setup-node@v2
         with:
@@ -174,76 +171,76 @@ jobs:
             *.node
             lightningcss
 
-  # build-wasm:
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@v2
-  #     - name: Install Node.JS
-  #       uses: actions/setup-node@v2
-  #       with:
-  #         node-version: 14
-  #     - name: Install wasm-pack
-  #       run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
-  #     - name: Build wasm
-  #       run: yarn wasm-browser:build-release
-  #     - name: Upload artifacts
-  #       uses: actions/upload-artifact@v2
-  #       with:
-  #         name: wasm
-  #         path: node/pkg
+  build-wasm:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install Node.JS
+        uses: actions/setup-node@v2
+        with:
+          node-version: 14
+      - name: Install wasm-pack
+        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+      - name: Build wasm
+        run: yarn wasm-browser:build-release
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: wasm
+          path: node/pkg
 
-  # release:
-  #   runs-on: ubuntu-latest
-  #   name: Build and release
-  #   needs:
-  #     - build
-  #     - build-linux
-  #     - build-apple-silicon
-  #     - build-wasm
-  #   steps:
-  #     - uses: actions/checkout@v1
-  #     - uses: bahmutov/npm-install@v1.1.0
-  #     - name: Download artifacts
-  #       uses: actions/download-artifact@v2
-  #       with:
-  #         path: artifacts
-  #     - name: Build npm packages
-  #       run: |
-  #         node scripts/build-npm.js
-  #         node scripts/build-wasm.js
-  #     - run: echo //registry.npmjs.org/:_authToken=${NPM_TOKEN} > ~/.npmrc
-  #       env:
-  #         NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-  #     - name: Publish to npm
-  #       run: |
-  #         for pkg in npm/*; do
-  #           echo "Publishing $pkg..."
-  #           cd $pkg;
-  #           npm publish;
-  #           cd ../..;
-  #         done
-  #         cd cli
-  #         echo "Publishing lightningcss-cli...";
-  #         npm publish
-  #         cd ..
-  #         echo "Publishing lightningcss...";
-  #         npm publish
+  release:
+    runs-on: ubuntu-latest
+    name: Build and release
+    needs:
+      - build
+      - build-linux
+      - build-apple-silicon
+      - build-wasm
+    steps:
+      - uses: actions/checkout@v1
+      - uses: bahmutov/npm-install@v1.1.0
+      - name: Download artifacts
+        uses: actions/download-artifact@v2
+        with:
+          path: artifacts
+      - name: Build npm packages
+        run: |
+          node scripts/build-npm.js
+          node scripts/build-wasm.js
+      - run: echo //registry.npmjs.org/:_authToken=${NPM_TOKEN} > ~/.npmrc
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: Publish to npm
+        run: |
+          for pkg in npm/*; do
+            echo "Publishing $pkg..."
+            cd $pkg;
+            npm publish;
+            cd ../..;
+          done
+          cd cli
+          echo "Publishing lightningcss-cli...";
+          npm publish
+          cd ..
+          echo "Publishing lightningcss...";
+          npm publish
 
-  # release-crates:
-  #   runs-on: ubuntu-latest
-  #   name: Release Rust crate
-  #   steps:
-  #     - uses: actions/checkout@v1
-  #     - uses: bahmutov/npm-install@v1.1.0
-  #     - name: Install Rust
-  #       uses: actions-rs/toolchain@v1
-  #       with:
-  #         toolchain: stable
-  #         profile: minimal
-  #         override: true
-  #     - run: cargo login ${CRATES_IO_TOKEN}
-  #       env:
-  #         CRATES_IO_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
-  #     - run: |
-  #         cargo install cargo-workspaces
-  #         cargo workspaces publish --from-git -y
+  release-crates:
+    runs-on: ubuntu-latest
+    name: Release Rust crate
+    steps:
+      - uses: actions/checkout@v1
+      - uses: bahmutov/npm-install@v1.1.0
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+          override: true
+      - run: cargo login ${CRATES_IO_TOKEN}
+        env:
+          CRATES_IO_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
+      - run: |
+          cargo install cargo-workspaces
+          cargo workspaces publish --from-git -y

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,7 @@
 name: release
 on:
   workflow_dispatch:
+  push:
 
 jobs:
   build:
@@ -148,6 +149,9 @@ jobs:
         if: ${{ matrix.setup }}
         run: ${{ matrix.setup }}
 
+      - name: Debug
+        run: ldd --version
+
       - name: Setup rust target
         run: rustup target add ${{ matrix.target }}
 
@@ -171,76 +175,76 @@ jobs:
             *.node
             lightningcss
 
-  build-wasm:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - name: Install Node.JS
-        uses: actions/setup-node@v2
-        with:
-          node-version: 14
-      - name: Install wasm-pack
-        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
-      - name: Build wasm
-        run: yarn wasm-browser:build-release
-      - name: Upload artifacts
-        uses: actions/upload-artifact@v2
-        with:
-          name: wasm
-          path: node/pkg
+  # build-wasm:
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #     - name: Install Node.JS
+  #       uses: actions/setup-node@v2
+  #       with:
+  #         node-version: 14
+  #     - name: Install wasm-pack
+  #       run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+  #     - name: Build wasm
+  #       run: yarn wasm-browser:build-release
+  #     - name: Upload artifacts
+  #       uses: actions/upload-artifact@v2
+  #       with:
+  #         name: wasm
+  #         path: node/pkg
 
-  release:
-    runs-on: ubuntu-latest
-    name: Build and release
-    needs:
-      - build
-      - build-linux
-      - build-apple-silicon
-      - build-wasm
-    steps:
-      - uses: actions/checkout@v1
-      - uses: bahmutov/npm-install@v1.1.0
-      - name: Download artifacts
-        uses: actions/download-artifact@v2
-        with:
-          path: artifacts
-      - name: Build npm packages
-        run: |
-          node scripts/build-npm.js
-          node scripts/build-wasm.js
-      - run: echo //registry.npmjs.org/:_authToken=${NPM_TOKEN} > ~/.npmrc
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-      - name: Publish to npm
-        run: |
-          for pkg in npm/*; do
-            echo "Publishing $pkg..."
-            cd $pkg;
-            npm publish;
-            cd ../..;
-          done
-          cd cli
-          echo "Publishing lightningcss-cli...";
-          npm publish
-          cd ..
-          echo "Publishing lightningcss...";
-          npm publish
+  # release:
+  #   runs-on: ubuntu-latest
+  #   name: Build and release
+  #   needs:
+  #     - build
+  #     - build-linux
+  #     - build-apple-silicon
+  #     - build-wasm
+  #   steps:
+  #     - uses: actions/checkout@v1
+  #     - uses: bahmutov/npm-install@v1.1.0
+  #     - name: Download artifacts
+  #       uses: actions/download-artifact@v2
+  #       with:
+  #         path: artifacts
+  #     - name: Build npm packages
+  #       run: |
+  #         node scripts/build-npm.js
+  #         node scripts/build-wasm.js
+  #     - run: echo //registry.npmjs.org/:_authToken=${NPM_TOKEN} > ~/.npmrc
+  #       env:
+  #         NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+  #     - name: Publish to npm
+  #       run: |
+  #         for pkg in npm/*; do
+  #           echo "Publishing $pkg..."
+  #           cd $pkg;
+  #           npm publish;
+  #           cd ../..;
+  #         done
+  #         cd cli
+  #         echo "Publishing lightningcss-cli...";
+  #         npm publish
+  #         cd ..
+  #         echo "Publishing lightningcss...";
+  #         npm publish
 
-  release-crates:
-    runs-on: ubuntu-latest
-    name: Release Rust crate
-    steps:
-      - uses: actions/checkout@v1
-      - uses: bahmutov/npm-install@v1.1.0
-      - name: Install Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          profile: minimal
-          override: true
-      - run: cargo login ${CRATES_IO_TOKEN}
-        env:
-          CRATES_IO_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
-      - run: |
-          cargo install cargo-workspaces
-          cargo workspaces publish --from-git -y
+  # release-crates:
+  #   runs-on: ubuntu-latest
+  #   name: Release Rust crate
+  #   steps:
+  #     - uses: actions/checkout@v1
+  #     - uses: bahmutov/npm-install@v1.1.0
+  #     - name: Install Rust
+  #       uses: actions-rs/toolchain@v1
+  #       with:
+  #         toolchain: stable
+  #         profile: minimal
+  #         override: true
+  #     - run: cargo login ${CRATES_IO_TOKEN}
+  #       env:
+  #         CRATES_IO_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
+  #     - run: |
+  #         cargo install cargo-workspaces
+  #         cargo workspaces publish --from-git -y

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -114,11 +114,11 @@ jobs:
             setup: npm install --global yarn@1
           - target: aarch64-unknown-linux-gnu
             strip: aarch64-linux-gnu-strip
-            image: ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-debian
+            image: ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-debian@sha256:4e170e00b4e33251a775bcadc34380a6a5a86611df132590885257e453646fdc
             setup: apt install gcc-aarch64-linux-gnu g++-aarch64-linux-gnu -y
           - target: armv7-unknown-linux-gnueabihf
             strip: arm-linux-gnueabihf-strip
-            image: ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-debian
+            image: ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-debian@sha256:4e170e00b4e33251a775bcadc34380a6a5a86611df132590885257e453646fdc
             setup: apt install gcc-arm-linux-gnueabihf g++-arm-linux-gnueabihf -y
           - target: aarch64-unknown-linux-musl
             image: ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-alpine
@@ -134,6 +134,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+      - name: Debug
+        run: ldd --version
       - name: Install Node.JS
         uses: actions/setup-node@v2
         with:
@@ -148,9 +150,6 @@ jobs:
       - name: Setup cross compile toolchain
         if: ${{ matrix.setup }}
         run: ${{ matrix.setup }}
-
-      - name: Debug
-        run: ldd --version
 
       - name: Setup rust target
         run: rustup target add ${{ matrix.target }}


### PR DESCRIPTION
Fixes #335.

Do to an upstream commit (https://github.com/messense/manylinux-cross/commit/76f103138b2c65450b1d181318004203ef760ad5) on the base docker image use to build the ARM linux binaries, Ubuntu was upgraded to 22.01. This raised the GLIBC requirement to 2.35. For now I pinned to an older version of the docker image to downgrade again.