### PR TITLE
Fix media query parens

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6869,6 +6869,69 @@ mod tests {
 
     prefix_test(
       r#"
+        @media not (100px <= width <= 200px) {
+          .foo {
+            color: chartreuse;
+          }
+        }
+      "#,
+      indoc! { r#"
+        @media not ((min-width: 100px) and (max-width: 200px)) {
+          .foo {
+            color: #7fff00;
+          }
+        }
+      "#},
+      Browsers {
+        firefox: Some(85 << 16),
+        ..Browsers::default()
+      },
+    );
+
+    prefix_test(
+      r#"
+        @media (hover) and (100px <= width <= 200px) {
+          .foo {
+            color: chartreuse;
+          }
+        }
+      "#,
+      indoc! { r#"
+        @media (hover) and (min-width: 100px) and (max-width: 200px) {
+          .foo {
+            color: #7fff00;
+          }
+        }
+      "#},
+      Browsers {
+        firefox: Some(85 << 16),
+        ..Browsers::default()
+      },
+    );
+
+    prefix_test(
+      r#"
+        @media (hover) or (100px <= width <= 200px) {
+          .foo {
+            color: chartreuse;
+          }
+        }
+      "#,
+      indoc! { r#"
+        @media (hover) or ((min-width: 100px) and (max-width: 200px)) {
+          .foo {
+            color: #7fff00;
+          }
+        }
+      "#},
+      Browsers {
+        firefox: Some(85 << 16),
+        ..Browsers::default()
+      },
+    );
+
+    prefix_test(
+      r#"
         @media (100px < width < 200px) {
           .foo {
             color: chartreuse;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6717,6 +6717,8 @@ mod tests {
     );
     minify_test("@media { .foo { color: chartreuse }}", ".foo{color:#7fff00}");
     minify_test("@media all { .foo { color: chartreuse }}", ".foo{color:#7fff00}");
+    minify_test("@media not (((color) or (hover))) { .foo { color: chartreuse }}", "@media not ((color) or (hover)){.foo{color:#7fff00}}");
+    minify_test("@media (hover) and ((color) and (test)) { .foo { color: chartreuse }}", "@media (hover) and (color) and (test){.foo{color:#7fff00}}");
 
     prefix_test(
       r#"
@@ -22586,7 +22588,7 @@ mod tests {
         }
       }
     "#,
-      "@container my-layout (not (width>500px)){.foo{color:red}}",
+      "@container my-layout not (width>500px){.foo{color:red}}",
     );
 
     minify_test(
@@ -22619,7 +22621,7 @@ mod tests {
         }
       }
     "#,
-      "@container my-layout ((width:100px) and (not (height:100px))){.foo{color:red}}",
+      "@container my-layout (width:100px) and (not (height:100px)){.foo{color:red}}",
     );
 
     minify_test(

--- a/src/media_query.rs
+++ b/src/media_query.rs
@@ -457,7 +457,22 @@ impl<'i> ToCss for MediaCondition<'i> {
       MediaCondition::Feature(ref f) => f.to_css(dest),
       MediaCondition::Not(ref c) => {
         dest.write_str("not ")?;
-        c.to_css(dest)
+
+        let needs_parens = dest.targets.is_some() && 
+          matches!(&**c, MediaCondition::Feature(f) if matches!(f, MediaFeature::Interval { .. })) && 
+          !Feature::MediaIntervalSyntax.is_compatible(dest.targets.unwrap());
+        
+        if needs_parens {
+          dest.write_char('(')?;
+        }
+
+        c.to_css(dest)?;
+
+        if needs_parens {
+          dest.write_char(')')?;
+        }
+
+        Ok(())
       }
       MediaCondition::InParens(ref c) => {
         dest.write_char('(')?;

--- a/src/media_query.rs
+++ b/src/media_query.rs
@@ -1049,7 +1049,10 @@ mod tests {
   fn test_negated_interval_parens() {
     let media_query = parse("screen and not (200px <= width < 500px)");
     let printer_options = PrinterOptions {
-      targets: Browsers::from_browserslist(["chrome 95"]).unwrap(),
+      targets: Some(Browsers {
+        chrome: Some(95 << 16),
+        ..Default::default()
+      }),
       ..Default::default()
     };
     assert_eq!(media_query.to_css_string(printer_options).unwrap(), "screen and not ((min-width: 200px) and (max-width: 499.999px))");

--- a/src/media_query.rs
+++ b/src/media_query.rs
@@ -997,7 +997,7 @@ fn process_condition<'i>(
 #[cfg(test)]
 mod tests {
   use super::*;
-  use crate::stylesheet::PrinterOptions;
+  use crate::{stylesheet::PrinterOptions, targets::Browsers};
 
   fn parse(s: &str) -> MediaQuery {
     let mut input = ParserInput::new(&s);
@@ -1043,5 +1043,15 @@ mod tests {
     assert_eq!(and("all", "only screen"), "only screen");
     assert_eq!(and("only screen", "all"), "only screen");
     assert_eq!(and("print", "print"), "print");
+  }
+
+  #[test]
+  fn test_negated_interval_parens() {
+    let media_query = parse("screen and not (200px <= width < 500px)");
+    let printer_options = PrinterOptions {
+      targets: Browsers::from_browserslist(["chrome 95"]).unwrap(),
+      ..Default::default()
+    };
+    assert_eq!(media_query.to_css_string(printer_options).unwrap(), "screen and not ((min-width: 200px) and (max-width: 499.999px))");
   }
 }


### PR DESCRIPTION
Fixes #320. Closes #332. Closes #333. Closes #334.

This detects when parentheses are needed in media queries and inserts them during printing. This allows us to remove the `InParens` variant from the AST, which simplifies the code and ensures that any transforms that occur produce valid output. It should also remove parens that aren't needed.