### PR TITLE
Make the fields of the `TrackRepeat` struct public

### DIFF
--- a/src/properties/grid.rs
+++ b/src/properties/grid.rs
@@ -163,12 +163,12 @@ pub enum TrackBreadth {
 #[cfg_attr(feature = "jsonschema", derive(schemars::JsonSchema))]
 pub struct TrackRepeat<'i> {
   /// The repeat count.
-  count: RepeatCount,
+  pub count: RepeatCount,
   /// The line names to repeat.
   #[cfg_attr(feature = "serde", serde(borrow))]
-  line_names: Vec<CustomIdentList<'i>>,
+  pub line_names: Vec<CustomIdentList<'i>>,
   /// The track sizes to repeat.
-  track_sizes: Vec<TrackSize>,
+  pub track_sizes: Vec<TrackSize>,
 }
 
 /// A [`<repeat-count>`](https://drafts.csswg.org/css-grid-2/#typedef-track-repeat) value,


### PR DESCRIPTION
# Objective

Make it possible to access the details of `repeat()` functions parsed from `grid_template_columns` / `grid_template_rows` properties.

## Context 

We need this in order to use `lightningcss` for parsing CSS styles in https://github.com/DioxusLabs/blitz

## Changes made

Make the fields of the `TrackRepeat` struct public


