### PR TITLE
Invalid value handling

### DIFF
--- a/tests/test_invalid_input.rs
+++ b/tests/test_invalid_input.rs
@@ -1,5 +1,6 @@
 use lightningcss::{
-  error::{Error, ParserError},
+  error::{Error, ErrorLocation, ParserError},
+  rules::Location,
   stylesheet::{ParserOptions, StyleSheet},
 };
 
@@ -15,7 +16,14 @@ fn invalid_hsla_value() {
 
   let expected = Error {
     kind: ParserError::InvalidValue,
-    loc: None
+    loc: Some(ErrorLocation::new(
+      Location {
+        line: 0,
+        column: 23,
+        source_index: 0,
+      },
+      "".to_string(),
+    )),
   };
 
   assert_eq!(parsed.to_string(), expected.to_string());

--- a/tests/test_invalid_input.rs
+++ b/tests/test_invalid_input.rs
@@ -5,7 +5,7 @@ use lightningcss::{
 };
 
 #[test]
-fn invalid_hsla_value() {
+fn value_missing_closing_brace() {
   let input = r#"
     .corrupt {
       color: hsla(120, 62.32%;

--- a/tests/test_invalid_input.rs
+++ b/tests/test_invalid_input.rs
@@ -1,0 +1,22 @@
+use lightningcss::{
+  error::{Error, ParserError},
+  stylesheet::{ParserOptions, StyleSheet},
+};
+
+#[test]
+fn invalid_hsla_value() {
+  let input = r#"
+    .corrupt {
+      color: hsla(120, 62.32%;
+    }
+  "#;
+
+  let parsed = StyleSheet::parse(input, ParserOptions::default()).unwrap_err();
+
+  let expected = Error {
+    kind: ParserError::InvalidValue,
+    loc: None
+  };
+
+  assert_eq!(parsed.to_string(), expected.to_string());
+}


### PR DESCRIPTION
We should handle errors when parsing a value with a missing closing brace:

```css
.corrupt {
  color: hsla(120, 62.32%;
}
```

Related issue: https://github.com/parcel-bundler/lightningcss/issues/427

This aims to replicate this browser behavior
![image](https://user-images.githubusercontent.com/1226564/226947677-ef40f387-f46e-4754-8861-8acff1b15d8e.png)

