### PR TITLE
fix(tests): Add failing "do not duplicate existing `@supports` vendor prefixes" test for #403

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12554,6 +12554,26 @@ mod tests {
         ..Default::default()
       },
     );
+    prefix_test(
+      r#"
+      @supports ((-webkit-backdrop-filter: blur(10px)) or (backdrop-filter: blur(10px))) {
+        .test {
+          foo: bar;
+        }
+      }
+    "#,
+      indoc! { r#"
+      @supports ((-webkit-backdrop-filter: blur(10px)) or (backdrop-filter: blur(10px))) {
+        .test {
+          foo: bar;
+        }
+      }
+    "#},
+      Browsers {
+        safari: Some(14 << 16),
+        ..Default::default()
+      },
+    );
     minify_test(
       r#"
       @supports (width: calc(10px * 2)) {


### PR DESCRIPTION
Tests https://github.com/parcel-bundler/lightningcss/issues/403#issuecomment-1652000851

Confirms https://github.com/parcel-bundler/lightningcss/issues/403#issuecomment-1652000851 by failing with the following output:

```
failures:

---- tests::test_supports_rule stdout ----
thread 'tests::test_supports_rule' panicked at 'assertion failed: `(left == right)`
  left: `"@supports ((-webkit-backdrop-filter: blur(10px))) or ((-webkit-backdrop-filter: blur(10px)) or (backdrop-filter: blur(10px))) {\n  .test {\n    foo: bar;\n  }\n}\n"`,
 right: `"@supports ((-webkit-backdrop-filter: blur(10px)) or (backdrop-filter: blur(10px))) {\n  .test {\n    foo: bar;\n  }\n}\n"`', src/lib.rs:110:5
stack backtrace:
   0: rust_begin_unwind
             at /rustc/90c541806f23a127002de5b4038be731ba1458ca/library/std/src/panicking.rs:578:5
   1: core::panicking::panic_fmt
             at /rustc/90c541806f23a127002de5b4038be731ba1458ca/library/core/src/panicking.rs:67:14
   2: core::panicking::assert_failed_inner
   3: core::panicking::assert_failed
             at /rustc/90c541806f23a127002de5b4038be731ba1458ca/library/core/src/panicking.rs:228:5
   4: lightningcss::tests::prefix_test
             at ./src/lib.rs:110:5
   5: lightningcss::tests::test_supports_rule
             at ./src/lib.rs:12557:5
   6: lightningcss::tests::test_supports_rule::{{closure}}
             at ./src/lib.rs:12343:27
   7: core::ops::function::FnOnce::call_once
             at /rustc/90c541806f23a127002de5b4038be731ba1458ca/library/core/src/ops/function.rs:250:5
   8: core::ops::function::FnOnce::call_once
             at /rustc/90c541806f23a127002de5b4038be731ba1458ca/library/core/src/ops/function.rs:250:5
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.


failures:
    tests::test_supports_rule
```