### PR TITLE
Add support for TypeScript `moduleResolution` - `bundler`

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "main": "node/index.js",
   "types": "node/index.d.ts",
   "exports": {
+    "types": "./node/index.d.ts",
     "import": "./node/index.mjs",
     "require": "./node/index.js"
   },


### PR DESCRIPTION
## What's the purpose of this package?

Let me start with - **why**.

While developing my package, I am using TypeScript version `v5.0`.
The build compilation were failing because of the following error:

```
src/cli.ts(5,27): error TS7016: Could not find a declaration file for module 'lightningcss'. '/home/xeho91/Nextcloud/Projects/oss/typewind/node_modules/.pnpm/lightningcss@1.19.0/node_modules/
lightningcss/node/index.mjs' implicitly has an 'any' type.
  There are types at '/home/xeho91/Nextcloud/Projects/oss/typewind/packages/typewind/node_modules/lightningcss/node/index.d.ts', but this result could not be resolved when respecting package.
json "exports". The 'lightningcss' library may need to update its package.json or typings.

Error: error occured in dts build
    at Worker.<anonymous> (/home/xeho91/Nextcloud/Projects/oss/typewind/node_modules/.pnpm/tsup@6.7.0_postcss@8.4.21_typescript@5.0.3/node_modules/tsup/dist/index.js:2281:26)
    at Worker.emit (node:events:513:28)
    at MessagePort.<anonymous> (node:internal/worker:233:53)
    at [nodejs.internal.kHybridDispatch] (node:internal/event_target:735:20)
    at exports.emitMessage (node:internal/per_context/messageport:23:28)
DTS Build error
RollupError: Failed to compile. Check the logs above.
    at error (/home/xeho91/Nextcloud/Projects/oss/typewind/node_modules/.pnpm/rollup@3.20.2/node_modules/rollup/dist/shared/rollup.js:274:30)
    at Object.error (/home/xeho91/Nextcloud/Projects/oss/typewind/node_modules/.pnpm/rollup@3.20.2/node_modules/rollup/dist/shared/rollup.js:24694:20)
    at Object.error (/home/xeho91/Nextcloud/Projects/oss/typewind/node_modules/.pnpm/rollup@3.20.2/node_modules/rollup/dist/shared/rollup.js:23888:42)
    at generateDtsFromTs (/home/xeho91/Nextcloud/Projects/oss/typewind/node_modules/.pnpm/tsup@6.7.0_postcss@8.4.21_typescript@5.0.3/node_modules/tsup/dist/rollup.js:7498:22)
    at /home/xeho91/Nextcloud/Projects/oss/typewind/node_modules/.pnpm/tsup@6.7.0_postcss@8.4.21_typescript@5.0.3/node_modules/tsup/dist/rollup.js:7505:59
    at _nullishCoalesce (/home/xeho91/Nextcloud/Projects/oss/typewind/node_modules/.pnpm/tsup@6.7.0_postcss@8.4.21_typescript@5.0.3/node_modules/tsup/dist/rollup.js:1:198)
    at Object.transform (/home/xeho91/Nextcloud/Projects/oss/typewind/node_modules/.pnpm/tsup@6.7.0_postcss@8.4.21_typescript@5.0.3/node_modules/tsup/dist/rollup.js:7505:18)
    at /home/xeho91/Nextcloud/Projects/oss/typewind/node_modules/.pnpm/rollup@3.20.2/node_modules/rollup/dist/shared/rollup.js:24893:40
 ELIFECYCLE  Command failed with exit code 1.
```

So, I cloned your reposiory, and I have used the tool [publint](https://github.com/bluwy/publint), to see what's wrong.

There was a warning:

```
$ pnpm publint .
lightningcss lint results:
Warnings:
1. The library has types at node/index.d.ts but it is not exported from pkg.exports.
Consider adding it to pkg.exports.types to be compatible with TypeScript's "moduleResolution": "bundler" compiler option.
```

---

This is the reason of this Pull Request, a simple, one-line fix in `package.json` file.
