### PR TITLE
feat: Implement `IntoOwned` for more types

### DIFF
--- a/derive/src/into_owned.rs
+++ b/derive/src/into_owned.rs
@@ -152,7 +152,15 @@ pub(crate) fn derive_into_owned(input: TokenStream) -> TokenStream {
       }
     }
   } else {
-    let params = generics.type_params();
+    let mut generics_without_default = generics.clone();
+
+    for p in generics_without_default.params.iter_mut() {
+      if let syn::GenericParam::Type(ty) = p {
+        ty.default = None;
+      }
+    }
+
+    let params = generics_without_default.type_params();
     quote! {
       impl #impl_generics crate::traits::IntoOwned<'any> for #self_name #ty_generics #where_clause {
         type Owned = #self_name<'any, #(#params),*>;

--- a/derive/src/into_owned.rs
+++ b/derive/src/into_owned.rs
@@ -184,9 +184,7 @@ fn into_owned(ty: &Type, name: proc_macro2::TokenStream) -> proc_macro2::TokenSt
             _ => quote! { #v.into_owned() },
           };
           quote! { #name.map(|#v| #into_owned) }
-        } else if last.ident == "Vec"
-          || last.ident == "SmallVec"
-          || last.ident == "CustomIdentList"
+        } else if last.ident == "CustomIdentList"
           || last.ident == "AnimationList"
           || last.ident == "AnimationNameList"
         {

--- a/src/rules/container.rs
+++ b/src/rules/container.rs
@@ -25,6 +25,7 @@ use crate::visitor::Visit;
 #[cfg_attr(feature = "visitor", derive(Visit))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "jsonschema", derive(schemars::JsonSchema))]
+#[cfg_attr(feature = "into_owned", derive(lightningcss_derive::IntoOwned))]
 pub struct ContainerRule<'i, R = DefaultAtRule> {
   /// The name of the container.
   #[cfg_attr(feature = "serde", serde(borrow))]

--- a/src/rules/document.rs
+++ b/src/rules/document.rs
@@ -17,6 +17,7 @@ use crate::visitor::Visit;
 #[cfg_attr(feature = "visitor", derive(Visit))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "jsonschema", derive(schemars::JsonSchema))]
+#[cfg_attr(feature = "into_owned", derive(lightningcss_derive::IntoOwned))]
 pub struct MozDocumentRule<'i, R = DefaultAtRule> {
   /// Nested rules within the `@-moz-document` rule.
   #[cfg_attr(feature = "serde", serde(borrow))]

--- a/src/rules/layer.rs
+++ b/src/rules/layer.rs
@@ -116,6 +116,7 @@ impl<'i> ToCss for LayerStatementRule<'i> {
 #[cfg_attr(feature = "visitor", derive(Visit))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "jsonschema", derive(schemars::JsonSchema))]
+#[cfg_attr(feature = "into_owned", derive(lightningcss_derive::IntoOwned))]
 pub struct LayerBlockRule<'i, R = DefaultAtRule> {
   /// The name of the layer to declare, or `None` to declare an anonymous layer.
   #[cfg_attr(feature = "serde", serde(borrow))]

--- a/src/rules/media.rs
+++ b/src/rules/media.rs
@@ -15,6 +15,7 @@ use crate::visitor::Visit;
 #[cfg_attr(feature = "visitor", derive(Visit))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "jsonschema", derive(schemars::JsonSchema))]
+#[cfg_attr(feature = "into_owned", derive(lightningcss_derive::IntoOwned))]
 pub struct MediaRule<'i, R = DefaultAtRule> {
   /// The media query list.
   #[cfg_attr(feature = "serde", serde(borrow))]

--- a/src/rules/mod.rs
+++ b/src/rules/mod.rs
@@ -130,6 +130,7 @@ pub struct Location {
   serde(tag = "type", content = "value", rename_all = "kebab-case")
 )]
 #[cfg_attr(feature = "jsonschema", derive(schemars::JsonSchema), schemars(rename = "Rule"))]
+#[cfg_attr(feature = "into_owned", derive(lightningcss_derive::IntoOwned))]
 pub enum CssRule<'i, R = DefaultAtRule> {
   /// A `@media` rule.
   #[cfg_attr(feature = "serde", serde(borrow))]
@@ -412,6 +413,7 @@ impl<'i, T> CssRule<'i, T> {
 #[derive(Debug, PartialEq, Clone, Default)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize), serde(transparent))]
 #[cfg_attr(feature = "jsonschema", derive(schemars::JsonSchema))]
+#[cfg_attr(feature = "into_owned", derive(lightningcss_derive::IntoOwned))]
 pub struct CssRuleList<'i, R = DefaultAtRule>(
   #[cfg_attr(feature = "serde", serde(borrow))] pub Vec<CssRule<'i, R>>,
 );

--- a/src/rules/nesting.rs
+++ b/src/rules/nesting.rs
@@ -14,6 +14,7 @@ use crate::visitor::Visit;
 #[cfg_attr(feature = "visitor", derive(Visit))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "jsonschema", derive(schemars::JsonSchema))]
+#[cfg_attr(feature = "into_owned", derive(lightningcss_derive::IntoOwned))]
 pub struct NestingRule<'i, R = DefaultAtRule> {
   /// The style rule that defines the selector and declarations for the `@nest` rule.
   #[cfg_attr(feature = "serde", serde(borrow))]

--- a/src/rules/scope.rs
+++ b/src/rules/scope.rs
@@ -23,6 +23,7 @@ use crate::visitor::Visit;
   serde(rename_all = "camelCase")
 )]
 #[cfg_attr(feature = "jsonschema", derive(schemars::JsonSchema))]
