### PR TITLE
fix: windows test errors

### DIFF
--- a/node/test/bundle.test.mjs
+++ b/node/test/bundle.test.mjs
@@ -27,7 +27,7 @@ test('resolver', async () => {
     filename: 'foo.css',
     resolver: {
       read(file) {
-        const result = inMemoryFs.get(path.normalize(file));
+        const result = inMemoryFs.get(path.normalize(file).replace(/\\/g, "/"));
         if (!result) throw new Error(`Could not find ${file} in ${Array.from(inMemoryFs.keys()).join(', ')}.`);
         return result;
       },
@@ -78,7 +78,7 @@ test('only custom read', async () => {
     filename: 'foo.css',
     resolver: {
       read(file) {
-        const result = inMemoryFs.get(path.normalize(file));
+        const result = inMemoryFs.get(path.normalize(file).replace(/\\/g, "/"));
         if (!result) throw new Error(`Could not find ${file} in ${Array.from(inMemoryFs.keys()).join(', ')}.`);
         return result;
       },


### PR DESCRIPTION
Relevant issue: https://github.com/parcel-bundler/lightningcss/issues/541

# Description

The bundle test was an easy fix, but the rounding differences for some color mix minify tests seem to boil down to how the different OSes handle floating point arithmetic.

After some debugging for this test,

```rust
minify_test(
  ".foo { color: color-mix(in lch, peru 40%, palegoldenrod); }",
  ".foo{color:lch(79.7255% 40.4542 84.7634)}",
);
```

I noticed that `p1` and `p2` in `src\values\color.rs`  ([L2875](https://github.com/parcel-bundler/lightningcss/blob/master/src/values/color.rs#L2875))  don't end up with `0.4` and `0.6`, unlike my Unix build.

Couldn't really figure out why the class names were being converted differently either, so I'll only be adding the fix to the `bundle.test.mjs` file.

# Changes

- replace `\` with `/` for paths used in in-memory filesystem tests (for `yarn test`)

