### PR TITLE
feat: Make `Visitor` bounded by `?Sized`

### DIFF
--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -98,7 +98,7 @@ fn derive(
 
   impl_generics
     .params
-    .push(parse_quote! { #v: crate::visitor::Visitor<#lifetime, #t> });
+    .push(parse_quote! { #v: ?Sized + crate::visitor::Visitor<#lifetime, #t> });
 
   for ty in generics.type_params() {
     let name = &ty.ident;

--- a/examples/custom_at_rule.rs
+++ b/examples/custom_at_rule.rs
@@ -154,7 +154,9 @@ struct StyleRuleCollector<'i, 'a> {
 impl<'i, 'a> Visitor<'i, AtRule> for StyleRuleCollector<'i, 'a> {
   type Error = Infallible;
 
-  const TYPES: VisitTypes = VisitTypes::RULES;
+  fn visit_types(&self) -> VisitTypes {
+    VisitTypes::RULES
+  }
 
   fn visit_rule(&mut self, rule: &mut lightningcss::rules::CssRule<'i, AtRule>) -> Result<(), Self::Error> {
     match rule {
@@ -187,7 +189,9 @@ struct ApplyVisitor<'a, 'i> {
 impl<'a, 'i> Visitor<'i, AtRule> for ApplyVisitor<'a, 'i> {
   type Error = Infallible;
 
-  const TYPES: VisitTypes = visit_types!(RULES | COLORS | LENGTHS | DASHED_IDENTS | SELECTORS | TOKENS);
+  fn visit_types(&self) -> VisitTypes {
+    visit_types!(RULES | COLORS | LENGTHS | DASHED_IDENTS | SELECTORS | TOKENS)
+  }
 
   fn visit_rule(&mut self, rule: &mut CssRule<'i, AtRule>) -> Result<(), Self::Error> {
     // Replace @apply rule with nested style rule.

--- a/node/src/transformer.rs
+++ b/node/src/transformer.rs
@@ -248,8 +248,6 @@ impl JsVisitor {
 impl<'i> Visitor<'i, AtRule<'i>> for JsVisitor {
   type Error = napi::Error;
 
-  const TYPES: lightningcss::visitor::VisitTypes = VisitTypes::all();
-
   fn visit_types(&self) -> VisitTypes {
     self.types
   }

--- a/src/properties/custom.rs
+++ b/src/properties/custom.rs
@@ -1183,7 +1183,9 @@ struct VarInliner<'a, 'i> {
 impl<'a, 'i> crate::visitor::Visitor<'i> for VarInliner<'a, 'i> {
   type Error = std::convert::Infallible;
 
-  const TYPES: crate::visitor::VisitTypes = crate::visit_types!(TOKENS | VARIABLES);
+  fn visit_types(&self) -> crate::visitor::VisitTypes {
+    crate::visit_types!(TOKENS | VARIABLES)
+  }
 
   fn visit_token_list(&mut self, tokens: &mut TokenList<'i>) -> Result<(), Self::Error> {
     let mut i = 0;

--- a/src/rules/mod.rs
+++ b/src/rules/mod.rs
@@ -455,7 +455,7 @@ impl<'i, T> CssRuleList<'i, T> {
 // Manually implemented to avoid circular child types.
 #[cfg(feature = "visitor")]
 #[cfg_attr(docsrs, doc(cfg(feature = "visitor")))]
-impl<'i, T: Visit<'i, T, V>, V: Visitor<'i, T>> Visit<'i, T, V> for CssRuleList<'i, T> {
+impl<'i, T: Visit<'i, T, V>, V: ?Sized + Visitor<'i, T>> Visit<'i, T, V> for CssRuleList<'i, T> {
   const CHILD_TYPES: VisitTypes = VisitTypes::all();
 
   fn visit(&mut self, visitor: &mut V) -> Result<(), V::Error> {

--- a/src/selector.rs
+++ b/src/selector.rs
@@ -2052,7 +2052,7 @@ pub(crate) fn is_unused(
 
 #[cfg(feature = "visitor")]
 #[cfg_attr(docsrs, doc(cfg(feature = "visitor")))]
-impl<'i, T: Visit<'i, T, V>, V: Visitor<'i, T>> Visit<'i, T, V> for SelectorList<'i> {
+impl<'i, T: Visit<'i, T, V>, V: ?Sized + Visitor<'i, T>> Visit<'i, T, V> for SelectorList<'i> {
   const CHILD_TYPES: VisitTypes = VisitTypes::SELECTORS;
 
   fn visit(&mut self, visitor: &mut V) -> Result<(), V::Error> {
@@ -2070,7 +2070,7 @@ impl<'i, T: Visit<'i, T, V>, V: Visitor<'i, T>> Visit<'i, T, V> for SelectorList
 
 #[cfg(feature = "visitor")]
 #[cfg_attr(docsrs, doc(cfg(feature = "visitor")))]
-impl<'i, T: Visit<'i, T, V>, V: Visitor<'i, T>> Visit<'i, T, V> for Selector<'i> {
+impl<'i, T: Visit<'i, T, V>, V: ?Sized + Visitor<'i, T>> Visit<'i, T, V> for Selector<'i> {
   const CHILD_TYPES: VisitTypes = VisitTypes::SELECTORS;
 
   fn visit(&mut self, visitor: &mut V) -> Result<(), V::Error> {

--- a/src/values/color.rs
+++ b/src/values/color.rs
@@ -3259,7 +3259,7 @@ impl HueInterpolationMethod {
 
 #[cfg(feature = "visitor")]
 #[cfg_attr(docsrs, doc(cfg(feature = "visitor")))]
-impl<'i, V: Visitor<'i, T>, T: Visit<'i, T, V>> Visit<'i, T, V> for RGBA {
+impl<'i, V: ?Sized + Visitor<'i, T>, T: Visit<'i, T, V>> Visit<'i, T, V> for RGBA {
   const CHILD_TYPES: VisitTypes = VisitTypes::empty();
   fn visit_children(&mut self, _: &mut V) -> Result<(), V::Error> {
     Ok(())

--- a/src/values/string.rs
+++ b/src/values/string.rs
@@ -308,7 +308,7 @@ impl<'de> serde::de::Visitor<'de> for CowArcStrVisitor {
 }
 
 #[cfg(feature = "visitor")]
-impl<'i, V: Visitor<'i, T>, T: Visit<'i, T, V>> Visit<'i, T, V> for CowArcStr<'i> {
+impl<'i, V: ?Sized + Visitor<'i, T>, T: Visit<'i, T, V>> Visit<'i, T, V> for CowArcStr<'i> {
   const CHILD_TYPES: VisitTypes = VisitTypes::empty();
   fn visit_children(&mut self, _: &mut V) -> Result<(), V::Error> {
     Ok(())

--- a/src/vendor_prefix.rs
+++ b/src/vendor_prefix.rs
@@ -150,7 +150,7 @@ impl<'de> serde::Deserialize<'de> for VendorPrefix {
 
 #[cfg(feature = "visitor")]
 #[cfg_attr(docsrs, doc(cfg(feature = "visitor")))]
-impl<'i, V: Visitor<'i, T>, T: Visit<'i, T, V>> Visit<'i, T, V> for VendorPrefix {
+impl<'i, V: ?Sized + Visitor<'i, T>, T: Visit<'i, T, V>> Visit<'i, T, V> for VendorPrefix {
   const CHILD_TYPES: VisitTypes = VisitTypes::empty();
   fn visit_children(&mut self, _: &mut V) -> Result<(), V::Error> {
     Ok(())

--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -140,7 +140,7 @@ macro_rules! visit_types {
 }
 
 /// A trait for visiting or transforming rules, properties, and values in a StyleSheet.
-pub trait Visitor<'i, T: Visit<'i, T, Self> = DefaultAtRule>: Sized {
+pub trait Visitor<'i, T: Visit<'i, T, Self> = DefaultAtRule> {
   /// The `Err` value for `Result`s returned by `visit_*` methods.
   type Error;
 
@@ -313,7 +313,7 @@ pub trait Visitor<'i, T: Visit<'i, T, Self> = DefaultAtRule>: Sized {
 }
 
 /// A trait for values that can be visited by a [Visitor](Visitor).
-pub trait Visit<'i, T: Visit<'i, T, V>, V: Visitor<'i, T>> {
+pub trait Visit<'i, T: Visit<'i, T, V>, V: ?Sized + Visitor<'i, T>> {
   /// The types of values contained within this value and its children.
   /// This is used to skip branches that don't have any values requested
   /// by the Visitor.

--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -144,17 +144,9 @@ pub trait Visitor<'i, T: Visit<'i, T, Self> = DefaultAtRule> {
   /// The `Err` value for `Result`s returned by `visit_*` methods.
   type Error;
 
-  /// The types of values that this visitor should visit. May be constructed using
-  /// the [visit_types](visit_types) macro. Accurately setting these flags improves
-  /// performance by skipping branches that do not have any values of the requested types.
-  const TYPES: VisitTypes;
-
   /// Returns the types of values that this visitor should visit. By default, it returns
   /// `Self::TYPES`, but this can be overridden to change the value at runtime.
-  #[inline]
-  fn visit_types(&self) -> VisitTypes {
-    Self::TYPES
-  }
+  fn visit_types(&self) -> VisitTypes;
 
   /// Visits a rule list.
   #[inline]

--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -330,7 +330,7 @@ pub trait Visit<'i, T: Visit<'i, T, V>, V: ?Sized + Visitor<'i, T>> {
   fn visit_children(&mut self, visitor: &mut V) -> Result<(), V::Error>;
 }
 
-impl<'i, T: Visit<'i, T, V>, V: Visitor<'i, T>, U: Visit<'i, T, V>> Visit<'i, T, V> for Option<U> {
+impl<'i, T: Visit<'i, T, V>, V: ?Sized + Visitor<'i, T>, U: Visit<'i, T, V>> Visit<'i, T, V> for Option<U> {
   const CHILD_TYPES: VisitTypes = U::CHILD_TYPES;
 
   fn visit(&mut self, visitor: &mut V) -> Result<(), V::Error> {
@@ -350,7 +350,7 @@ impl<'i, T: Visit<'i, T, V>, V: Visitor<'i, T>, U: Visit<'i, T, V>> Visit<'i, T,
   }
 }
 
-impl<'i, T: Visit<'i, T, V>, V: Visitor<'i, T>, U: Visit<'i, T, V>> Visit<'i, T, V> for Box<U> {
+impl<'i, T: Visit<'i, T, V>, V: ?Sized + Visitor<'i, T>, U: Visit<'i, T, V>> Visit<'i, T, V> for Box<U> {
   const CHILD_TYPES: VisitTypes = U::CHILD_TYPES;
 
   fn visit(&mut self, visitor: &mut V) -> Result<(), V::Error> {
@@ -362,7 +362,7 @@ impl<'i, T: Visit<'i, T, V>, V: Visitor<'i, T>, U: Visit<'i, T, V>> Visit<'i, T,
   }
 }
 
-impl<'i, T: Visit<'i, T, V>, V: Visitor<'i, T>, U: Visit<'i, T, V>> Visit<'i, T, V> for Vec<U> {
+impl<'i, T: Visit<'i, T, V>, V: ?Sized + Visitor<'i, T>, U: Visit<'i, T, V>> Visit<'i, T, V> for Vec<U> {
   const CHILD_TYPES: VisitTypes = U::CHILD_TYPES;
 
   fn visit(&mut self, visitor: &mut V) -> Result<(), V::Error> {
@@ -374,8 +374,8 @@ impl<'i, T: Visit<'i, T, V>, V: Visitor<'i, T>, U: Visit<'i, T, V>> Visit<'i, T,
   }
 }
 
-impl<'i, A: smallvec::Array<Item = U>, U: Visit<'i, T, V>, T: Visit<'i, T, V>, V: Visitor<'i, T>> Visit<'i, T, V>
-  for SmallVec<A>
+impl<'i, A: smallvec::Array<Item = U>, U: Visit<'i, T, V>, T: Visit<'i, T, V>, V: ?Sized + Visitor<'i, T>>
+  Visit<'i, T, V> for SmallVec<A>
 {
   const CHILD_TYPES: VisitTypes = U::CHILD_TYPES;
 
@@ -390,7 +390,7 @@ impl<'i, A: smallvec::Array<Item = U>, U: Visit<'i, T, V>, T: Visit<'i, T, V>, V
 
 macro_rules! impl_visit {
   ($t: ty) => {
-    impl<'i, V: Visitor<'i, T>, T: Visit<'i, T, V>> Visit<'i, T, V> for $t {
+    impl<'i, V: ?Sized + Visitor<'i, T>, T: Visit<'i, T, V>> Visit<'i, T, V> for $t {
       const CHILD_TYPES: VisitTypes = VisitTypes::empty();
 
       fn visit_children(&mut self, _: &mut V) -> Result<(), V::Error> {

--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -33,7 +33,9 @@
 //! impl<'i> Visitor<'i> for MyVisitor {
 //!   type Error = Infallible;
 //!
-//!   const TYPES: VisitTypes = visit_types!(URLS | LENGTHS);
+//!   fn visit_types(&self) -> VisitTypes {
+//!     visit_types!(URLS | LENGTHS)
+//!   }
 //!
 //!   fn visit_url(&mut self, url: &mut Url<'i>) -> Result<(), Self::Error> {
 //!     url.url = format!("https://mywebsite.com/{}", url.url).into();


### PR DESCRIPTION
It does not have to be `Sized`.




# Real usage

I'm trying to use `lightningcss` for some SWC-related projects and I need to create a trait object of `Visitor`