### PR TITLE
Improve support for `CustomFunction` transforms

### DIFF
--- a/examples/custom_at_rule.rs
+++ b/examples/custom_at_rule.rs
@@ -22,6 +22,7 @@ fn main() {
   let source = std::fs::read_to_string(&args[1]).unwrap();
   let opts = ParserOptions {
     filename: args[1].clone(),
+    nesting: true,
     ..Default::default()
   };
 
@@ -191,7 +192,9 @@ impl<'a, 'i> Visitor<'i, AtRule> for ApplyVisitor<'a, 'i> {
     if let CssRule::Custom(AtRule::Apply(apply)) = rule {
       let mut declarations = DeclarationBlock::new();
       for name in &apply.names {
-        let applied = self.rules.get(name).unwrap();
+        let Some(applied) = self.rules.get(name) else {
+          continue;
+        };
         declarations
           .important_declarations
           .extend(applied.important_declarations.iter().cloned());

--- a/selectors/parser.rs
+++ b/selectors/parser.rs
@@ -744,8 +744,11 @@ impl<'i, Impl: SelectorImpl<'i>> Selector<'i, Impl> {
 
     // Manually move the first `index` elements
     let mut old_iter = old.into_iter();
-    let i = 0;
-    while let (Some(old_component), true) = (old_iter.next(), i < index) {
+    for _ in 0..index {
+      let Some(old_component) = old_iter.next() else {
+        unreachable!("index is never greater than selector len")
+      };
+
       self.1.push(old_component)
     }
 

--- a/selectors/parser.rs
+++ b/selectors/parser.rs
@@ -735,14 +735,14 @@ impl<'i, Impl: SelectorImpl<'i>> Selector<'i, Impl> {
     let old_len = self.1.len();
     let mut old = std::mem::replace(&mut self.1, Vec::with_capacity(old_len + components.len()));
 
-    // Fast track: insert at index 0 is same as Vec::append
+    // Fast track: insert at index 0 is the same as Vec::append
     if index == 0 {
       self.1.append(&mut components);
       self.1.append(&mut old);
       return;
     }
 
-    // Manually move first `index` elements
+    // Manually move the first `index` elements
     let mut old_iter = old.into_iter();
     let i = 0;
     while let (Some(old_component), true) = (old_iter.next(), i < index) {

--- a/selectors/parser.rs
+++ b/selectors/parser.rs
@@ -715,6 +715,44 @@ impl<'i, Impl: SelectorImpl<'i>> Selector<'i, Impl> {
     self.1.insert(index, component);
   }
 
+  /// Inserts a [`Component`] to an arbitrary index in the internal components Vec.
+  ///
+  /// An order in which components are stored is right-to-left (see [`Selector::iter_raw_match_order()`])
+  #[inline]
+  pub fn insert_raw(&mut self, index: usize, component: Component<'i, Impl>) {
+    self.1.insert(index, component)
+  }
+
+  /// Inserts multiple [`Component`]s to an arbitrary index in the internal components Vec.
+  ///
+  /// An order in which components are stored is right-to-left (see [`Selector::iter_raw_match_order()`])
+  #[inline]
+  pub fn insert_raw_multiple(&mut self, index: usize, mut components: Vec<Component<'i, Impl>>) {
+    if index > self.1.len() {
+      return;
+    }
+
+    let old_len = self.1.len();
+    let mut old = std::mem::replace(&mut self.1, Vec::with_capacity(old_len + components.len()));
+
+    // Fast track: insert at index 0 is same as Vec::append
+    if index == 0 {
+      self.1.append(&mut components);
+      self.1.append(&mut old);
+      return;
+    }
+
+    // Manually move first `index` elements
+    let mut old_iter = old.into_iter();
+    let i = 0;
+    while let (Some(old_component), true) = (old_iter.next(), i < index) {
+      self.1.push(old_component)
+    }
+
+    self.1.append(&mut components);
+    self.1.extend(old_iter);
+  }
+
   #[inline]
   pub fn parts(&self) -> Option<&[Impl::Identifier]> {
     if !self.is_part() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6008,8 +6008,14 @@ mod tests {
       "::cue(v[voice=active]){color:#ff0}",
     );
     minify_test(":foo(bar) { color: yellow }", ":foo(bar){color:#ff0}");
+    minify_test(":foo(bar baz qux) { color: yellow }", ":foo(bar baz qux){color:#ff0}");
+    minify_test(":foo(.bar .baz .qux) { color: yellow }", ":foo(.bar .baz .qux){color:#ff0}");
+    minify_test(":foo(  .bar  .baz  .qux  ) { color: yellow }", ":foo( .bar .baz .qux ){color:#ff0}");
     minify_test("::foo(bar) { color: yellow }", "::foo(bar){color:#ff0}");
     minify_test("::foo(*) { color: yellow }", "::foo(*){color:#ff0}");
+    minify_test("::foo(bar baz qux) { color: yellow }", "::foo(bar baz qux){color:#ff0}");
+    minify_test("::foo(.bar .baz .qux) { color: yellow }", "::foo(.bar .baz .qux){color:#ff0}");
+    minify_test("::foo(  .bar  .baz  .qux  ) { color: yellow }", "::foo( .bar .baz .qux ){color:#ff0}");
 
     minify_test(":is(.foo) { color: yellow }", ".foo{color:#ff0}");
     minify_test(":is(#foo) { color: yellow }", "#foo{color:#ff0}");

--- a/src/properties/custom.rs
+++ b/src/properties/custom.rs
@@ -291,7 +291,7 @@ impl<'i> TokenList<'i> {
   pub(crate) fn parse<'t>(
     input: &mut Parser<'i, 't>,
     options: &ParserOptions<'_, 'i>,
-    depth: usize
+    depth: usize,
   ) -> Result<Self, ParseError<'i, ParserError<'i>>> {
     let mut tokens = vec![];
     TokenList::parse_into(input, &mut tokens, options, depth, false)?;
@@ -315,7 +315,7 @@ impl<'i> TokenList<'i> {
   pub(crate) fn parse_preserve_whitespace<'t>(
     input: &mut Parser<'i, 't>,
     options: &ParserOptions<'_, 'i>,
-    depth: usize
+    depth: usize,
   ) -> Result<Self, ParseError<'i, ParserError<'i>>> {
     let mut tokens = vec![];
     TokenList::parse_into(input, &mut tokens, options, depth, true)?;

--- a/src/selector.rs
+++ b/src/selector.rs
@@ -196,7 +196,7 @@ impl<'a, 'o, 'i> parcel_selectors::parser::Parser<'i> for SelectorParser<'a, 'o,
         }
         CustomFunction {
           name: name.into(),
-          arguments: TokenList::parse(parser, &self.options, 0)?
+          arguments: TokenList::parse_preserve_whitespace(parser, &self.options, 0)?
         }
       },
     };

--- a/src/selector.rs
+++ b/src/selector.rs
@@ -276,7 +276,7 @@ impl<'a, 'o, 'i> parcel_selectors::parser::Parser<'i> for SelectorParser<'a, 'o,
         if !name.starts_with('-') {
           self.options.warn(arguments.new_custom_error(SelectorParseErrorKind::UnsupportedPseudoClassOrElement(name.clone())));
         }
-        CustomFunction { name: name.into(), arguments: TokenList::parse(arguments, &self.options, 0)? }
+        CustomFunction { name: name.into(), arguments: TokenList::parse_preserve_whitespace(arguments, &self.options, 0)? }
       }
     };
 


### PR DESCRIPTION
This PR enables authoring custom transformers for `PseudoElement` and `PseudoClass` `CustomFunction`s.

## Parsing whitespace inside custom pseudo functions is now more conservative
Previously, `:foo(.bar .baz .qux)` was parsed as `:foo(.bar.baz.qux)` which greatly limited custom transformers.

This PR bypasses aggressive whitespace removal inside `TokenList::parse_into` behind a flag.

To ensure that no API change is introduced, conservative parsing is only enabled for `CustomFunction` via new `TokenList::parse_preserve_whitespace`.

## `Selector` manipulations got two more public methods
`Selector::append` is a useful method for adding extra components to selectors, however it is quite limited when adding `Component::Combinator` and makes it impossible to reliably append complex expressions like `.foo > .bar #baz`

- `Selector::insert_raw(&mut self, index: usize, component: Component)` can be used for inserting new selector components into an arbitrary location, bypassing the limitations of `append`;
- `Selector::insert_raw_multiple(&mut self, index: usize, mut components: Vec<Component>)` is an optimized version of `insert_raw` to avoid the extra cost of allocations and memcpy when making multiple calls.

## Tests
Tests were added to ensure the correctness of a different parsing strategy. No existing tests changed