### PR TITLE
napi: fix build error in cargo-auditable

### DIFF
--- a/napi/Cargo.toml
+++ b/napi/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2021"
 [features]
 default = []
 visitor = ["lightningcss/visitor"]
-bundler = ["dep:crossbeam-channel", "dep:rayon"]
+bundler = ["dep:crossbeam-channel", "rayon"]
 
 [dependencies]
 serde = { version = "1.0.123", features = ["derive"] }


### PR DESCRIPTION
As reported https://github.com/parcel-bundler/lightningcss/issues/702
when trying to build via `cargo auditable build --release --lib --bin=lightningcss --features="cli"` build fails with the following error.
```
   Compiling lightningcss v1.0.0-alpha.55 (/home/masum/Dev-Environment/lightningcss)
    Building [=======================> ] 169/171: lightningcss                            thread 'main' panicked at cargo-auditable/src/collect_audit_data.rs:77:9:
cargo metadata failure: error: Package `lightningcss-napi v0.1.0 (/home/masum/Dev-Environment/lightningcss/napi)` does not have feature `rayon`. It has an optional dependency with that name, but that dependency uses the "dep:" syntax in the features table, so it does not have an implicit feature with that name.
```

This patch fixes the bug and the build succeeds on cargo auditable.