### PR TITLE
Visitor: allow short-circuiting on error

### DIFF
--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -143,7 +143,7 @@ mod bundle {
       &config,
       visitor.as_mut().map(|visitor| {
         |stylesheet: &mut StyleSheet| {
-          stylesheet.visit(visitor);
+          stylesheet.visit(visitor).unwrap();
           if let Some(err) = visitor.errors.first() {
             return Err(err.clone());
           }
@@ -396,7 +396,7 @@ mod bundle {
         std::ptr::null_mut(),
         0,
         move |ctx: ThreadSafeCallContext<VisitMessage>| {
-          ctx.value.stylesheet.visit(&mut visitor);
+          ctx.value.stylesheet.visit(&mut visitor).unwrap();
           if let Some(err) = visitor.errors.first() {
             ctx.value.tx.send(Err(err.clone())).expect("send error");
             return Ok(());
@@ -638,7 +638,7 @@ fn compile<'i>(
     )?;
 
     if let Some(visitor) = visitor.as_mut() {
-      stylesheet.visit(visitor);
+      stylesheet.visit(visitor).unwrap();
     }
 
     stylesheet.minify(MinifyOptions {
@@ -853,7 +853,7 @@ fn compile_attr<'i>(
     )?;
 
     if let Some(visitor) = visitor.as_mut() {
-      attr.visit(visitor);
+      attr.visit(visitor).unwrap();
     }
 
     attr.minify(MinifyOptions {

--- a/node/src/transformer.rs
+++ b/node/src/transformer.rs
@@ -603,7 +603,7 @@ fn visit<V: Serialize + Deserialize<'static>>(
   value: &mut V,
   visit: &Option<Ref<()>>,
   errors: &mut Vec<napi::Error>,
-) -> Result<(), ()> {
+) -> Result<(), Infallible> {
   if let Some(visit) = visit
     .as_ref()
     .and_then(|v| env.get_reference_value_unchecked::<JsFunction>(v).ok())

--- a/src/main.rs
+++ b/src/main.rs
@@ -97,7 +97,7 @@ pub fn main() -> Result<(), std::io::Error> {
       (filename, contents)
     }
   };
-    
+
   let css_modules = if let Some(_) = cli_args.css_modules {
     let pattern = if let Some(pattern) = cli_args.css_modules_pattern.as_ref() {
       match lightningcss::css_modules::Pattern::parse(pattern) {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -116,7 +116,9 @@ impl crate::traits::ToCss for DefaultAtRule {
 #[cfg(feature = "visitor")]
 impl<'i, V: Visitor<'i, DefaultAtRule>> Visit<'i, DefaultAtRule, V> for DefaultAtRule {
   const CHILD_TYPES: VisitTypes = VisitTypes::empty();
-  fn visit_children(&mut self, _: &mut V) {}
+  fn visit_children(&mut self, _: &mut V) -> Result<(), V::Error> {
+    Ok(())
+  }
 }
 
 #[derive(PartialEq, PartialOrd)]

--- a/src/properties/custom.rs
+++ b/src/properties/custom.rs
@@ -26,6 +26,8 @@ use crate::vendor_prefix::VendorPrefix;
 #[cfg(feature = "visitor")]
 use crate::visitor::Visit;
 use cssparser::*;
+#[cfg(feature = "visitor")]
+use std::convert::Infallible;
 
 #[cfg(feature = "serde")]
 use crate::serialization::ValueWrapper;
@@ -995,7 +997,7 @@ impl<'i> TokenList<'i> {
   /// Substitutes variables with the provided values.
   #[cfg(feature = "substitute_variables")]
   pub fn substitute_variables(&mut self, vars: &std::collections::HashMap<&str, TokenList<'i>>) {
-    self.visit(&mut VarInliner { vars })
+    self.visit(&mut VarInliner { vars }).unwrap()
   }
 }
 
@@ -1006,14 +1008,16 @@ struct VarInliner<'a, 'i> {
 
 #[cfg(feature = "substitute_variables")]
 impl<'a, 'i> crate::visitor::Visitor<'i> for VarInliner<'a, 'i> {
+  type Error = Infallible;
+
   const TYPES: crate::visitor::VisitTypes = crate::visit_types!(TOKENS | VARIABLES);
 
-  fn visit_token_list(&mut self, tokens: &mut TokenList<'i>) {
+  fn visit_token_list(&mut self, tokens: &mut TokenList<'i>) -> Result<(), Self::Error> {
     let mut i = 0;
     let mut seen = std::collections::HashSet::new();
     while i < tokens.0.len() {
       let token = &mut tokens.0[i];
-      token.visit(self);
+      token.visit(self).unwrap();
       if let TokenOrValue::Var(var) = token {
         if let Some(value) = self.vars.get(var.name.ident.0.as_ref()) {
           // Ignore circular references.
@@ -1033,6 +1037,7 @@ impl<'a, 'i> crate::visitor::Visitor<'i> for VarInliner<'a, 'i> {
       seen.clear();
       i += 1;
     }
+    Ok(())
   }
 }
 

--- a/src/rules/mod.rs
+++ b/src/rules/mod.rs
@@ -400,7 +400,7 @@ pub struct CssRuleList<'i, R = DefaultAtRule>(
 impl<'i, T: Visit<'i, T, V>, V: Visitor<'i, T>> Visit<'i, T, V> for CssRuleList<'i, T> {
   const CHILD_TYPES: VisitTypes = VisitTypes::all();
 
-  fn visit(&mut self, visitor: &mut V) {
+  fn visit(&mut self, visitor: &mut V) -> Result<(), V::Error> {
     if visitor.visit_types().contains(VisitTypes::RULES) {
       visitor.visit_rule_list(self)
     } else {
@@ -408,7 +408,7 @@ impl<'i, T: Visit<'i, T, V>, V: Visitor<'i, T>> Visit<'i, T, V> for CssRuleList<
     }
   }
 
-  fn visit_children(&mut self, visitor: &mut V) {
+  fn visit_children(&mut self, visitor: &mut V) -> Result<(), V::Error> {
     self.0.visit(visitor)
   }
 }

--- a/src/selector.rs
+++ b/src/selector.rs
@@ -1827,7 +1827,7 @@ pub(crate) fn is_unused(
 impl<'i, T: Visit<'i, T, V>, V: Visitor<'i, T>> Visit<'i, T, V> for SelectorList<'i> {
   const CHILD_TYPES: VisitTypes = VisitTypes::SELECTORS;
 
-  fn visit(&mut self, visitor: &mut V) {
+  fn visit(&mut self, visitor: &mut V) -> Result<(), V::Error> {
     if visitor.visit_types().contains(VisitTypes::SELECTORS) {
       visitor.visit_selector_list(self)
     } else {
@@ -1835,10 +1835,8 @@ impl<'i, T: Visit<'i, T, V>, V: Visitor<'i, T>> Visit<'i, T, V> for SelectorList
     }
   }
 
-  fn visit_children(&mut self, visitor: &mut V) {
-    for selector in self.0.iter_mut() {
-      Visit::visit(selector, visitor)
-    }
+  fn visit_children(&mut self, visitor: &mut V) -> Result<(), V::Error> {
+    self.0.iter_mut().try_for_each(|selector| Visit::visit(selector, visitor))
   }
 }
 
@@ -1846,9 +1844,11 @@ impl<'i, T: Visit<'i, T, V>, V: Visitor<'i, T>> Visit<'i, T, V> for SelectorList
 impl<'i, T: Visit<'i, T, V>, V: Visitor<'i, T>> Visit<'i, T, V> for Selector<'i> {
   const CHILD_TYPES: VisitTypes = VisitTypes::SELECTORS;
 
-  fn visit(&mut self, visitor: &mut V) {
+  fn visit(&mut self, visitor: &mut V) -> Result<(), V::Error> {
     visitor.visit_selector(self)
   }
 
-  fn visit_children(&mut self, _visitor: &mut V) {}
+  fn visit_children(&mut self, _visitor: &mut V) -> Result<(), V::Error> {
+    Ok(())
+  }
 }

--- a/src/stylesheet.rs
+++ b/src/stylesheet.rs
@@ -286,7 +286,7 @@ where
 {
   const CHILD_TYPES: VisitTypes = VisitTypes::all();
 
-  fn visit_children(&mut self, visitor: &mut V) {
+  fn visit_children(&mut self, visitor: &mut V) -> Result<(), V::Error> {
     self.rules.visit(visitor)
   }
 }

--- a/src/values/color.rs
+++ b/src/values/color.rs
@@ -3226,5 +3226,7 @@ impl HueInterpolationMethod {
 #[cfg(feature = "visitor")]
 impl<'i, V: Visitor<'i, T>, T: Visit<'i, T, V>> Visit<'i, T, V> for RGBA {
   const CHILD_TYPES: VisitTypes = VisitTypes::empty();
-  fn visit_children(&mut self, _: &mut V) {}
+  fn visit_children(&mut self, _: &mut V) -> Result<(), V::Error> {
+    Ok(())
+  }
 }

--- a/src/values/string.rs
+++ b/src/values/string.rs
@@ -308,7 +308,9 @@ impl<'de> serde::de::Visitor<'de> for CowArcStrVisitor {
 #[cfg(feature = "visitor")]
 impl<'i, V: Visitor<'i, T>, T: Visit<'i, T, V>> Visit<'i, T, V> for CowArcStr<'i> {
   const CHILD_TYPES: VisitTypes = VisitTypes::empty();
-  fn visit_children(&mut self, _: &mut V) {}
+  fn visit_children(&mut self, _: &mut V) -> Result<(), V::Error> {
+    Ok(())
+  }
 }
 
 /// A quoted CSS string.

--- a/src/vendor_prefix.rs
+++ b/src/vendor_prefix.rs
@@ -191,7 +191,9 @@ impl<'de> serde::Deserialize<'de> for VendorPrefix {
 #[cfg(feature = "visitor")]
 impl<'i, V: Visitor<'i, T>, T: Visit<'i, T, V>> Visit<'i, T, V> for VendorPrefix {
   const CHILD_TYPES: VisitTypes = VisitTypes::empty();
-  fn visit_children(&mut self, _: &mut V) {}
+  fn visit_children(&mut self, _: &mut V) -> Result<(), V::Error> {
+    Ok(())
+  }
 }
 
 #[cfg(feature = "jsonschema")]

--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -10,6 +10,7 @@
 //! This example transforms a stylesheet, adding a prefix to all URLs, and converting pixels to rems.
 //!
 //! ```
+//! use std::convert::Infallible;
 //! use lightningcss::{
 //!   stylesheet::{StyleSheet, ParserOptions, PrinterOptions},
 //!   visitor::{Visitor, Visit, VisitTypes},
@@ -30,21 +31,26 @@
 //!
 //! struct MyVisitor;
 //! impl<'i> Visitor<'i> for MyVisitor {
+//!   type Error = Infallible;
+//!
 //!   const TYPES: VisitTypes = visit_types!(URLS | LENGTHS);
 //!
-//!   fn visit_url(&mut self, url: &mut Url<'i>) {
-//!     url.url = format!("https://mywebsite.com/{}", url.url).into()
+//!   fn visit_url(&mut self, url: &mut Url<'i>) -> Result<(), Self::Error> {
+//!     url.url = format!("https://mywebsite.com/{}", url.url).into();
+//!     Ok(())
 //!   }
 //!
-//!   fn visit_length(&mut self, length: &mut LengthValue) {
+//!   fn visit_length(&mut self, length: &mut LengthValue) -> Result<(), Self::Error> {
 //!     match length {
 //!       LengthValue::Px(px) => *length = LengthValue::Rem(*px / 16.0),
 //!       _ => {}
 //!     }
+//!
+//!     Ok(())
 //!   }
 //! }
 //!
-//! stylesheet.visit(&mut MyVisitor);
+//! stylesheet.visit(&mut MyVisitor).unwrap();
 //!
 //! let res = stylesheet.to_css(PrinterOptions { minify: true, ..Default::default() }).unwrap();
 //! assert_eq!(res.code, ".foo{background:url(https://mywebsite.com/bg.png);width:2rem}");
@@ -134,6 +140,9 @@ macro_rules! visit_types {
 
 /// A trait for visiting or transforming rules, properties, and values in a StyleSheet.
 pub trait Visitor<'i, T: Visit<'i, T, Self> = DefaultAtRule>: Sized {
+  /// The `Err` value for `Result`s returned by `visit_*` methods.
+  type Error;
+
   /// The types of values that this visitor should visit. May be constructed using
   /// the [visit_types](visit_types) macro. Accurately setting these flags improves
   /// performance by skipping branches that do not have any values of the requested types.
@@ -148,136 +157,156 @@ pub trait Visitor<'i, T: Visit<'i, T, Self> = DefaultAtRule>: Sized {
 
   /// Visits a rule list.
   #[inline]
-  fn visit_rule_list(&mut self, rules: &mut CssRuleList<'i, T>) {
+  fn visit_rule_list(&mut self, rules: &mut CssRuleList<'i, T>) -> Result<(), Self::Error> {
     rules.visit_children(self)
   }
 
   /// Visits a rule.
   #[inline]
-  fn visit_rule(&mut self, rule: &mut CssRule<'i, T>) {
+  fn visit_rule(&mut self, rule: &mut CssRule<'i, T>) -> Result<(), Self::Error> {
     rule.visit_children(self)
   }
 
   /// Visits a declaration block.
   #[inline]
-  fn visit_declaration_block(&mut self, decls: &mut DeclarationBlock<'i>) {
+  fn visit_declaration_block(&mut self, decls: &mut DeclarationBlock<'i>) -> Result<(), Self::Error> {
     decls.visit_children(self)
   }
 
   /// Visits a property.
   #[inline]
-  fn visit_property(&mut self, property: &mut Property<'i>) {
+  fn visit_property(&mut self, property: &mut Property<'i>) -> Result<(), Self::Error> {
     property.visit_children(self)
   }
 
   /// Visits a url.
-  fn visit_url(&mut self, _url: &mut Url<'i>) {}
+  fn visit_url(&mut self, _url: &mut Url<'i>) -> Result<(), Self::Error> {
+    Ok(())
+  }
 
   /// Visits a color.
   #[allow(unused_variables)]
-  fn visit_color(&mut self, color: &mut CssColor) {}
+  fn visit_color(&mut self, color: &mut CssColor) -> Result<(), Self::Error> {
+    Ok(())
+  }
 
   /// Visits an image.
   #[inline]
-  fn visit_image(&mut self, image: &mut Image<'i>) {
+  fn visit_image(&mut self, image: &mut Image<'i>) -> Result<(), Self::Error> {
     image.visit_children(self)
   }
 
   /// Visits a length.
   #[allow(unused_variables)]
-  fn visit_length(&mut self, length: &mut LengthValue) {}
+  fn visit_length(&mut self, length: &mut LengthValue) -> Result<(), Self::Error> {
+    Ok(())
+  }
 
   /// Visits an angle.
   #[allow(unused_variables)]
-  fn visit_angle(&mut self, angle: &mut Angle) {}
+  fn visit_angle(&mut self, angle: &mut Angle) -> Result<(), Self::Error> {
+    Ok(())
+  }
 
   /// Visits a ratio.
   #[allow(unused_variables)]
-  fn visit_ratio(&mut self, ratio: &mut Ratio) {}
+  fn visit_ratio(&mut self, ratio: &mut Ratio) -> Result<(), Self::Error> {
+    Ok(())
+  }
 
   /// Visits a resolution.
   #[allow(unused_variables)]
-  fn visit_resolution(&mut self, resolution: &mut Resolution) {}
+  fn visit_resolution(&mut self, resolution: &mut Resolution) -> Result<(), Self::Error> {
+    Ok(())
+  }
 
   /// Visits a time.
   #[allow(unused_variables)]
-  fn visit_time(&mut self, time: &mut Time) {}
+  fn visit_time(&mut self, time: &mut Time) -> Result<(), Self::Error> {
+    Ok(())
+  }
 
   /// Visits a custom ident.
   #[allow(unused_variables)]
-  fn visit_custom_ident(&mut self, ident: &mut CustomIdent) {}
+  fn visit_custom_ident(&mut self, ident: &mut CustomIdent) -> Result<(), Self::Error> {
+    Ok(())
+  }
 
   /// Visits a dashed ident.
   #[allow(unused_variables)]
-  fn visit_dashed_ident(&mut self, ident: &mut DashedIdent) {}
+  fn visit_dashed_ident(&mut self, ident: &mut DashedIdent) -> Result<(), Self::Error> {
+    Ok(())
+  }
 
   /// Visits a variable reference.
   #[inline]
-  fn visit_variable(&mut self, var: &mut Variable<'i>) {
+  fn visit_variable(&mut self, var: &mut Variable<'i>) -> Result<(), Self::Error> {
     var.visit_children(self)
   }
 
   /// Visits an environment variable reference.
   #[inline]
-  fn visit_environment_variable(&mut self, env: &mut EnvironmentVariable<'i>) {
+  fn visit_environment_variable(&mut self, env: &mut EnvironmentVariable<'i>) -> Result<(), Self::Error> {
     env.visit_children(self)
   }
 
   /// Visits a media query list.
   #[inline]
-  fn visit_media_list(&mut self, media: &mut MediaList<'i>) {
+  fn visit_media_list(&mut self, media: &mut MediaList<'i>) -> Result<(), Self::Error> {
     media.visit_children(self)
   }
 
   /// Visits a media query.
   #[inline]
-  fn visit_media_query(&mut self, query: &mut MediaQuery<'i>) {
+  fn visit_media_query(&mut self, query: &mut MediaQuery<'i>) -> Result<(), Self::Error> {
     query.visit_children(self)
   }
 
   /// Visits a media feature.
   #[inline]
-  fn visit_media_feature(&mut self, feature: &mut MediaFeature<'i>) {
+  fn visit_media_feature(&mut self, feature: &mut MediaFeature<'i>) -> Result<(), Self::Error> {
     feature.visit_children(self)
   }
 
   /// Visits a media feature value.
   #[inline]
-  fn visit_media_feature_value(&mut self, value: &mut MediaFeatureValue<'i>) {
+  fn visit_media_feature_value(&mut self, value: &mut MediaFeatureValue<'i>) -> Result<(), Self::Error> {
     value.visit_children(self)
   }
 
   /// Visits a supports condition.
   #[inline]
-  fn visit_supports_condition(&mut self, condition: &mut SupportsCondition<'i>) {
+  fn visit_supports_condition(&mut self, condition: &mut SupportsCondition<'i>) -> Result<(), Self::Error> {
     condition.visit_children(self)
   }
 
   /// Visits a selector list.
   #[inline]
-  fn visit_selector_list(&mut self, selectors: &mut SelectorList<'i>) {
+  fn visit_selector_list(&mut self, selectors: &mut SelectorList<'i>) -> Result<(), Self::Error> {
     selectors.visit_children(self)
   }
 
   /// Visits a selector.
   #[allow(unused_variables)]
-  fn visit_selector(&mut self, selector: &mut Selector<'i>) {}
+  fn visit_selector(&mut self, selector: &mut Selector<'i>) -> Result<(), Self::Error> {
+    Ok(())
+  }
 
   /// Visits a custom function.
   #[inline]
-  fn visit_function(&mut self, function: &mut Function<'i>) {
+  fn visit_function(&mut self, function: &mut Function<'i>) -> Result<(), Self::Error> {
     function.visit_children(self)
   }
 
   /// Visits a token list.
   #[inline]
-  fn visit_token_list(&mut self, tokens: &mut TokenList<'i>) {
+  fn visit_token_list(&mut self, tokens: &mut TokenList<'i>) -> Result<(), Self::Error> {
     tokens.visit_children(self)
   }
 
   /// Visits a token or value in an unparsed property.
   #[inline]
-  fn visit_token(&mut self, token: &mut TokenOrValue<'i>) {
+  fn visit_token(&mut self, token: &mut TokenOrValue<'i>) -> Result<(), Self::Error> {
     token.visit_children(self)
   }
 }
@@ -292,26 +321,30 @@ pub trait Visit<'i, T: Visit<'i, T, V>, V: Visitor<'i, T>> {
   /// Visits the value by calling an appropriate method on the Visitor.
   /// If no corresponding visitor method exists, then the children are visited.
   #[inline]
-  fn visit(&mut self, visitor: &mut V) {
+  fn visit(&mut self, visitor: &mut V) -> Result<(), V::Error> {
     self.visit_children(visitor)
   }
 
   /// Visit the children of this value.
-  fn visit_children(&mut self, visitor: &mut V);
+  fn visit_children(&mut self, visitor: &mut V) -> Result<(), V::Error>;
 }
 
 impl<'i, T: Visit<'i, T, V>, V: Visitor<'i, T>, U: Visit<'i, T, V>> Visit<'i, T, V> for Option<U> {
   const CHILD_TYPES: VisitTypes = U::CHILD_TYPES;
 
-  fn visit(&mut self, visitor: &mut V) {
+  fn visit(&mut self, visitor: &mut V) -> Result<(), V::Error> {
     if let Some(v) = self {
       v.visit(visitor)
+    } else {
+      Ok(())
     }
   }
 
-  fn visit_children(&mut self, visitor: &mut V) {
+  fn visit_children(&mut self, visitor: &mut V) -> Result<(), V::Error> {
     if let Some(v) = self {
       v.visit_children(visitor)
+    } else {
+      Ok(())
     }
   }
 }
@@ -319,11 +352,11 @@ impl<'i, T: Visit<'i, T, V>, V: Visitor<'i, T>, U: Visit<'i, T, V>> Visit<'i, T,
 impl<'i, T: Visit<'i, T, V>, V: Visitor<'i, T>, U: Visit<'i, T, V>> Visit<'i, T, V> for Box<U> {
   const CHILD_TYPES: VisitTypes = U::CHILD_TYPES;
 
-  fn visit(&mut self, visitor: &mut V) {
+  fn visit(&mut self, visitor: &mut V) -> Result<(), V::Error> {
     self.as_mut().visit(visitor)
   }
 
-  fn visit_children(&mut self, visitor: &mut V) {
+  fn visit_children(&mut self, visitor: &mut V) -> Result<(), V::Error> {
     self.as_mut().visit_children(visitor)
   }
 }
@@ -331,16 +364,12 @@ impl<'i, T: Visit<'i, T, V>, V: Visitor<'i, T>, U: Visit<'i, T, V>> Visit<'i, T,
 impl<'i, T: Visit<'i, T, V>, V: Visitor<'i, T>, U: Visit<'i, T, V>> Visit<'i, T, V> for Vec<U> {
   const CHILD_TYPES: VisitTypes = U::CHILD_TYPES;
 
-  fn visit(&mut self, visitor: &mut V) {
-    for v in self {
-      v.visit(visitor)
-    }
+  fn visit(&mut self, visitor: &mut V) -> Result<(), V::Error> {
+    self.iter_mut().try_for_each(|v| v.visit(visitor))
   }
 
-  fn visit_children(&mut self, visitor: &mut V) {
-    for v in self {
-      v.visit_children(visitor)
-    }
+  fn visit_children(&mut self, visitor: &mut V) -> Result<(), V::Error> {
+    self.iter_mut().try_for_each(|v| v.visit_children(visitor))
   }
 }
 
@@ -349,16 +378,12 @@ impl<'i, A: smallvec::Array<Item = U>, U: Visit<'i, T, V>, T: Visit<'i, T, V>, V
 {
   const CHILD_TYPES: VisitTypes = U::CHILD_TYPES;
 
-  fn visit(&mut self, visitor: &mut V) {
-    for v in self {
-      v.visit(visitor)
-    }
+  fn visit(&mut self, visitor: &mut V) -> Result<(), V::Error> {
+    self.iter_mut().try_for_each(|v| v.visit(visitor))
   }
 
-  fn visit_children(&mut self, visitor: &mut V) {
-    for v in self {
-      v.visit_children(visitor)
-    }
+  fn visit_children(&mut self, visitor: &mut V) -> Result<(), V::Error> {
+    self.iter_mut().try_for_each(|v| v.visit_children(visitor))
   }
 }
 
@@ -366,7 +391,10 @@ macro_rules! impl_visit {
   ($t: ty) => {
     impl<'i, V: Visitor<'i, T>, T: Visit<'i, T, V>> Visit<'i, T, V> for $t {
       const CHILD_TYPES: VisitTypes = VisitTypes::empty();
-      fn visit_children(&mut self, _: &mut V) {}
+
+      fn visit_children(&mut self, _: &mut V) -> Result<(), V::Error> {
+        Ok(())
+      }
     }
   };
 }


### PR DESCRIPTION
In [Classmate](https://github.com/georgeclaghorn/classmate), visitors call fallible Ruby methods. I’d like to stop traversal at the first error and propagate it back up to the caller.

I currently approximate that by storing the error on the visitor and wrapping each `Visitor` method’s body in `if self.error.is_none() { ... }`. It would be nicer if I could just return an error from a visitor method and let it bubble up. This PR makes that possible.

The JS bindings’ `JsVisitor` intentionally remains infallible to preserve existing behavior, where it continues traversal after an error, but it could adopt the new behavior if desired.