### PR TITLE
Add sourcemap feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,14 +27,15 @@ path = "src/lib.rs"
 crate-type = ["rlib"]
 
 [features]
-default = ["bundler", "grid", "nodejs"]
+default = ["bundler", "grid", "nodejs", "sourcemap"]
 browserslist = ["browserslist-rs"]
-bundler = ["dashmap", "rayon"]
+bundler = ["dashmap", "sourcemap", "rayon"]
 cli = ["clap", "serde_json", "browserslist", "jemallocator"]
 grid = []
+jsonschema = ["schemars", "serde", "parcel_selectors/jsonschema"]
 nodejs = ["dep:serde"]
 serde = ["dep:serde", "smallvec/serde", "cssparser/serde", "parcel_selectors/serde"]
-jsonschema = ["schemars", "serde", "parcel_selectors/jsonschema"]
+sourcemap = ["parcel_sourcemap"]
 visitor = ["lightningcss-derive"]
 
 [dependencies]
@@ -44,7 +45,7 @@ parcel_selectors = { version = "0.24.9", path = "./selectors" }
 itertools = "0.10.1"
 smallvec = { version = "1.7.0", features = ["union"] }
 bitflags = "1.3.2"
-parcel_sourcemap = { version = "2.1.1", features = ["json"] }
+parcel_sourcemap = { version = "2.1.1", features = ["json"], optional = true }
 data-encoding = "2.3.2"
 lazy_static = "1.4.0"
 const-str = "0.3.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22754,6 +22754,7 @@ mod tests {
   }
 
   #[test]
