### PR TITLE
Remove derive-move

### DIFF
--- a/selectors/Cargo.toml
+++ b/selectors/Cargo.toml
@@ -21,7 +21,6 @@ jsonschema = ["serde", "schemars"]
 [dependencies]
 bitflags = "1.0"
 cssparser = "0.29"
-derive_more = "0.99"
 fxhash = "0.2"
 log = "0.4"
 phf = "0.8"

--- a/selectors/builder.rs
+++ b/selectors/builder.rs
@@ -23,6 +23,7 @@ use crate::sink::Push;
 use smallvec::{self, SmallVec};
 use std::cmp;
 use std::iter;
+use std::ops::{Add, AddAssign};
 use std::ptr;
 use std::slice;
 
@@ -228,11 +229,29 @@ impl SpecificityAndFlags {
 
 const MAX_10BIT: u32 = (1u32 << 10) - 1;
 
-#[derive(Add, AddAssign, Clone, Copy, Default, Eq, Ord, PartialEq, PartialOrd)]
+#[derive(Clone, Copy, Default, Eq, Ord, PartialEq, PartialOrd)]
 struct Specificity {
   id_selectors: u32,
   class_like_selectors: u32,
   element_selectors: u32,
+}
+impl Add for Specificity {
+  type Output = Specificity;
+
+  fn add(self, rhs: Self) -> Self::Output {
+    Specificity {
+      id_selectors: self.id_selectors + rhs.id_selectors,
+      class_like_selectors: self.class_like_selectors + rhs.class_like_selectors,
+      element_selectors: self.element_selectors + rhs.element_selectors,
+    }
+  }
+}
+impl AddAssign for Specificity {
+  fn add_assign(&mut self, rhs: Self) {
+    self.id_selectors += rhs.id_selectors;
+    self.element_selectors += rhs.element_selectors;
+    self.class_like_selectors += rhs.class_like_selectors;
+  }
 }
 
 impl From<u32> for Specificity {

--- a/selectors/lib.rs
+++ b/selectors/lib.rs
@@ -9,8 +9,6 @@
 extern crate bitflags;
 #[macro_use]
 extern crate cssparser;
-#[macro_use]
-extern crate derive_more;
 extern crate fxhash;
 #[macro_use]
 extern crate log;


### PR DESCRIPTION
Saves around 3.5% on `lightningcss` compile times on my machine.
