### PR TITLE
Introduce "bundler" feature flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,14 @@ name = "lightningcss"
 path = "src/lib.rs"
 crate-type = ["rlib"]
 
+[features]
+default = ["bundler", "grid"]
+browserslist = ["browserslist-rs"]
+bundler = ["dashmap", "rayon"]
+cli = ["clap", "serde_json", "browserslist", "jemallocator"]
+grid = []
+serde = ["smallvec/serde", "cssparser/serde"]
+
 [dependencies]
 serde = { version = "1.0.123", features = ["derive"] }
 cssparser = "0.29.1"
@@ -41,8 +49,8 @@ pathdiff = "0.2.1"
 # CLI deps
 clap = { version = "3.0.6", features = ["derive"], optional = true }
 browserslist-rs = { version = "0.7.0", optional = true }
-rayon = "1.5.1"
-dashmap = "5.0.0"
+rayon = { version = "1.5.1", optional = true }
+dashmap = { version = "5.0.0", optional = true }
 serde_json = { version = "1.0.78", optional = true }
 lightningcss-derive = { version = "1.0.0-alpha.35", path = "./derive" }
 
@@ -55,13 +63,6 @@ assert_cmd = "2.0"
 assert_fs = "1.0"
 predicates = "2.1"
 serde_json = "1"
-
-[features]
-default = ["grid"]
-browserslist = ["browserslist-rs"]
-cli = ["clap", "serde_json", "browserslist", "jemallocator"]
-grid = []
-serde = ["smallvec/serde", "cssparser/serde"]
 
 [[test]]
 name = "cli_integration_tests"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,7 @@
 
 #![deny(missing_docs)]
 
+#[cfg(feature = "bundler")]
 pub mod bundler;
 mod compat;
 mod context;


### PR DESCRIPTION
This commit adds a "bundler" feature flag to the lightningcss crate.

We put the "dashmap" and "rayon" dependencies behind this new flag.

Users that do not need the bundler can now disable the feature to save
on compile time.

Related: https://github.com/parcel-bundler/lightningcss/issues/357
