### PR TITLE
Allow whitespace (or nothing) in the `initial-value` of `@property` with universal syntax

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25903,7 +25903,7 @@ mod tests {
       @property --property-name {
         syntax: "*";
         inherits: false;
-        initial-value:;
+        initial-value: ;
       }
     "#},
     );
@@ -25916,7 +25916,7 @@ mod tests {
         initial-value:;
       }
     "#,
-      "@property --property-name{syntax:\"*\";inherits:false;initial-value:}",
+      "@property --property-name{syntax:\"*\";inherits:false;initial-value: }",
     );
 
     minify_test(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25863,6 +25863,62 @@ mod tests {
       "@property --property-name{syntax:\"<color>\";inherits:false;initial-value:#ff0}",
     );
 
+    test(
+      r#"
+      @property --property-name {
+        syntax: '*';
+        inherits: false;
+        initial-value: ;
+      }
+    "#,
+      indoc! {r#"
+      @property --property-name {
+        syntax: "*";
+        inherits: false;
+        initial-value: ;
+      }
+    "#},
+    );
+
+    minify_test(
+      r#"
+      @property --property-name {
+        syntax: '*';
+        inherits: false;
+        initial-value: ;
+      }
+    "#,
+      "@property --property-name{syntax:\"*\";inherits:false;initial-value: }",
+    );
+
+    test(
+      r#"
+      @property --property-name {
+        syntax: '*';
+        inherits: false;
+        initial-value:;
+      }
+    "#,
+      indoc! {r#"
+      @property --property-name {
+        syntax: "*";
+        inherits: false;
+        initial-value:;
+      }
+    "#},
+    );
+
+    minify_test(
+      r#"
+      @property --property-name {
+        syntax: '*';
+        inherits: false;
+        initial-value:;
+      }
+    "#,
+      "@property --property-name{syntax:\"*\";inherits:false;initial-value:}",
+    );
+
     minify_test(
       r#"
       @property --property-name {

--- a/src/rules/property.rs
+++ b/src/rules/property.rs
@@ -80,7 +80,15 @@ impl<'i> PropertyRule<'i> {
         Some(val) => {
           let mut input = ParserInput::new(val);
           let mut parser = Parser::new(&mut input);
-          Some(syntax.parse_value(&mut parser)?)
+
+          if parser.is_exhausted() {
+            Some(ParsedComponent::Token(match parser.next_including_whitespace() {
+              Ok(t) => t.into(),
+              Err(_) => crate::properties::custom::Token::WhiteSpace("".into()),
+            }))
+          } else {
+            Some(syntax.parse_value(&mut parser)?)
+          }
         }
       },
       _ => {

--- a/src/rules/property.rs
+++ b/src/rules/property.rs
@@ -137,21 +137,25 @@ impl<'i> ToCss for PropertyRule<'i> {
       dest.write_str("initial-value:")?;
       match initial_value {
         ParsedComponent::Token(crate::properties::custom::Token::WhiteSpace(value)) => {
-          // Only emit a single whitespace if the value has one or more spaces. This happens in
-          // the scenario where initial-value was defined as:
+          // Only emit a single whitespace character if the value has one or more spaces. This
+          // happens in the scenario where initial-value was defined as:
+          //
           // ```css
           // @property --foo {
           //   initial-value: ;
           // }
           // ```
-          // or with more spaces
+          //
+          // or with more spaces:
+          //
           // ```css
           // @property --foo {
           //   initial-value:      ;
           // }
           // ```
           //
-          // If no spaces were defined at all, then we don't want to emit any whitespace.
+          // If no spaces were defined at all, then we don't want to emit any whitespace:
+          //
           // ```css
           // @property --foo {
           //   initial-value:;

--- a/src/rules/property.rs
+++ b/src/rules/property.rs
@@ -82,10 +82,9 @@ impl<'i> PropertyRule<'i> {
           let mut parser = Parser::new(&mut input);
 
           if parser.is_exhausted() {
-            Some(ParsedComponent::Token(match parser.next_including_whitespace() {
-              Ok(t) => t.into(),
-              Err(_) => crate::properties::custom::Token::WhiteSpace("".into()),
-            }))
+            Some(ParsedComponent::Token(crate::properties::custom::Token::WhiteSpace(
+              " ".into(),
+            )))
           } else {
             Some(syntax.parse_value(&mut parser)?)
           }
@@ -144,37 +143,7 @@ impl<'i> ToCss for PropertyRule<'i> {
 
       dest.write_str("initial-value:")?;
       match initial_value {
-        ParsedComponent::Token(crate::properties::custom::Token::WhiteSpace(value)) => {
-          // Only emit a single whitespace character if the value has one or more spaces. This
-          // happens in the scenario where initial-value was defined as:
-          //
-          // ```css
-          // @property --foo {
-          //   initial-value: ;
-          // }
-          // ```
-          //
-          // or with more spaces:
-          //
-          // ```css
-          // @property --foo {
-          //   initial-value:      ;
-          // }
-          // ```
-          //
-          // If no spaces were defined at all, then we don't want to emit any whitespace:
-          //
-          // ```css
-          // @property --foo {
-          //   initial-value:;
-          // }
-          // ```
-          if value.len() >= 1 {
-            // Not using dest.whitespace() because we _do_ want to emit a single space even when
-            // minifying.
-            dest.write_char(' ')?
-          }
-        }
+        ParsedComponent::Token(crate::properties::custom::Token::WhiteSpace(value)) => dest.write_str(value)?,
         _ => {
           dest.whitespace()?;
           initial_value.to_css(dest)?;

--- a/src/values/syntax.rs
+++ b/src/values/syntax.rs
@@ -200,14 +200,7 @@ impl<'i> SyntaxString {
   ) -> Result<ParsedComponent<'i>, ParseError<'i, ParserError<'i>>> {
     match self {
       SyntaxString::Universal => Ok(ParsedComponent::Token(crate::properties::custom::Token::from(
-        match input.next_including_whitespace() {
-          Ok(token) => token,
-          Err(BasicParseError {
-            kind: BasicParseErrorKind::EndOfInput,
-            ..
-          }) => &Token::WhiteSpace(""),
-          Err(e) => return Err(e.into()),
-        },
+        input.next()?,
       ))),
       SyntaxString::Components(components) => {
         // Loop through each component, and return the first one that parses successfully.

--- a/src/values/syntax.rs
+++ b/src/values/syntax.rs
@@ -200,7 +200,14 @@ impl<'i> SyntaxString {
   ) -> Result<ParsedComponent<'i>, ParseError<'i, ParserError<'i>>> {
     match self {
       SyntaxString::Universal => Ok(ParsedComponent::Token(crate::properties::custom::Token::from(
-        input.next()?,
+        match input.next_including_whitespace() {
+          Ok(token) => token,
+          Err(BasicParseError {
+            kind: BasicParseErrorKind::EndOfInput,
+            ..
+          }) => &Token::WhiteSpace(""),
+          Err(e) => return Err(e.into()),
+        },
       ))),
       SyntaxString::Components(components) => {
         // Loop through each component, and return the first one that parses successfully.


### PR DESCRIPTION
When declaring a `@property` with `syntax: '*'`, then the `initial-value` can be empty or can containe whitespace. Currently this errors with an `Unexpected end of input`.

This PR fixes that by allowing the whitespace in the `initial-value` spot.

I know it is 100% correct because we _do_ want to allow whitespace but just not print all of it.

- Right now I added it in a `syntax.rs` file and it's not _only_ for the `initial-value` but for everything that uses that parser with `SyntaxString::Universal` but I'm not 100% sure on how to fix this. A new property on the parser? An additional argument with some options?
- We also "abuse" the `EndOfInput` error in case of `initial-value:;`, this definitely feels hacky but I got it to work this way. Catching the `EndOfInput` allows us to convert it to `Whitespce("")` (also hacky).

I started with adding the tests so that we can work from there, then updated the parser and the printer.

Looking forward to feedback and obvious improvements!

Fixes: #654

