### PR TITLE
Fix unpkg url in docs

### DIFF
--- a/website/pages/docs.md
+++ b/website/pages/docs.md
@@ -67,7 +67,7 @@ See the [Parcel docs](https://parceljs.org/languages/css) for more details.
 The `lightningcss-wasm` package can be used in Deno or directly in browsers. This uses a WebAssembly build of Lightning CSS. Use `TextEncoder` and `TextDecoder` convert code from a string to a typed array and back.
 
 ```js
-import init, { transform } from 'https://unpkg.com/lightningcss-wasm?module';
+import init, { transform } from 'https://esm.run/lightningcss-wasm';
 
 await init();
 


### PR DESCRIPTION
See https://github.com/parcel-bundler/lightningcss/issues/565

https://unpkg.com/lightningcss-wasm?module imports https://unpkg.com/napi-wasm@^1.0.1?module which responds with
```
Cannot generate module for napi-wasm@1.1.0/index.mjs

SyntaxError: unknown: Support for the experimental syntax 'classProperties' isn't currently enabled (32:10):

  30 | 
  31 | export class Environment {
> 32 |   scopes = [];
     |          ^
  33 |   referenceId = 1;
  34 |   references = new Map();
  35 |   deferred = [null];

Add @babel/plugin-proposal-class-properties (https://git.io/vb4SL) to the 'plugins' section of your Babel config to enable transformation.

undefined
```

https://esm.run (= [jsdelivr](https://www.jsdelivr.com/esm)) works fine