+#[cfg_attr(feature = "into_owned", derive(lightningcss_derive::IntoOwned))]
 pub struct ScopeRule<'i, R = DefaultAtRule> {
   /// A selector list used to identify the scoping root(s).
   pub scope_start: Option<SelectorList<'i>>,

--- a/src/rules/starting_style.rs
+++ b/src/rules/starting_style.rs
@@ -14,6 +14,7 @@ use crate::visitor::Visit;
 #[cfg_attr(feature = "visitor", derive(Visit))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "jsonschema", derive(schemars::JsonSchema))]
+#[cfg_attr(feature = "into_owned", derive(lightningcss_derive::IntoOwned))]
 pub struct StartingStyleRule<'i, R = DefaultAtRule> {
   /// Nested rules within the `@starting-style` rule.
   #[cfg_attr(feature = "serde", serde(borrow))]

--- a/src/rules/style.rs
+++ b/src/rules/style.rs
@@ -25,6 +25,7 @@ use cssparser::*;
 #[cfg_attr(feature = "visitor", derive(Visit))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "jsonschema", derive(schemars::JsonSchema))]
+#[cfg_attr(feature = "into_owned", derive(lightningcss_derive::IntoOwned))]
 pub struct StyleRule<'i, R = DefaultAtRule> {
   /// The selectors for the style rule.
   #[cfg_attr(feature = "serde", serde(borrow))]

--- a/src/rules/supports.rs
+++ b/src/rules/supports.rs
@@ -22,6 +22,7 @@ use crate::serialization::ValueWrapper;
 #[cfg_attr(feature = "visitor", derive(Visit))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "jsonschema", derive(schemars::JsonSchema))]
+#[cfg_attr(feature = "into_owned", derive(lightningcss_derive::IntoOwned))]
 pub struct SupportsRule<'i, R = DefaultAtRule> {
   /// The supports condition.
   #[cfg_attr(feature = "serde", serde(borrow))]

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -55,11 +55,13 @@ where
 }
 
 #[cfg(feature = "into_owned")]
-impl<'any, T> IntoOwned<'any> for SmallVec<T>
+impl<'any, T, const N: usize> IntoOwned<'any> for SmallVec<[T; N]>
 where
   T: for<'aa> IntoOwned<'aa>,
+  [T; N]: smallvec::Array<Item = T>,
+  [<T as IntoOwned<'any>>::Owned; N]: smallvec::Array<Item = <T as IntoOwned<'any>>::Owned>,
 {
-  type Owned = Vec<<T as IntoOwned<'any>>::Owned>;
+  type Owned = SmallVec<[<T as IntoOwned<'any>>::Owned; N]>;
 
   fn into_owned(self) -> Self::Owned {
     self.into_iter().map(|v| v.into_owned()).collect()

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -42,6 +42,30 @@ macro_rules! impl_into_owned {
 #[cfg(feature = "into_owned")]
 impl_into_owned!(bool, f32, f64, u8, u16, u32, u64, u128, i8, i16, i32, i64, i128, usize, isize);
 
+#[cfg(feature = "into_owned")]
+impl<'any, T> IntoOwned<'any> for Vec<T>
+where
+  T: for<'aa> IntoOwned<'aa>,
+{
+  type Owned = Vec<<T as IntoOwned<'any>>::Owned>;
+
+  fn into_owned(self) -> Self::Owned {
+    self.into_iter().map(|v| v.into_owned()).collect()
+  }
+}
+
+#[cfg(feature = "into_owned")]
+impl<'any, T> IntoOwned<'any> for SmallVec<T>
+where
+  T: for<'aa> IntoOwned<'aa>,
+{
+  type Owned = Vec<<T as IntoOwned<'any>>::Owned>;
+
+  fn into_owned(self) -> Self::Owned {
+    self.into_iter().map(|v| v.into_owned()).collect()
+  }
+}
+
 /// Trait for things that can be parsed from CSS syntax.
 pub trait Parse<'i>: Sized {
   /// Parse a value of this type using an existing parser.


### PR DESCRIPTION
I forgot to add `derive`s.


But I'm stuck due to an API design issue.

Is it fine to implement `IntoOwned` for the selector types? If so, where should the trait definition go?
