### PR TITLE
website: Make title visible in selection

### DIFF
--- a/website/docs.css
+++ b/website/docs.css
@@ -64,6 +64,11 @@ header .title {
   text-decoration: none;
 }
 
+header .title::selection {
+  -webkit-text-stroke-color: #fffddd;
+  background-color: var(--gold-text);
+}
+
 h1, h2, h3 {
   font-family: urbane-rounded, ui-rounded;
   font-weight: 600;

--- a/website/index.html
+++ b/website/index.html
@@ -263,6 +263,11 @@
         letter-spacing: -0.02em;
       }
 
+      header h1::selection { 
+        -webkit-text-stroke-color: #fffddd;
+        background-color: var(--gold-text);
+      }
+
       header h2 {
         font-family: urbane-rounded;
         color: lch(65% 85 35);


### PR DESCRIPTION
Now, website title text is invisible in selection cause it's color is transparent.

![CleanShot 2023-03-04 at 22 03 21@2x](https://user-images.githubusercontent.com/13414731/222906820-ac45ef8c-8e2a-427c-959e-bad6df20d652.png)

Override its color in `::selection` to fix this.


![CleanShot 2023-03-04 at 22 06 25@2x](https://user-images.githubusercontent.com/13414731/222906931-8392424a-c55f-4c5d-8a94-064b54b2c3d3.png)



Also the title in docs.


![CleanShot 2023-03-04 at 22 07 29@2x](https://user-images.githubusercontent.com/13414731/222906980-b44982de-28a4-42a7-b6df-32d5e1246644.png)
