### PR TITLE
Add `Visitor::visit_selector_component`

### DIFF
--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -65,7 +65,7 @@ use crate::{
     Property,
   },
   rules::{supports::SupportsCondition, CssRule, CssRuleList},
-  selector::{Selector, SelectorList},
+  selector::{Component, Selector, SelectorList},
   values::{
     angle::Angle,
     color::CssColor,
@@ -289,7 +289,13 @@ pub trait Visitor<'i, T: Visit<'i, T, Self> = DefaultAtRule>: Sized {
   /// Visits a selector.
   #[allow(unused_variables)]
   fn visit_selector(&mut self, selector: &mut Selector<'i>) -> Result<(), Self::Error> {
-    Ok(())
+    selector.visit_children(self)
+  }
+
+  /// Visits a selector component.
+  #[allow(unused_variables)]
+  fn visit_selector_component(&mut self, component: &mut Component<'i>) -> Result<(), Self::Error> {
+    component.visit_children(self)
   }
 
   /// Visits a custom function.


### PR DESCRIPTION
References #397. Implements the Rust side of https://github.com/parcel-bundler/lightningcss/issues/397#issuecomment-1381323367:

> We could add `SelectorComponent` as a visitor function to allow visiting individual components. This would also allow handling nested selectors (e.g. in `:not()`).

I could particularly use the ability to visit nested selectors in Rust.