### PR TITLE
fix(tests): Add failing "do not remove required `-webkit-` vendor prefix" test for #537

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12795,6 +12795,25 @@ mod tests {
         ..Browsers::default()
       },
     );
+
+    prefix_test(
+      r#"
+      .foo {
+        -webkit-backdrop-filter: blur(8px);
+        backdrop-filter: blur(8px);
+      }
+      "#,
+      indoc! {r#"
+      .foo {
+        -webkit-backdrop-filter: blur(8px);
+        backdrop-filter: blur(8px);
+      }
+      "#},
+      Browsers {
+        safari: Some(16 << 16),
+        ..Browsers::default()
+      },
+    );
   }
 
   #[test]


### PR DESCRIPTION
Tests https://github.com/parcel-bundler/lightningcss/issues/537#issuecomment-1652019542

Confirms https://github.com/parcel-bundler/lightningcss/issues/537#issuecomment-1652019542 by failing with:

```
failures:

---- tests::test_prefixes stdout ----
thread 'tests::test_prefixes' panicked at 'assertion failed: `(left == right)`
  left: `".foo {\n  backdrop-filter: blur(8px);\n}\n"`,
 right: `".foo {\n  -webkit-backdrop-filter: blur(8px);\n  backdrop-filter: blur(8px);\n}\n"`', src/lib.rs:110:5
stack backtrace:
   0: rust_begin_unwind
             at /rustc/90c541806f23a127002de5b4038be731ba1458ca/library/std/src/panicking.rs:578:5
   1: core::panicking::panic_fmt
             at /rustc/90c541806f23a127002de5b4038be731ba1458ca/library/core/src/panicking.rs:67:14
   2: core::panicking::assert_failed_inner
   3: core::panicking::assert_failed
             at /rustc/90c541806f23a127002de5b4038be731ba1458ca/library/core/src/panicking.rs:228:5
   4: lightningcss::tests::prefix_test
             at ./src/lib.rs:110:5
   5: lightningcss::tests::test_prefixes
             at ./src/lib.rs:12799:5
   6: lightningcss::tests::test_prefixes::{{closure}}
             at ./src/lib.rs:12763:22
   7: core::ops::function::FnOnce::call_once
             at /rustc/90c541806f23a127002de5b4038be731ba1458ca/library/core/src/ops/function.rs:250:5
   8: core::ops::function::FnOnce::call_once
             at /rustc/90c541806f23a127002de5b4038be731ba1458ca/library/core/src/ops/function.rs:250:5
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.


failures:
    tests::test_prefixes
```