### PR TITLE
Expose `Targets` in types

### DIFF
--- a/node/index.d.ts
+++ b/node/index.d.ts
@@ -3,6 +3,8 @@ import type { Targets } from './targets';
 
 export * from './ast';
 
+export { Targets };
+
 export interface TransformOptions<C extends CustomAtRules> {
   /** The filename being transformed. Used for error messages and source maps. */
   filename: string,


### PR DESCRIPTION
Can be useful for exposing a set of options for integrating into tools like Vite ;)

(Currently doing `type LightningCSSTargets = ReturnType<typeof browserslistToTargets>`)