### PR TITLE
fix(tests): Add failing "do not duplicate existing `transition-property` vendor prefixes" test for #403

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10503,6 +10503,24 @@ mod tests {
         ..Browsers::default()
       },
     );
+
+    prefix_test(
+      r#"
+      .foo {
+        transition-property: -webkit-backdrop-filter, backdrop-filter;
+      }
+    "#,
+      indoc! {r#"
+      .foo {
+        transition-property: -webkit-backdrop-filter, backdrop-filter;
+      }
+    "#
+      },
+      Browsers {
+        safari: Some(15 << 16),
+        ..Browsers::default()
+      },
+    );
   }
 
   #[test]


### PR DESCRIPTION
Tests https://github.com/parcel-bundler/lightningcss/issues/403#issuecomment-1652055068

Confirms https://github.com/parcel-bundler/lightningcss/issues/403#issuecomment-1652055068 by failing with the following output:

```
failures:

---- tests::test_transitions stdout ----
thread 'tests::test_transitions' panicked at 'assertion failed: `(left == right)`
  left: `".foo {\n  transition-property: -webkit-backdrop-filter, -webkit-backdrop-filter, backdrop-filter;\n}\n"`,
 right: `".foo {\n  transition-property: -webkit-backdrop-filter, backdrop-filter;\n}\n"`', src/lib.rs:110:5
stack backtrace:
   0: rust_begin_unwind
             at /rustc/90c541806f23a127002de5b4038be731ba1458ca/library/std/src/panicking.rs:578:5
   1: core::panicking::panic_fmt
             at /rustc/90c541806f23a127002de5b4038be731ba1458ca/library/core/src/panicking.rs:67:14
   2: core::panicking::assert_failed_inner
   3: core::panicking::assert_failed
             at /rustc/90c541806f23a127002de5b4038be731ba1458ca/library/core/src/panicking.rs:228:5
   4: lightningcss::tests::prefix_test
             at ./src/lib.rs:110:5
   5: lightningcss::tests::test_transitions
             at ./src/lib.rs:10507:5
   6: lightningcss::tests::test_transitions::{{closure}}
             at ./src/lib.rs:9840:25
   7: core::ops::function::FnOnce::call_once
             at /rustc/90c541806f23a127002de5b4038be731ba1458ca/library/core/src/ops/function.rs:250:5
   8: core::ops::function::FnOnce::call_once
             at /rustc/90c541806f23a127002de5b4038be731ba1458ca/library/core/src/ops/function.rs:250:5
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.


failures:
    tests::test_transitions
```