### PR TITLE
Make CLI example work with Windows (update docs.md)

### DIFF
--- a/website/pages/docs.md
+++ b/website/pages/docs.md
@@ -155,7 +155,7 @@ Then, you can run the `lightningcss` command via `npx`, `yarn`, or by setting up
 ```json
 {
   "scripts": {
-    "build": "lightningcss --minify --bundle --targets '>= 0.25%' input.css -o output.css"
+    "build": "lightningcss --minify --bundle --targets \">= 0.25%\" input.css -o output.css"
   }
 }
 ```


### PR DESCRIPTION
Using single quotes in the CLI command will cause a panic in the main thread.

```
> lightningcss --bundle --targets '>= 0.5%' src/app.css -o dist/app.bundle.css

thread 'main' panicked at src/main.rs:191:56:
called `Result::unwrap()` on an `Err` value: Nom("")
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

This PR updates the example code to also work on Windows systems (wasn't immediately obvious that this was the problem).