### PR TITLE
Name casing: SASS → Sass

### DIFF
--- a/website/pages/docs.md
+++ b/website/pages/docs.md
@@ -174,6 +174,6 @@ By default, Lightning CSS is strict, and will error when parsing an invalid rule
 
 Lightning CSS supports generating source maps when compiling, minifying, and bundling your source code to make debugging easier. Use the `sourceMap` option to enable it when using the API, or the `--sourcemap` CLI flag.
 
-If the input CSS came from another compiler such as SASS or Less, you can also pass an input source map to Lightning CSS using the `inputSourceMap` API option. This will map compiled locations back to their location in the original source code.
+If the input CSS came from another compiler such as Sass or Less, you can also pass an input source map to Lightning CSS using the `inputSourceMap` API option. This will map compiled locations back to their location in the original source code.
 
 Finally, the `projectRoot` option can be used to make file paths in source maps relative to a root directory. This makes build stable between machines.

--- a/website/pages/transpilation.md
+++ b/website/pages/transpilation.md
@@ -425,7 +425,7 @@ Lightning CSS can also be configured to compile several draft specs that are not
 
 ### Nesting
 
-The [CSS Nesting](https://drafts.csswg.org/css-nesting/) draft spec enables style rules to be nested, with the selectors of the child rules extending the parent selector in some way. This is very commonly supported by CSS pre-processors like SASS, but with this spec, it will eventually be supported natively in browsers. Lightning CSS compiles this syntax to un-nested style rules that are supported in all browsers today.
+The [CSS Nesting](https://drafts.csswg.org/css-nesting/) draft spec enables style rules to be nested, with the selectors of the child rules extending the parent selector in some way. This is very commonly supported by CSS pre-processors like Sass, but with this spec, it will eventually be supported natively in browsers. Lightning CSS compiles this syntax to un-nested style rules that are supported in all browsers today.
 
 Because nesting is a draft, it is not enabled by default. To use it, enable the `nesting` option under `drafts` when calling the Lightning CSS API. When using the CLI, enable the `--nesting` flag.
 


### PR DESCRIPTION
https://sass-lang.com
https://github.com/sass/dart-sass
https://sass-lang.com/libsass
https://en.wikipedia.org/wiki/Sass_(stylesheet_language)
https://twitter.com/SassCSS

Sass is neither an acronym/initialism nor is it stylized as SASS anywhere. SCSS syntax meets this criteria, but Sass does not.