### PR TITLE
[Docs] fix Deno example

### DIFF
--- a/website/pages/docs.md
+++ b/website/pages/docs.md
@@ -67,9 +67,8 @@ See the [Parcel docs](https://parceljs.org/languages/css) for more details.
 The `lightningcss-wasm` package can be used in Deno or directly in browsers. This uses a WebAssembly build of Lightning CSS. Use `TextEncoder` and `TextDecoder` convert code from a string to a typed array and back.
 
 ```js
-import init, { transform } from 'https://unpkg.com/lightningcss-wasm?module';
-
-await init();
+import init, { transform } from "https://esm.sh/lightningcss-wasm";
+await init("https://esm.sh/lightningcss-wasm/lightningcss_node.wasm")
 
 let {code, map} = transform({
   filename: 'style.css',


### PR DESCRIPTION
## What does this change?

Use esm.sh and pass a qualified URL to the WASM init function.

## Why?

The current example does not work in Deno, but [this one does](https://github.com/ije/esm.sh/issues/524#issuecomment-1436145046).