### PR TITLE
fix: missing placeholder prop on ImportDependency type

### DIFF
--- a/node/index.d.ts
+++ b/node/index.d.ts
@@ -348,7 +348,9 @@ export interface ImportDependency {
   /** The `supports()` query for the `@import` rule. */
   supports: string | null,
   /** The source location where the `@import` rule was found. */
-  loc: SourceLocation
+  loc: SourceLocation,
+  /** The placeholder that the import was replaced with. */
+  placeholder: string
 }
 
 export interface UrlDependency {


### PR DESCRIPTION
Adds missing `placeholder` property on the `ImportDependency` type