### PR TITLE
Revert "Disable syn default features in lightningcss-derive"

### DIFF
--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -11,6 +11,6 @@ repository = "https://github.com/parcel-bundler/lightningcss"
 proc-macro = true
 
 [dependencies]
-syn = { version = "1.0", default-features = false }
+syn = { version = "1.0", features = ["extra-traits"] }
 quote = "1.0"
 proc-macro2 = "1.0"


### PR DESCRIPTION
Reverts parcel-bundler/lightningcss#361

This seems to have broken `cargo build -p lightningcss-derive`.