### PR TITLE
fix: `<layer-name>` should be escaped

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22488,6 +22488,23 @@ mod tests {
     "#,
       "@layer{.bar{color:red}}",
     );
+    minify_test(
+      r#"
+      @layer foo\20 bar, baz;
+    "#,
+      "@layer foo\\ bar,baz;",
+    );
+    minify_test(
+      r#"
+      @layer one.two\20 three\#four\.five {
+        .bar {
+          color: red;
+        }
+      }
+    "#,
+      "@layer one.two\\ three\\#four\\.five{.bar{color:red}}",
+    );
+
     error_test("@layer;", ParserError::UnexpectedToken(Token::Semicolon));
     error_test("@layer foo, bar {};", ParserError::AtRuleBodyInvalid);
     minify_test("@import 'test.css' layer;", "@import \"test.css\" layer;");
@@ -22495,6 +22512,10 @@ mod tests {
     minify_test(
       "@import 'test.css' layer(foo.bar);",
       "@import \"test.css\" layer(foo.bar);",
+    );
+    minify_test(
+      "@import 'test.css' layer(foo\\20 bar);",
+      "@import \"test.css\" layer(foo\\ bar);",
     );
     error_test(
       "@import 'test.css' layer(foo, bar) {};",

--- a/src/rules/layer.rs
+++ b/src/rules/layer.rs
@@ -72,7 +72,7 @@ impl<'i> ToCss for LayerName<'i> {
         dest.write_char('.')?;
       }
 
-      dest.write_str(name)?;
+      serialize_identifier(name, dest)?;
     }
 
     Ok(())


### PR DESCRIPTION
Spec: https://w3c.github.io/csswg-drafts/css-cascade-5/#typedef-layer-name

Closes: #382