### PR TITLE
WASM: Only use `import.meta.url` in fallback scenario

### DIFF
--- a/wasm/index.mjs
+++ b/wasm/index.mjs
@@ -1,9 +1,9 @@
 import { Environment, napi } from 'napi-wasm';
 
-const url = new URL('lightningcss_node.wasm', import.meta.url);
 let wasm;
 
-export default async function init(input = url) {
+export default async function init(input) {
+  input = input ?? new URL('lightningcss_node.wasm', import.meta.url);
   if (typeof input === 'string' || (typeof Request === 'function' && input instanceof Request) || (typeof URL === 'function' && input instanceof URL)) {
     input = fetch(input);
   }


### PR DESCRIPTION
I'm currently using this in a "classic" (not module) worker and `import.meta.url` is not defined which is breaking the call to the `URL` constructor, which I don't even use because I send in the path the WASM module manually. 

This change uses `import.meta.url` and the `URL` constructor only in the fallback case when a user doesn't pass in a custom url.