### PR TITLE
Publish docs for optional features on docs.rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,10 @@ edition = "2021"
 keywords = [ "CSS", "minifier", "Parcel" ]
 repository = "https://github.com/parcel-bundler/lightningcss"
 
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
+
 [[bin]]
 name = "lightningcss"
 path = "src/main.rs"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,8 +15,10 @@
 //! style sheet. See the individual module documentation for more details and examples.
 
 #![deny(missing_docs)]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 #[cfg(feature = "bundler")]
+#[cfg_attr(docsrs, doc(cfg(feature = "bundler")))]
 pub mod bundler;
 mod compat;
 mod context;
@@ -39,6 +41,7 @@ pub mod traits;
 pub mod values;
 pub mod vendor_prefix;
 #[cfg(feature = "visitor")]
+#[cfg_attr(docsrs, doc(cfg(feature = "visitor")))]
 pub mod visitor;
 
 #[cfg(feature = "serde")]
@@ -10181,7 +10184,7 @@ mod tests {
         @bottom-left-corner {
           content: "Foo";
         }
-      
+
         @bottom-right-corner {
           content: "Bar";
         }
@@ -19670,7 +19673,7 @@ mod tests {
           color: green;
           & { color: blue; }
           color: red;
-        }      
+        }
       "#,
       indoc! {r#"
         article {

--- a/src/media_query.rs
+++ b/src/media_query.rs
@@ -208,6 +208,7 @@ impl<'i> Parse<'i> for MediaType<'i> {
 }
 
 #[cfg(feature = "jsonschema")]
+#[cfg_attr(docsrs, doc(cfg(feature = "jsonschema")))]
 impl<'a> schemars::JsonSchema for MediaType<'a> {
   fn is_referenceable() -> bool {
     true

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -114,6 +114,7 @@ impl crate::traits::ToCss for DefaultAtRule {
 }
 
 #[cfg(feature = "visitor")]
+#[cfg_attr(docsrs, doc(cfg(feature = "visitor")))]
 impl<'i, V: Visitor<'i, DefaultAtRule>> Visit<'i, DefaultAtRule, V> for DefaultAtRule {
   const CHILD_TYPES: VisitTypes = VisitTypes::empty();
   fn visit_children(&mut self, _: &mut V) {}

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -17,6 +17,7 @@ pub struct PrinterOptions<'a> {
   pub minify: bool,
   /// An optional reference to a source map to write mappings into.
   #[cfg(feature = "sourcemap")]
+  #[cfg_attr(docsrs, doc(cfg(feature = "sourcemap")))]
   pub source_map: Option<&'a mut SourceMap>,
   /// An optional project root path, used to generate relative paths for sources used in CSS module hashes.
   pub project_root: Option<&'a str>,
@@ -65,8 +66,10 @@ pub struct Printer<'a, 'b, 'c, W> {
   pub(crate) sources: Option<&'c Vec<String>>,
   dest: &'a mut W,
   #[cfg(feature = "sourcemap")]
+  #[cfg_attr(docsrs, doc(cfg(feature = "sourcemap")))]
   pub(crate) source_map: Option<&'a mut SourceMap>,
   #[cfg(feature = "sourcemap")]
+  #[cfg_attr(docsrs, doc(cfg(feature = "sourcemap")))]
   pub(crate) source_maps: Vec<Option<SourceMap>>,
   pub(crate) loc: Location,
   indent: u8,
@@ -216,6 +219,7 @@ impl<'a, 'b, 'c, W: std::fmt::Write + Sized> Printer<'a, 'b, 'c, W> {
 
   /// Adds a mapping to the source map, if any.
   #[cfg(feature = "sourcemap")]
+  #[cfg_attr(docsrs, doc(cfg(feature = "sourcemap")))]
   pub fn add_mapping(&mut self, loc: Location) {
     self.loc = loc;
 

--- a/src/properties/custom.rs
+++ b/src/properties/custom.rs
@@ -111,6 +111,7 @@ impl<'i> ToCss for CustomPropertyName<'i> {
 }
 
 #[cfg(feature = "serde")]
+#[cfg_attr(docsrs, doc(cfg(feature = "serde")))]
 impl<'i, 'de: 'i> serde::Deserialize<'de> for CustomPropertyName<'i> {
   fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
   where
@@ -177,6 +178,7 @@ impl<'i> UnparsedProperty<'i> {
 
   /// Substitutes variables and re-parses the property.
   #[cfg(feature = "substitute_variables")]
+  #[cfg_attr(docsrs, doc(cfg(feature = "substitute_variables")))]
   pub fn substitute_variables<'x>(
     mut self,
     vars: &std::collections::HashMap<&str, TokenList<'i>>,
@@ -994,6 +996,7 @@ impl<'i> TokenList<'i> {
 
   /// Substitutes variables with the provided values.
   #[cfg(feature = "substitute_variables")]
+  #[cfg_attr(docsrs, doc(cfg(feature = "substitute_variables")))]
   pub fn substitute_variables(&mut self, vars: &std::collections::HashMap<&str, TokenList<'i>>) {
     self.visit(&mut VarInliner { vars })
   }

--- a/src/properties/grid.rs
+++ b/src/properties/grid.rs
@@ -1043,6 +1043,7 @@ enum AutoFlowDirection {
 }
 
 #[cfg(feature = "jsonschema")]
+#[cfg_attr(docsrs, doc(cfg(feature = "jsonschema")))]
 impl<'a> schemars::JsonSchema for GridAutoFlow {
   fn is_referenceable() -> bool {
     true

--- a/src/properties/mod.rs
+++ b/src/properties/mod.rs
@@ -498,6 +498,7 @@ macro_rules! define_properties {
     }
 
     #[cfg(feature = "serde")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "serde")))]
     impl<'i> serde::Serialize for PropertyId<'i> {
       fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
       where
@@ -522,6 +523,7 @@ macro_rules! define_properties {
     }
 
     #[cfg(feature = "serde")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "serde")))]
     impl<'i, 'de: 'i> serde::Deserialize<'de> for PropertyId<'i> {
       fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
       where
@@ -572,6 +574,7 @@ macro_rules! define_properties {
     }
 
     #[cfg(feature = "jsonschema")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "jsonschema")))]
     impl<'i> schemars::JsonSchema for PropertyId<'i> {
       fn is_referenceable() -> bool {
         true
@@ -896,6 +899,7 @@ macro_rules! define_properties {
     }
 
     #[cfg(feature = "serde")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "serde")))]
     impl<'i> serde::Serialize for Property<'i> {
       fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
       where
@@ -950,6 +954,7 @@ macro_rules! define_properties {
     }
 
     #[cfg(feature = "serde")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "serde")))]
     impl<'i, 'de: 'i> serde::Deserialize<'de> for Property<'i> {
       fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
       where
@@ -1053,6 +1058,7 @@ macro_rules! define_properties {
     }
 
     #[cfg(feature = "jsonschema")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "jsonschema")))]
     impl<'i> schemars::JsonSchema for Property<'i> {
       fn is_referenceable() -> bool {
         true
@@ -1322,34 +1328,49 @@ define_properties! {
   "flex-preferred-size": FlexPreferredSize(LengthPercentageOrAuto, VendorPrefix) / Ms unprefixed: false,
 
   #[cfg(feature = "grid")]
+  #[cfg_attr(docsrs, doc(cfg(feature = "grid")))]
   "grid-template-columns": GridTemplateColumns(TrackSizing<'i>),
   #[cfg(feature = "grid")]
+  #[cfg_attr(docsrs, doc(cfg(feature = "grid")))]
   "grid-template-rows": GridTemplateRows(TrackSizing<'i>),
   #[cfg(feature = "grid")]
+  #[cfg_attr(docsrs, doc(cfg(feature = "grid")))]
   "grid-auto-columns": GridAutoColumns(TrackSizeList),
   #[cfg(feature = "grid")]
+  #[cfg_attr(docsrs, doc(cfg(feature = "grid")))]
   "grid-auto-rows": GridAutoRows(TrackSizeList),
   #[cfg(feature = "grid")]
+  #[cfg_attr(docsrs, doc(cfg(feature = "grid")))]
   "grid-auto-flow": GridAutoFlow(GridAutoFlow),
   #[cfg(feature = "grid")]
+  #[cfg_attr(docsrs, doc(cfg(feature = "grid")))]
   "grid-template-areas": GridTemplateAreas(GridTemplateAreas),
   #[cfg(feature = "grid")]
+  #[cfg_attr(docsrs, doc(cfg(feature = "grid")))]
   "grid-template": GridTemplate(GridTemplate<'i>) shorthand: true,
   #[cfg(feature = "grid")]
+  #[cfg_attr(docsrs, doc(cfg(feature = "grid")))]
   "grid": Grid(Grid<'i>) shorthand: true,
   #[cfg(feature = "grid")]
+  #[cfg_attr(docsrs, doc(cfg(feature = "grid")))]
   "grid-row-start": GridRowStart(GridLine<'i>),
   #[cfg(feature = "grid")]
+  #[cfg_attr(docsrs, doc(cfg(feature = "grid")))]
   "grid-row-end": GridRowEnd(GridLine<'i>),
   #[cfg(feature = "grid")]
+  #[cfg_attr(docsrs, doc(cfg(feature = "grid")))]
   "grid-column-start": GridColumnStart(GridLine<'i>),
   #[cfg(feature = "grid")]
+  #[cfg_attr(docsrs, doc(cfg(feature = "grid")))]
   "grid-column-end": GridColumnEnd(GridLine<'i>),
   #[cfg(feature = "grid")]
+  #[cfg_attr(docsrs, doc(cfg(feature = "grid")))]
   "grid-row": GridRow(GridRow<'i>) shorthand: true,
   #[cfg(feature = "grid")]
+  #[cfg_attr(docsrs, doc(cfg(feature = "grid")))]
   "grid-column": GridColumn(GridColumn<'i>) shorthand: true,
   #[cfg(feature = "grid")]
+  #[cfg_attr(docsrs, doc(cfg(feature = "grid")))]
   "grid-area": GridArea(GridArea<'i>) shorthand: true,
 
   "margin-top": MarginTop(LengthPercentageOrAuto) [logical_group: Margin, category: Physical],

--- a/src/properties/text.rs
+++ b/src/properties/text.rs
@@ -131,6 +131,7 @@ impl From<SerializedTextTransformOther> for TextTransformOther {
 }
 
 #[cfg(feature = "jsonschema")]
+#[cfg_attr(docsrs, doc(cfg(feature = "jsonschema")))]
 impl<'a> schemars::JsonSchema for TextTransformOther {
   fn is_referenceable() -> bool {
     true
@@ -655,6 +656,7 @@ impl From<SerializedTextDecorationLine> for TextDecorationLine {
 }
 
 #[cfg(feature = "jsonschema")]
+#[cfg_attr(docsrs, doc(cfg(feature = "jsonschema")))]
 impl<'a> schemars::JsonSchema for TextDecorationLine {
   fn is_referenceable() -> bool {
     true

--- a/src/properties/ui.rs
+++ b/src/properties/ui.rs
@@ -378,6 +378,7 @@ impl<'i> ToCss for Appearance<'i> {
 }
 
 #[cfg(feature = "serde")]
+#[cfg_attr(docsrs, doc(cfg(feature = "serde")))]
 impl<'i> serde::Serialize for Appearance<'i> {
   fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
   where
@@ -388,6 +389,7 @@ impl<'i> serde::Serialize for Appearance<'i> {
 }
 
 #[cfg(feature = "serde")]
+#[cfg_attr(docsrs, doc(cfg(feature = "serde")))]
 impl<'i, 'de: 'i> serde::Deserialize<'de> for Appearance<'i> {
   fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
   where
@@ -399,6 +401,7 @@ impl<'i, 'de: 'i> serde::Deserialize<'de> for Appearance<'i> {
 }
 
 #[cfg(feature = "jsonschema")]
+#[cfg_attr(docsrs, doc(cfg(feature = "jsonschema")))]
 impl<'a> schemars::JsonSchema for Appearance<'a> {
   fn is_referenceable() -> bool {
     true

--- a/src/rules/mod.rs
+++ b/src/rules/mod.rs
@@ -180,6 +180,7 @@ pub enum CssRule<'i, R = DefaultAtRule> {
 
 // Manually implemented deserialize to reduce binary size.
 #[cfg(feature = "serde")]
+#[cfg_attr(docsrs, doc(cfg(feature = "serde")))]
 impl<'i, 'de: 'i, R: serde::Deserialize<'de>> serde::Deserialize<'de> for CssRule<'i, R> {
   fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
   where
@@ -397,6 +398,7 @@ pub struct CssRuleList<'i, R = DefaultAtRule>(
 
 // Manually implemented to avoid circular child types.
 #[cfg(feature = "visitor")]
+#[cfg_attr(docsrs, doc(cfg(feature = "visitor")))]
 impl<'i, T: Visit<'i, T, V>, V: Visitor<'i, T>> Visit<'i, T, V> for CssRuleList<'i, T> {
   const CHILD_TYPES: VisitTypes = VisitTypes::all();
 

--- a/src/selector.rs
+++ b/src/selector.rs
@@ -1824,6 +1824,7 @@ pub(crate) fn is_unused(
 }
 
 #[cfg(feature = "visitor")]
+#[cfg_attr(docsrs, doc(cfg(feature = "visitor")))]
 impl<'i, T: Visit<'i, T, V>, V: Visitor<'i, T>> Visit<'i, T, V> for SelectorList<'i> {
   const CHILD_TYPES: VisitTypes = VisitTypes::SELECTORS;
 
@@ -1843,6 +1844,7 @@ impl<'i, T: Visit<'i, T, V>, V: Visitor<'i, T>> Visit<'i, T, V> for SelectorList
 }
 
 #[cfg(feature = "visitor")]
+#[cfg_attr(docsrs, doc(cfg(feature = "visitor")))]
 impl<'i, T: Visit<'i, T, V>, V: Visitor<'i, T>> Visit<'i, T, V> for Selector<'i> {
   const CHILD_TYPES: VisitTypes = VisitTypes::SELECTORS;
 

--- a/src/stylesheet.rs
+++ b/src/stylesheet.rs
@@ -183,6 +183,7 @@ where
 
   /// Returns the inline source map associated with the source at the given index.
   #[cfg(feature = "sourcemap")]
+  #[cfg_attr(docsrs, doc(cfg(feature = "sourcemap")))]
   pub fn source_map(&self, source_index: usize) -> Option<SourceMap> {
     SourceMap::from_data_url("/", self.source_map_url(source_index)?).ok()
   }
@@ -278,6 +279,7 @@ where
 }
 
 #[cfg(feature = "visitor")]
+#[cfg_attr(docsrs, doc(cfg(feature = "visitor")))]
 impl<'i, 'o, T, V> Visit<'i, T::AtRule, V> for StyleSheet<'i, 'o, T>
 where
   T: AtRuleParser<'i>,

--- a/src/targets.rs
+++ b/src/targets.rs
@@ -37,6 +37,7 @@ pub struct Browsers {
 }
 
 #[cfg(feature = "browserslist")]
+#[cfg_attr(docsrs, doc(cfg(feature = "browserslist")))]
 impl Browsers {
   /// Parses a list of browserslist queries into Lightning CSS targets.
   pub fn from_browserslist<S: AsRef<str>, I: IntoIterator<Item = S>>(

--- a/src/values/color.rs
+++ b/src/values/color.rs
@@ -3224,6 +3224,7 @@ impl HueInterpolationMethod {
 }
 
 #[cfg(feature = "visitor")]
+#[cfg_attr(docsrs, doc(cfg(feature = "visitor")))]
 impl<'i, V: Visitor<'i, T>, T: Visit<'i, T, V>> Visit<'i, T, V> for RGBA {
   const CHILD_TYPES: VisitTypes = VisitTypes::empty();
   fn visit_children(&mut self, _: &mut V) {}

--- a/src/values/length.rs
+++ b/src/values/length.rs
@@ -281,6 +281,7 @@ macro_rules! define_length_units {
     impl_try_from_angle!(LengthValue);
 
     #[cfg(feature = "jsonschema")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "jsonschema")))]
     impl schemars::JsonSchema for LengthValue {
       fn is_referenceable() -> bool {
         true

--- a/src/values/string.rs
+++ b/src/values/string.rs
@@ -248,6 +248,7 @@ impl<'a> Serialize for CowArcStr<'a> {
 }
 
 #[cfg(feature = "serde")]
+#[cfg_attr(docsrs, doc(cfg(feature = "serde")))]
 impl<'a, 'de: 'a> Deserialize<'de> for CowArcStr<'a> {
   fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
   where
@@ -258,6 +259,7 @@ impl<'a, 'de: 'a> Deserialize<'de> for CowArcStr<'a> {
 }
 
 #[cfg(feature = "jsonschema")]
+#[cfg_attr(docsrs, doc(cfg(feature = "jsonschema")))]
 impl<'a> schemars::JsonSchema for CowArcStr<'a> {
   fn is_referenceable() -> bool {
     true

--- a/src/vendor_prefix.rs
+++ b/src/vendor_prefix.rs
@@ -135,6 +135,7 @@ impl cssparser::ToCss for VendorPrefix {
 }
 
 #[cfg(feature = "serde")]
+#[cfg_attr(docsrs, doc(cfg(feature = "serde")))]
 impl serde::Serialize for VendorPrefix {
   fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
   where
@@ -163,6 +164,7 @@ impl serde::Serialize for VendorPrefix {
 }
 
 #[cfg(feature = "serde")]
+#[cfg_attr(docsrs, doc(cfg(feature = "serde")))]
 impl<'de> serde::Deserialize<'de> for VendorPrefix {
   fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
   where
@@ -189,12 +191,14 @@ impl<'de> serde::Deserialize<'de> for VendorPrefix {
 }
 
 #[cfg(feature = "visitor")]
+#[cfg_attr(docsrs, doc(cfg(feature = "visitor")))]
 impl<'i, V: Visitor<'i, T>, T: Visit<'i, T, V>> Visit<'i, T, V> for VendorPrefix {
   const CHILD_TYPES: VisitTypes = VisitTypes::empty();
   fn visit_children(&mut self, _: &mut V) {}
 }
 
 #[cfg(feature = "jsonschema")]
+#[cfg_attr(docsrs, doc(cfg(feature = "jsonschema")))]
 impl schemars::JsonSchema for VendorPrefix {
   fn is_referenceable() -> bool {
     true


### PR DESCRIPTION
The docs for the `visitor` module currently don't appear on [docs.rs](https://docs.rs/lightningcss/1.0.0-alpha.39/lightningcss/). Fix by enabling all optional features when generating docs for docs.rs. Annotate public items that require optional features.

<img width="523" alt="image" src="https://user-images.githubusercontent.com/94129/214209445-8b7fb655-5d85-4289-b448-e4a776dcfb1a.png">

<img width="993" alt="image" src="https://user-images.githubusercontent.com/94129/214206182-d95f956e-91ae-42fe-81d3-fa27bb70c726.png">

<img width="628" alt="image" src="https://user-images.githubusercontent.com/94129/214209579-77250f57-b59b-475f-9b7a-ebd150af9f83.png">

To test locally, run:

```
RUSTDOCFLAGS="--cfg docsrs" cargo +nightly doc --all-features --open
```

(Apologies if these docs are intentionally not published.)

References: [Stack Overflow](https://stackoverflow.com/a/61417700).