### PR TITLE
Update ahash to fix compilation issue on nightly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,9 +15,9 @@ dependencies = [
 
 [[package]]
 name = "ahash"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91429305e9f0a25f6205c5b8e0d2db09e0708a7a6df0f42212bb56c32c8ac97a"
+checksum = "77c3a9648d43b9cd48db467b3f87fdd6e146bcc88ab0180006cef2179fe11d01"
 dependencies = [
  "cfg-if",
  "getrandom",
@@ -149,7 +149,7 @@ version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9bda9b4595376bf255f68dafb5dcc5b0e2842b38dc2a7b52c4e0bfe9fd1c651"
 dependencies = [
- "ahash 0.8.6",
+ "ahash 0.8.7",
  "anyhow",
  "chrono",
  "either",
@@ -743,7 +743,7 @@ dependencies = [
 name = "lightningcss"
 version = "1.0.0-alpha.52"
 dependencies = [
- "ahash 0.7.7",
+ "ahash 0.8.7",
  "assert_cmd",
  "assert_fs",
  "atty",
@@ -1931,18 +1931,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.7.25"
+version = "0.7.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cd369a67c0edfef15010f980c3cbe45d7f651deac2cd67ce097cd801de16557"
+checksum = "74d4d3961e53fa4c9a25a8637fc2bfaf2595b3d3ae34875568a5cf64787716be"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.7.25"
+version = "0.7.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2f140bda219a26ccc0cdb03dba58af72590c53b22642577d88a927bc5c87d6b"
+checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -755,6 +755,7 @@ dependencies = [
  "cssparser-color",
  "dashmap",
  "data-encoding",
+ "getrandom",
  "indoc",
  "itertools 0.10.5",
  "jemallocator",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,6 +75,9 @@ static-self = { version = "0.1.0", path = "static-self", optional = true }
 [target.'cfg(target_os = "macos")'.dependencies]
 jemallocator = { version = "0.3.2", features = ["disable_initial_exec_tls"], optional = true }
 
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+getrandom = { version = "0.2", features = ["custom"], default-features = false }
+
 [dev-dependencies]
 indoc = "1.0.3"
 assert_cmd = "2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,7 @@ data-encoding = "2.3.2"
 lazy_static = "1.4.0"
 const-str = "0.3.1"
 pathdiff = "0.2.1"
-ahash = "0.7.6"
+ahash = "0.8.7"
 paste = "1.0.12"
 # CLI deps
 atty = { version = "0.2", optional = true }

--- a/node/test/bundle.test.mjs
+++ b/node/test/bundle.test.mjs
@@ -2,11 +2,15 @@ import path from 'path';
 import fs from 'fs';
 import { test } from 'uvu';
 import * as assert from 'uvu/assert';
+import {webcrypto as crypto} from 'node:crypto';
 
 let bundleAsync;
 if (process.env.TEST_WASM === 'node') {
   bundleAsync = (await import('../../wasm/wasm-node.mjs')).bundleAsync;
 } else if (process.env.TEST_WASM === 'browser') {
+  // Define crypto globally for old node.
+  // @ts-ignore
+  globalThis.crypto ??= crypto;
   let wasm = await import('../../wasm/index.mjs');
   await wasm.default();
   bundleAsync = function (options) {

--- a/node/test/composeVisitors.test.mjs
+++ b/node/test/composeVisitors.test.mjs
@@ -2,11 +2,15 @@
 
 import { test } from 'uvu';
 import * as assert from 'uvu/assert';
+import {webcrypto as crypto} from 'node:crypto';
 
 let transform, composeVisitors;
 if (process.env.TEST_WASM === 'node') {
   ({transform, composeVisitors} = await import('../../wasm/wasm-node.mjs'));
 } else if (process.env.TEST_WASM === 'browser') {
+  // Define crypto globally for old node.
+  // @ts-ignore
+  globalThis.crypto ??= crypto;
   let wasm = await import('../../wasm/index.mjs');
   await wasm.default();
   ({transform, composeVisitors} = wasm);

--- a/node/test/customAtRules.mjs
+++ b/node/test/customAtRules.mjs
@@ -3,11 +3,15 @@
 import { test } from 'uvu';
 import * as assert from 'uvu/assert';
 import fs from 'fs';
+import {webcrypto as crypto} from 'node:crypto';
 
 let bundle, transform;
 if (process.env.TEST_WASM === 'node') {
   ({ bundle, transform } = await import('../../wasm/wasm-node.mjs'));
 } else if (process.env.TEST_WASM === 'browser') {
+  // Define crypto globally for old node.
+  // @ts-ignore
+  globalThis.crypto ??= crypto;
   let wasm = await import('../../wasm/index.mjs');
   await wasm.default();
   transform = wasm.transform;

--- a/node/test/transform.test.mjs
+++ b/node/test/transform.test.mjs
@@ -1,10 +1,14 @@
 import { test } from 'uvu';
 import * as assert from 'uvu/assert';
+import {webcrypto as crypto} from 'node:crypto';
 
 let transform, Features;
 if (process.env.TEST_WASM === 'node') {
   ({transform, Features} = await import('../../wasm/wasm-node.mjs'));
 } else if (process.env.TEST_WASM === 'browser') {
+  // Define crypto globally for old node.
+  // @ts-ignore
+  globalThis.crypto ??= crypto;
   let wasm = await import('../../wasm/index.mjs');
   await wasm.default();
   ({transform, Features} = wasm);

--- a/node/test/visitor.test.mjs
+++ b/node/test/visitor.test.mjs
@@ -3,11 +3,15 @@
 import { test } from 'uvu';
 import * as assert from 'uvu/assert';
 import fs from 'fs';
+import {webcrypto as crypto} from 'node:crypto';
 
 let bundle, bundleAsync, transform, transformStyleAttribute;
 if (process.env.TEST_WASM === 'node') {
   ({ bundle, bundleAsync, transform, transformStyleAttribute } = await import('../../wasm/wasm-node.mjs'));
 } else if (process.env.TEST_WASM === 'browser') {
+  // Define crypto globally for old node.
+  // @ts-ignore
+  globalThis.crypto ??= crypto;
   let wasm = await import('../../wasm/index.mjs');
   await wasm.default();
   ({ transform, transformStyleAttribute } = wasm);

--- a/wasm/index.mjs
+++ b/wasm/index.mjs
@@ -15,10 +15,20 @@ export default async function init(input) {
     input = fetchOrReadFromFs(input);
   }
 
+  let env;
   initPromise = input
-    .then(input => load(input, {env: {...napi, await_promise_sync}}))
+    .then(input => load(input, {
+      env: {
+        ...napi,
+        await_promise_sync,
+        __getrandom_custom: (ptr, len) => {
+          let buf = env.memory.subarray(ptr, ptr + len);
+          crypto.getRandomValues(buf);
+        },
+      }
+    }))
     .then(({instance}) => {
-      let env = new Environment(instance);
+      env = new Environment(instance);
       bundleAsyncInternal = createBundleAsync(env);
       wasm = env.exports;
     });

--- a/wasm/wasm-node.mjs
+++ b/wasm/wasm-node.mjs
@@ -7,7 +7,11 @@ let wasmModule = new WebAssembly.Module(wasmBytes);
 let instance = new WebAssembly.Instance(wasmModule, {
   env: {
     ...napi,
-    await_promise_sync
+    await_promise_sync,
+    __getrandom_custom: (ptr, len) => {
+      let buf = env.memory.subarray(ptr, ptr + len);
+      crypto.getRandomValues(buf);
+    },
   },
 });
 let env = new Environment(instance);

--- a/wasm/wasm-node.mjs
+++ b/wasm/wasm-node.mjs
@@ -1,6 +1,7 @@
 import { Environment, napi } from 'napi-wasm';
 import { await_promise_sync, createBundleAsync } from './async.mjs';
 import fs from 'fs';
+import {webcrypto as crypto} from 'node:crypto';
 
 let wasmBytes = fs.readFileSync(new URL('lightningcss_node.wasm', import.meta.url));
 let wasmModule = new WebAssembly.Module(wasmBytes);


### PR DESCRIPTION
The `ahash` crate has stopped compiling on `nightly` since today (https://github.com/tkaitchuck/aHash/issues/200). This broke many crates, including this one, and in turn also a part of the Rust compiler benchmark suite, which uses this crate as one of its runtime benchmarks :)

A newer version of `ahash` (`0.8.7`) is needed to fix the compilation issue. This PR updates the `ahash` dependency to fix the compilation of this crate on `nightly`:

```bash
$ cargo +nightly build --no-default-features --features grid,nodejs
```

However, it still won't work with default features, since `parcel_sourcemap` would also need to be updated.