### PR TITLE
fix: BundleOptions should exclude analyzeDependencies

### DIFF
--- a/node/index.d.ts
+++ b/node/index.d.ts
@@ -240,7 +240,7 @@ export interface DependencyOptions {
   preserveImports?: boolean
 }
 
-export type BundleOptions<C extends CustomAtRules> = Omit<TransformOptions<C>, 'code'>;
+export type BundleOptions<C extends CustomAtRules> = Omit<TransformOptions<C>, 'code', 'analyzeDependencies'>;
 
 export interface BundleAsyncOptions<C extends CustomAtRules> extends BundleOptions<C> {
   resolver?: Resolver;


### PR DESCRIPTION
fixed #514 