### PR TITLE
Support node in wasm package

### DIFF
--- a/wasm/index.mjs
+++ b/wasm/index.mjs
@@ -5,7 +5,7 @@ let wasm;
 
 export default async function init(input = url) {
   if (typeof input === 'string' || (typeof Request === 'function' && input instanceof Request) || (typeof URL === 'function' && input instanceof URL)) {
-    input = fetch(input);
+    input = fetchOrReadFromFs(input);
   }
 
   const { instance } = await load(await input, {
@@ -51,3 +51,12 @@ async function load(module, imports) {
     }
   }
 }
+
+const fetchOrReadFromFs = async (inputPath) => {
+  try {
+    const fs = await import('node:fs');
+    return fs.readFileSync(inputPath);
+  } catch {
+    return fetch(inputPath);
+  }
+};

--- a/wasm/index.mjs
+++ b/wasm/index.mjs
@@ -52,9 +52,9 @@ async function load(module, imports) {
   }
 }
 
-const fetchOrReadFromFs = async (inputPath) => {
+async function fetchOrReadFromFs(inputPath) {
   try {
-    const fs = await import('node:fs');
+    const fs = await import('fs');
     return fs.readFileSync(inputPath);
   } catch {
     return fetch(inputPath);


### PR DESCRIPTION
As discussed in #386, will try to read from filesystem (using `fs`) if used in a node environment, and fallback to `fetch` for browser/deno environments.