### PR TITLE
Avoid const enum for Features type

### DIFF
--- a/node/targets.d.ts
+++ b/node/targets.d.ts
@@ -12,28 +12,28 @@ export interface Targets {
   samsung?: number
 }
 
-export declare const enum Features {
-  Nesting = 1,
-  NotSelectorList = 2,
-  DirSelector = 4,
-  LangSelectorList = 8,
-  IsSelector = 16,
-  TextDecorationThicknessPercent = 32,
-  MediaIntervalSyntax = 64,
-  MediaRangeSyntax = 128,
-  CustomMediaQueries = 256,
-  ClampFunction = 512,
-  ColorFunction = 1024,
-  OklabColors = 2048,
-  LabColors = 4096,
-  P3Colors = 8192,
-  HexAlphaColors = 16384,
-  SpaceSeparatedColorNotation = 32768,
-  FontFamilySystemUi = 65536,
-  DoublePositionGradients = 131072,
-  VendorPrefixes = 262144,
-  LogicalProperties = 524288,
-  Selectors = 31,
-  MediaQueries = 448,
-  Colors = 64512,
+export const Features: {
+  Nesting: 1;
+  NotSelectorList: 2;
+  DirSelector: 4;
+  LangSelectorList: 8;
+  IsSelector: 16;
+  TextDecorationThicknessPercent: 32;
+  MediaIntervalSyntax: 64;
+  MediaRangeSyntax: 128;
+  CustomMediaQueries: 256;
+  ClampFunction: 512;
+  ColorFunction: 1024;
+  OklabColors: 2048;
+  LabColors: 4096;
+  P3Colors: 8192;
+  HexAlphaColors: 16384;
+  SpaceSeparatedColorNotation: 32768;
+  FontFamilySystemUi: 65536;
+  DoublePositionGradients: 131072;
+  VendorPrefixes: 262144;
+  LogicalProperties: 524288;
+  Selectors: 31;
+  MediaQueries: 448;
+  Colors: 64512;
 }


### PR DESCRIPTION
`const enum` can't be used with the [isolatedModules flag](https://www.typescriptlang.org/tsconfig#isolatedModules) which  is required by any compiler that is not tsc like esbuild which is used to compile the Vite config.

The proposed type described better the actual runtime code (I'm using `;` because this is the default prettier format, feel free to change if that's an issue for you)