### PR TITLE
Disable syn default features in lightningcss-derive

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -696,7 +696,6 @@ version = "1.0.0-alpha.35"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
 ]
 
 [[package]]

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -11,6 +11,6 @@ repository = "https://github.com/parcel-bundler/lightningcss"
 proc-macro = true
 
 [dependencies]
-syn = { version = "1.0", features = ["extra-traits"] }
+syn = { version = "1.0", default-features = false }
 quote = "1.0"
 proc-macro2 = "1.0"


### PR DESCRIPTION
This disables the default syn features in lightningcss-derive's
Cargo.toml.

It also removes an unused syn feature.

Related: https://github.com/parcel-bundler/lightningcss/issues/357
