### PR TITLE
Alow manipulating `Selector` parts from consumer code

### DIFF
--- a/selectors/parser.rs
+++ b/selectors/parser.rs
@@ -724,6 +724,47 @@ impl<'i, Impl: SelectorImpl<'i>> Selector<'i, Impl> {
     self.1.insert(index, component);
   }
 
+    /// Inserts a [`Component`] to an arbitrary index in the internal components Vec.
+  ///
+  /// An order in which components are stored is right-to-left (see [`Selector::iter_raw_match_order()`])
+  #[inline]
+  pub fn insert_raw(&mut self, index: usize, component: Component<'i, Impl>) {
+    self.1.insert(index, component)
+  }
+
+  /// Inserts multiple [`Component`]s to an arbitrary index in the internal components Vec.
+  ///
+  /// An order in which components are stored is right-to-left (see [`Selector::iter_raw_match_order()`])
+  #[inline]
+  pub fn insert_raw_multiple(&mut self, index: usize, mut components: Vec<Component<'i, Impl>>) {
+    if index > self.1.len() {
+      return;
+    }
+
+    let old_len = self.1.len();
+    let mut old = std::mem::replace(&mut self.1, Vec::with_capacity(old_len + components.len()));
+
+    // Fast track: insert at index 0 is the same as Vec::append
+    if index == 0 {
+      self.1.append(&mut components);
+      self.1.append(&mut old);
+      return;
+    }
+
+    // Manually move the first `index` elements
+    let mut old_iter = old.into_iter();
+    for _ in 0..index {
+      let Some(old_component) = old_iter.next() else {
+        unreachable!("index is never greater than selector len")
+      };
+
+      self.1.push(old_component)
+    }
+
+    self.1.append(&mut components);
+    self.1.extend(old_iter);
+  }
+
   #[inline]
   pub fn parts(&self) -> Option<&[Impl::Identifier]> {
     if !self.is_part() {


### PR DESCRIPTION
This PR needs a review and is open to renaming/tests suggestions.

This API is a logical continuation of https://github.com/parcel-bundler/lightningcss/issues/495, https://github.com/parcel-bundler/lightningcss/pull/485, and it covers a usecase of `fervid` project: https://github.com/phoenix-ru/fervid/blob/master/crates/fervid_css/src/transform_style_scoped.rs#L331-L337

It allows appending `Selector` components bypassing the checks in https://github.com/parcel-bundler/lightningcss/blob/master/selectors/parser.rs#L718-L725

Two new helpers are added:
- `insert_raw` for inserting a single `Component` at an arbitrary index;
- `insert_raw_multiple` for inserting multiple `Component`s at an arbitrary index.

It is a blocker to Vue `<style>` transformations, examples of which are here:
https://github.com/phoenix-ru/fervid/blob/master/crates/fervid_css/src/lib.rs#L92-L186