### PR TITLE
Fix panics in `custom_at_rule` example

### DIFF
--- a/examples/custom_at_rule.rs
+++ b/examples/custom_at_rule.rs
@@ -22,6 +22,7 @@ fn main() {
   let source = std::fs::read_to_string(&args[1]).unwrap();
   let opts = ParserOptions {
     filename: args[1].clone(),
+    nesting: true,
     ..Default::default()
   };
 
@@ -191,7 +192,9 @@ impl<'a, 'i> Visitor<'i, AtRule> for ApplyVisitor<'a, 'i> {
     if let CssRule::Custom(AtRule::Apply(apply)) = rule {
       let mut declarations = DeclarationBlock::new();
       for name in &apply.names {
-        let applied = self.rules.get(name).unwrap();
+        let Some(applied) = self.rules.get(name) else {
+          continue;
+        };
         declarations
           .important_declarations
           .extend(applied.important_declarations.iter().cloned());


### PR DESCRIPTION
This PR resolves https://github.com/parcel-bundler/lightningcss/issues/475 by adding a `nesting` option to an example and fixing a panic caused by `unwrap`