+  #[cfg(feature = "sourcemap")]
   fn test_input_source_map() {
     let source = r#".imported {
       content: "yay, file support!";

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -7,6 +7,7 @@ use crate::rules::Location;
 use crate::targets::Browsers;
 use crate::vendor_prefix::VendorPrefix;
 use cssparser::{serialize_identifier, serialize_name};
+#[cfg(feature = "sourcemap")]
 use parcel_sourcemap::{OriginalLocation, SourceMap};
 
 /// Options that control how CSS is serialized to a string.
@@ -15,6 +16,7 @@ pub struct PrinterOptions<'a> {
   /// Whether to minify the CSS, i.e. remove white space.
   pub minify: bool,
   /// An optional reference to a source map to write mappings into.
+  #[cfg(feature = "sourcemap")]
   pub source_map: Option<&'a mut SourceMap>,
   /// An optional project root path, used to generate relative paths for sources used in CSS module hashes.
   pub project_root: Option<&'a str>,
@@ -62,7 +64,9 @@ pub struct PseudoClasses<'a> {
 pub struct Printer<'a, 'b, 'c, W> {
   pub(crate) sources: Option<&'c Vec<String>>,
   dest: &'a mut W,
+  #[cfg(feature = "sourcemap")]
   pub(crate) source_map: Option<&'a mut SourceMap>,
+  #[cfg(feature = "sourcemap")]
   pub(crate) source_maps: Vec<Option<SourceMap>>,
   pub(crate) loc: Location,
   indent: u8,
@@ -86,7 +90,9 @@ impl<'a, 'b, 'c, W: std::fmt::Write + Sized> Printer<'a, 'b, 'c, W> {
     Printer {
       sources: None,
       dest,
+      #[cfg(feature = "sourcemap")]
       source_map: options.source_map,
+      #[cfg(feature = "sourcemap")]
       source_maps: Vec::new(),
       loc: Location {
         source_index: 0,
@@ -209,6 +215,7 @@ impl<'a, 'b, 'c, W: std::fmt::Write + Sized> Printer<'a, 'b, 'c, W> {
   }
 
   /// Adds a mapping to the source map, if any.
+  #[cfg(feature = "sourcemap")]
   pub fn add_mapping(&mut self, loc: Location) {
     self.loc = loc;
 

--- a/src/rules/container.rs
+++ b/src/rules/container.rs
@@ -78,6 +78,7 @@ impl<'a, 'i, T: ToCss> ToCssWithContext<'a, 'i, T> for ContainerRule<'i, T> {
   where
     W: std::fmt::Write,
   {
+    #[cfg(feature = "sourcemap")]
     dest.add_mapping(self.loc);
     dest.write_str("@container ")?;
     if let Some(name) = &self.name {

--- a/src/rules/counter_style.rs
+++ b/src/rules/counter_style.rs
@@ -31,6 +31,7 @@ impl<'i> ToCss for CounterStyleRule<'i> {
   where
     W: std::fmt::Write,
   {
+    #[cfg(feature = "sourcemap")]
     dest.add_mapping(self.loc);
     dest.write_str("@counter-style ")?;
     self.name.to_css(dest)?;

--- a/src/rules/custom_media.rs
+++ b/src/rules/custom_media.rs
@@ -30,6 +30,7 @@ impl<'i> ToCss for CustomMediaRule<'i> {
   where
     W: std::fmt::Write,
   {
+    #[cfg(feature = "sourcemap")]
     dest.add_mapping(self.loc);
     dest.write_str("@custom-media ")?;
     self.name.to_css(dest)?;

--- a/src/rules/document.rs
+++ b/src/rules/document.rs
@@ -37,6 +37,7 @@ impl<'i, T: ToCss> ToCss for MozDocumentRule<'i, T> {
   where
     W: std::fmt::Write,
   {
+    #[cfg(feature = "sourcemap")]
     dest.add_mapping(self.loc);
     dest.write_str("@-moz-document url-prefix()")?;
     dest.whitespace()?;

--- a/src/rules/font_face.rs
+++ b/src/rules/font_face.rs
@@ -420,6 +420,7 @@ impl<'i> ToCss for FontFaceRule<'i> {
   where
     W: std::fmt::Write,
   {
+    #[cfg(feature = "sourcemap")]
     dest.add_mapping(self.loc);
     dest.write_str("@font-face")?;
     dest.whitespace()?;

--- a/src/rules/font_palette_values.rs
+++ b/src/rules/font_palette_values.rs
@@ -342,6 +342,7 @@ impl<'i> ToCss for FontPaletteValuesRule<'i> {
   where
     W: std::fmt::Write,
   {
+    #[cfg(feature = "sourcemap")]
     dest.add_mapping(self.loc);
     dest.write_str("@font-palette-values ")?;
     self.name.to_css(dest)?;

--- a/src/rules/import.rs
+++ b/src/rules/import.rs
@@ -46,6 +46,7 @@ impl<'i> ToCss for ImportRule<'i> {
       None
     };
 
+    #[cfg(feature = "sourcemap")]
     dest.add_mapping(self.loc);
     dest.write_str("@import ")?;
     if let Some(dep) = dep {

--- a/src/rules/keyframes.rs
+++ b/src/rules/keyframes.rs
@@ -213,6 +213,7 @@ impl<'i> ToCss for KeyframesRule<'i> {
   where
     W: std::fmt::Write,
   {
+    #[cfg(feature = "sourcemap")]
     dest.add_mapping(self.loc);
     let mut first_rule = true;
     macro_rules! write_prefix {

--- a/src/rules/layer.rs
+++ b/src/rules/layer.rs
@@ -101,6 +101,7 @@ impl<'i> ToCss for LayerStatementRule<'i> {
   where
     W: std::fmt::Write,
   {
+    #[cfg(feature = "sourcemap")]
     dest.add_mapping(self.loc);
     dest.write_str("@layer ")?;
     self.names.to_css(dest)?;
@@ -146,6 +147,7 @@ impl<'a, 'i, T: ToCss> ToCssWithContext<'a, 'i, T> for LayerBlockRule<'i, T> {
   where
     W: std::fmt::Write,
   {
+    #[cfg(feature = "sourcemap")]
     dest.add_mapping(self.loc);
     dest.write_str("@layer")?;
     if let Some(name) = &self.name {

--- a/src/rules/media.rs
+++ b/src/rules/media.rs
@@ -58,6 +58,7 @@ impl<'a, 'i, T: ToCss> ToCssWithContext<'a, 'i, T> for MediaRule<'i, T> {
       return Ok(());
     }
 
+    #[cfg(feature = "sourcemap")]
     dest.add_mapping(self.loc);
     dest.write_str("@media ")?;
     self.query.to_css(dest)?;

--- a/src/rules/namespace.rs
+++ b/src/rules/namespace.rs
@@ -33,6 +33,7 @@ impl<'i> ToCss for NamespaceRule<'i> {
   where
     W: std::fmt::Write,
   {
+    #[cfg(feature = "sourcemap")]
     dest.add_mapping(self.loc);
     dest.write_str("@namespace ")?;
     if let Some(prefix) = &self.prefix {

--- a/src/rules/nesting.rs
+++ b/src/rules/nesting.rs
@@ -43,6 +43,7 @@ impl<'a, 'i, T: ToCss> ToCssWithContext<'a, 'i, T> for NestingRule<'i, T> {
   where
     W: std::fmt::Write,
   {
+    #[cfg(feature = "sourcemap")]
     dest.add_mapping(self.loc);
     if context.is_none() {
       dest.write_str("@nest ")?;

--- a/src/rules/page.rs
+++ b/src/rules/page.rs
@@ -143,6 +143,7 @@ impl<'i> ToCss for PageMarginRule<'i> {
   where
     W: std::fmt::Write,
   {
+    #[cfg(feature = "sourcemap")]
     dest.add_mapping(self.loc);
     dest.write_char('@')?;
     self.margin_box.to_css(dest)?;
@@ -211,6 +212,7 @@ impl<'i> ToCss for PageRule<'i> {
   where
     W: std::fmt::Write,
   {
+    #[cfg(feature = "sourcemap")]
     dest.add_mapping(self.loc);
     dest.write_str("@page")?;
     if let Some(first) = self.selectors.first() {

--- a/src/rules/property.rs
+++ b/src/rules/property.rs
@@ -101,6 +101,7 @@ impl<'i> ToCss for PropertyRule<'i> {
   where
     W: std::fmt::Write,
   {
+    #[cfg(feature = "sourcemap")]
     dest.add_mapping(self.loc);
     dest.write_str("@property ")?;
     self.name.to_css(dest)?;

--- a/src/rules/style.rs
+++ b/src/rules/style.rs
@@ -210,6 +210,7 @@ impl<'a, 'i, T: ToCss> StyleRule<'i, T> {
     let has_declarations = supports_nesting || len > 0 || self.rules.0.is_empty();
 
     if has_declarations {
+      #[cfg(feature = "sourcemap")]
       dest.add_mapping(self.loc);
       self.selectors.to_css_with_context(dest, context)?;
       dest.whitespace()?;

--- a/src/rules/supports.rs
+++ b/src/rules/supports.rs
@@ -57,6 +57,7 @@ impl<'a, 'i, T: ToCss> ToCssWithContext<'a, 'i, T> for SupportsRule<'i, T> {
   where
     W: std::fmt::Write,
   {
+    #[cfg(feature = "sourcemap")]
     dest.add_mapping(self.loc);
     dest.write_str("@supports ")?;
     self.condition.to_css(dest)?;

--- a/src/rules/unknown.rs
+++ b/src/rules/unknown.rs
@@ -33,6 +33,7 @@ impl<'i> ToCss for UnknownAtRule<'i> {
   where
     W: std::fmt::Write,
   {
+    #[cfg(feature = "sourcemap")]
     dest.add_mapping(self.loc);
     dest.write_char('@')?;
     dest.write_str(&self.name)?;

--- a/src/rules/viewport.rs
+++ b/src/rules/viewport.rs
@@ -35,6 +35,7 @@ impl<'i> ToCss for ViewportRule<'i> {
   where
     W: std::fmt::Write,
   {
+    #[cfg(feature = "sourcemap")]
     dest.add_mapping(self.loc);
     dest.write_char('@')?;
     self.vendor_prefix.to_css(dest)?;

--- a/src/stylesheet.rs
+++ b/src/stylesheet.rs
@@ -17,6 +17,7 @@ use crate::traits::ToCss;
 #[cfg(feature = "visitor")]
 use crate::visitor::{Visit, VisitTypes, Visitor};
 use cssparser::{AtRuleParser, Parser, ParserInput, RuleListParser};
+#[cfg(feature = "sourcemap")]
 use parcel_sourcemap::SourceMap;
 use std::collections::{HashMap, HashSet};
 
@@ -178,6 +179,7 @@ where
   }
 
   /// Returns the inline source map associated with the source at the given index.
+  #[cfg(feature = "sourcemap")]
   pub fn source_map(&self, source_index: usize) -> Option<SourceMap> {
     SourceMap::from_data_url("/", self.source_map_url(source_index)?).ok()
   }
@@ -233,7 +235,12 @@ where
     let project_root = options.project_root.clone();
     let mut printer = Printer::new(&mut dest, options);
 
-    printer.sources = Some(&self.sources);
+    #[cfg(feature = "sourcemap")]
+    {
+      printer.sources = Some(&self.sources);
+    }
+
+    #[cfg(feature = "sourcemap")]
     if printer.source_map.is_some() {
       printer.source_maps = self.sources.iter().enumerate().map(|(i, _)| self.source_map(i)).collect();
     }
@@ -339,6 +346,7 @@ impl<'i> StyleAttribute<'i> {
 
   /// Serializes the style attribute to a CSS string.
   pub fn to_css(&self, options: PrinterOptions) -> Result<ToCssResult, PrinterError> {
+    #[cfg(feature = "sourcemap")]
     assert!(
       options.source_map.is_none(),
       "Source maps are not supported for style attributes"


### PR DESCRIPTION
This commit introduces the "sourcemap" feature.

Users that do not need sourcemaps can disable this feature and save
roughly 15% on compile times.

Related to https://github.com/parcel-bundler/lightningcss/issues/357
