### PR TITLE
Add granular CSS Modules options

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -445,6 +445,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "diff"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
+
+[[package]]
 name = "difflib"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -786,6 +792,7 @@ dependencies = [
  "paste",
  "pathdiff",
  "predicates 2.1.5",
+ "pretty_assertions",
  "rayon",
  "schemars",
  "serde",
@@ -1195,6 +1202,16 @@ checksum = "368ba315fb8c5052ab692e68a0eefec6ec57b23a36959c14496f0b0df2c0cecf"
 dependencies = [
  "predicates-core",
  "termtree",
+]
+
+[[package]]
+name = "pretty_assertions"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af7cee1a6c8a5b9208b3cb1061f10c0cb689087b3d8ce85fb9d2dd7a29b6ba66"
+dependencies = [
+ "diff",
+ "yansi",
 ]
 
 [[package]]
@@ -1946,6 +1963,12 @@ checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
 dependencies = [
  "tap",
 ]
+
+[[package]]
+name = "yansi"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
 
 [[package]]
 name = "zerocopy"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,6 +86,7 @@ assert_cmd = "2.0"
 assert_fs = "1.0"
 predicates = "2.1"
 serde_json = "1"
+pretty_assertions = "1.4.0"
 
 [[test]]
 name = "cli_integration_tests"

--- a/napi/src/lib.rs
+++ b/napi/src/lib.rs
@@ -716,9 +716,9 @@ fn compile<'i>(
                 Default::default()
               },
               dashed_idents: c.dashed_idents.unwrap_or_default(),
-              animation: c.animation.unwrap_or_default(),
-              grid: c.grid.unwrap_or_default(),
-              custom_idents: c.custom_idents.unwrap_or_default(),
+              animation: c.animation.unwrap_or(true),
+              grid: c.grid.unwrap_or(true),
+              custom_idents: c.custom_idents.unwrap_or(true),
             }),
           }
         } else {

--- a/napi/src/lib.rs
+++ b/napi/src/lib.rs
@@ -848,7 +848,6 @@ fn compile_bundle<
             dashed_idents: c.dashed_idents.unwrap_or_default(),
             animation: c.animation.unwrap_or(true),
             grid: c.grid.unwrap_or(true),
-            keyframes: c.keyframes.unwrap_or(true),
             custom_idents: c.custom_idents.unwrap_or(true),
           }),
         }

--- a/napi/src/lib.rs
+++ b/napi/src/lib.rs
@@ -605,6 +605,9 @@ enum CssModulesOption {
 struct CssModulesConfig {
   pattern: Option<String>,
   dashed_idents: Option<bool>,
+  animation: Option<bool>,
+  grid: Option<bool>,
+  custom_idents: Option<bool>,
 }
 
 #[cfg(feature = "bundler")]
@@ -713,6 +716,9 @@ fn compile<'i>(
                 Default::default()
               },
               dashed_idents: c.dashed_idents.unwrap_or_default(),
+              animation: c.animation.unwrap_or_default(),
+              grid: c.grid.unwrap_or_default(),
+              custom_idents: c.custom_idents.unwrap_or_default(),
             }),
           }
         } else {
@@ -840,6 +846,10 @@ fn compile_bundle<
               Default::default()
             },
             dashed_idents: c.dashed_idents.unwrap_or_default(),
+            animation: c.animation.unwrap_or(true),
+            grid: c.grid.unwrap_or(true),
+            keyframes: c.keyframes.unwrap_or(true),
+            custom_idents: c.custom_idents.unwrap_or(true),
           }),
         }
       } else {

--- a/src/css_modules.rs
+++ b/src/css_modules.rs
@@ -25,13 +25,34 @@ use std::hash::{Hash, Hasher};
 use std::path::Path;
 
 /// Configuration for CSS modules.
-#[derive(Default, Clone, Debug)]
+#[derive(Clone, Debug)]
 pub struct Config<'i> {
   /// The name pattern to use when renaming class names and other identifiers.
   /// Default is `[hash]_[local]`.
   pub pattern: Pattern<'i>,
   /// Whether to rename dashed identifiers, e.g. custom properties.
   pub dashed_idents: bool,
+  /// Whether to scope animation names.
+  /// Default is `true`.
+  pub animation: bool,
+  /// Whether to scope grid names.
+  /// Default is `true`.
+  pub grid: bool,
+  /// Whether to scope custom identifiers
+  /// Default is `true`.
+  pub custom_idents: bool,
+}
+
+impl<'i> Default for Config<'i> {
+  fn default() -> Self {
+    Config {
+      pattern: Default::default(),
+      dashed_idents: Default::default(),
+      animation: true,
+      grid: true,
+      custom_idents: true,
+    }
+  }
 }
 
 /// A CSS modules class name pattern.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23101,6 +23101,51 @@ mod tests {
       },
     );
 
+    css_modules_test(
+      r#"
+      @counter-style circles {
+        symbols: Ⓐ Ⓑ Ⓒ;
+      }
+
+      ul {
+        list-style: circles;
+      }
+
+      ol {
+        list-style-type: none;
+      }
+
+      li {
+        list-style-type: disc;
+      }
+    "#,
+      indoc! {r#"
+      @counter-style circles {
+        symbols: Ⓐ Ⓑ Ⓒ;
+      }
+
+      ul {
+        list-style: circles;
+      }
+
+      ol {
+        list-style-type: none;
+      }
+
+      li {
+        list-style-type: disc;
+      }
+    "#},
+      map! {
+        "circles" => "EgL3uq_circles" referenced: true
+      },
+      HashMap::new(),
+      crate::css_modules::Config {
+        custom_idents: false,
+        ..Default::default()
+      },
+    );
+
     #[cfg(feature = "grid")]
     css_modules_test(
       r#"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23135,6 +23135,46 @@ mod tests {
       Default::default(),
     );
 
+    #[cfg(feature = "grid")]
+    css_modules_test(
+      r#"
+        .grid {
+          grid-template-areas: "foo";
+        }
+
+        .foo {
+          grid-area: foo;
+        }
+
+        .bar {
+          grid-column-start: foo-start;
+        }
+      "#,
+      indoc! {r#"
+        .EgL3uq_grid {
+          grid-template-areas: "foo";
+        }
+
+        .EgL3uq_foo {
+          grid-area: foo;
+        }
+
+        .EgL3uq_bar {
+          grid-column-start: foo-start;
+        }
+      "#},
+      map! {
+        "foo" => "EgL3uq_foo",
+        "grid" => "EgL3uq_grid",
+        "bar" => "EgL3uq_bar"
+      },
+      HashMap::new(),
+      crate::css_modules::Config {
+        grid: false,
+        ..Default::default()
+      },
+    );
+
     css_modules_test(
       r#"
       test {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,6 +64,7 @@ mod tests {
   use crate::vendor_prefix::VendorPrefix;
   use cssparser::SourceLocation;
   use indoc::indoc;
+  use pretty_assertions::assert_eq;
   use std::collections::HashMap;
 
   fn test(source: &str, expected: &str) {
@@ -23051,6 +23052,53 @@ mod tests {
       },
       HashMap::new(),
       Default::default(),
+    );
+
+    css_modules_test(
+      r#"
+      .foo {
+        color: red;
+      }
+
+      #id {
+        animation: 2s test;
+      }
+
+      @keyframes test {
+        from { color: red }
+        to { color: yellow }
+      }
+    "#,
+      indoc! {r#"
+      .EgL3uq_foo {
+        color: red;
+      }
+
+      #EgL3uq_id {
+        animation: 2s test;
+      }
+
+      @keyframes test {
+        from {
+          color: red;
+        }
+
+        to {
+          color: #ff0;
+        }
+      }
+    "#},
+      map! {
+        "foo" => "EgL3uq_foo",
+        "id" => "EgL3uq_id",
+        "test" => "EgL3uq_test" referenced: true
+      },
+      HashMap::new(),
+      crate::css_modules::Config {
+        animation: false,
+        // custom_idents: false,
+        ..Default::default()
+      },
     );
 
     #[cfg(feature = "grid")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23090,8 +23090,7 @@ mod tests {
     "#},
       map! {
         "foo" => "EgL3uq_foo",
-        "id" => "EgL3uq_id",
-        "test" => "EgL3uq_test" referenced: true
+        "id" => "EgL3uq_id"
       },
       HashMap::new(),
       crate::css_modules::Config {

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -289,38 +289,47 @@ impl<'a, 'b, 'c, W: std::fmt::Write + Sized> Printer<'a, 'b, 'c, W> {
 
         css_module.add_local(&ident, &ident, self.loc.source_index);
       } else {
-        serialize_identifier(ident, self)?;
+        serialize_identifier(ident, self)?
       }
     } else {
-      serialize_identifier(ident, self)?;
+      serialize_identifier(ident, self)?
     }
 
     Ok(())
   }
 
-  pub(crate) fn write_dashed_ident(&mut self, ident: &str, is_declaration: bool) -> Result<(), PrinterError> {
+  pub(crate) fn write_dashed_ident(
+    &mut self,
+    ident: &str,
+    is_declaration: bool,
+    handle_css_module: bool,
+  ) -> Result<(), PrinterError> {
     self.write_str("--")?;
 
-    match &mut self.css_module {
-      Some(css_module) if css_module.config.dashed_idents => {
-        let dest = &mut self.dest;
-        css_module.config.pattern.write(
-          &css_module.hashes[self.loc.source_index as usize],
-          &css_module.sources[self.loc.source_index as usize],
-          &ident[2..],
-          |s| {
-            self.col += s.len() as u32;
-            serialize_name(s, dest)
-          },
-        )?;
+    if handle_css_module {
+      match &mut self.css_module {
+        Some(css_module) if css_module.config.dashed_idents => {
+          let dest = &mut self.dest;
+          css_module.config.pattern.write(
+            &css_module.hashes[self.loc.source_index as usize],
+            &css_module.sources[self.loc.source_index as usize],
+            &ident[2..],
+            |s| {
+              self.col += s.len() as u32;
+              serialize_name(s, dest)
+            },
+          )?;
 
-        if is_declaration {
-          css_module.add_dashed(ident, self.loc.source_index);
+          if is_declaration {
+            css_module.add_dashed(ident, self.loc.source_index);
+          }
+        }
+        _ => {
+          serialize_name(&ident[2..], self)?;
         }
       }
-      _ => {
-        serialize_name(&ident[2..], self)?;
-      }
+    } else {
+      serialize_name(&ident[2..], self)?;
     }
 
     Ok(())

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -288,48 +288,37 @@ impl<'a, 'b, 'c, W: std::fmt::Write + Sized> Printer<'a, 'b, 'c, W> {
         )?;
 
         css_module.add_local(&ident, &ident, self.loc.source_index);
-      } else {
-        serialize_identifier(ident, self)?
+        return Ok(());
       }
-    } else {
-      serialize_identifier(ident, self)?
     }
 
+    serialize_identifier(ident, self)?;
     Ok(())
   }
 
-  pub(crate) fn write_dashed_ident(
-    &mut self,
-    ident: &str,
-    is_declaration: bool,
-    handle_css_module: bool,
-  ) -> Result<(), PrinterError> {
+  pub(crate) fn write_dashed_ident(&mut self, ident: &str, is_declaration: bool) -> Result<(), PrinterError> {
     self.write_str("--")?;
 
-    if handle_css_module {
-      match &mut self.css_module {
-        Some(css_module) if css_module.config.dashed_idents => {
-          let dest = &mut self.dest;
-          css_module.config.pattern.write(
-            &css_module.hashes[self.loc.source_index as usize],
-            &css_module.sources[self.loc.source_index as usize],
-            &ident[2..],
-            |s| {
-              self.col += s.len() as u32;
-              serialize_name(s, dest)
-            },
-          )?;
+    match &mut self.css_module {
+      Some(css_module) if css_module.config.dashed_idents => {
+        let dest = &mut self.dest;
+        css_module.config.pattern.write(
+          &css_module.hashes[self.loc.source_index as usize],
+          &css_module.sources[self.loc.source_index as usize],
+          &ident[2..],
+          |s| {
+            self.col += s.len() as u32;
+            serialize_name(s, dest)
+          },
+        )?;
 
-          if is_declaration {
-            css_module.add_dashed(ident, self.loc.source_index);
-          }
-        }
-        _ => {
-          serialize_name(&ident[2..], self)?;
+        if is_declaration {
+          css_module.add_dashed(ident, self.loc.source_index);
         }
       }
-    } else {
-      serialize_name(&ident[2..], self)?;
+      _ => {
+        serialize_name(&ident[2..], self)?;
+      }
     }
 
     Ok(())

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -267,26 +267,30 @@ impl<'a, 'b, 'c, W: std::fmt::Write + Sized> Printer<'a, 'b, 'c, W> {
   /// Writes a CSS identifier to the underlying destination, escaping it
   /// as appropriate. If the `css_modules` option was enabled, then a hash
   /// is added, and the mapping is added to the CSS module.
-  pub fn write_ident(&mut self, ident: &str) -> Result<(), PrinterError> {
-    if let Some(css_module) = &mut self.css_module {
-      let dest = &mut self.dest;
-      let mut first = true;
-      css_module.config.pattern.write(
-        &css_module.hashes[self.loc.source_index as usize],
-        &css_module.sources[self.loc.source_index as usize],
-        ident,
-        |s| {
-          self.col += s.len() as u32;
-          if first {
-            first = false;
-            serialize_identifier(s, dest)
-          } else {
-            serialize_name(s, dest)
-          }
-        },
-      )?;
+  pub fn write_ident(&mut self, ident: &str, handle_css_module: bool) -> Result<(), PrinterError> {
+    if handle_css_module {
+      if let Some(css_module) = &mut self.css_module {
+        let dest = &mut self.dest;
+        let mut first = true;
+        css_module.config.pattern.write(
+          &css_module.hashes[self.loc.source_index as usize],
+          &css_module.sources[self.loc.source_index as usize],
+          ident,
+          |s| {
+            self.col += s.len() as u32;
+            if first {
+              first = false;
+              serialize_identifier(s, dest)
+            } else {
+              serialize_name(s, dest)
+            }
+          },
+        )?;
 
-      css_module.add_local(&ident, &ident, self.loc.source_index);
+        css_module.add_local(&ident, &ident, self.loc.source_index);
+      } else {
+        serialize_identifier(ident, self)?;
+      }
     } else {
       serialize_identifier(ident, self)?;
     }

--- a/src/properties/animation.rs
+++ b/src/properties/animation.rs
@@ -67,7 +67,9 @@ impl<'i> ToCss for AnimationName<'i> {
         s.to_css(dest)
       }
       AnimationName::String(s) => {
+        let mut css_module_animation_enabled = false;
         if let Some(css_module) = &mut dest.css_module {
+          css_module_animation_enabled = css_module.config.animation;
           css_module.reference(&s, dest.loc.source_index)
         }
 
@@ -78,7 +80,7 @@ impl<'i> ToCss for AnimationName<'i> {
             Ok(())
           },
           _ => {
-            dest.write_ident(s.as_ref())
+            dest.write_ident(s.as_ref(), css_module_animation_enabled)
           }
         }
       }

--- a/src/properties/animation.rs
+++ b/src/properties/animation.rs
@@ -58,19 +58,22 @@ impl<'i> ToCss for AnimationName<'i> {
   where
     W: std::fmt::Write,
   {
+    let css_module_animation_enabled =
+      dest.css_module.as_mut().map_or(false, |css_module| css_module.config.animation);
+
     match self {
       AnimationName::None => dest.write_str("none"),
       AnimationName::Ident(s) => {
         if let Some(css_module) = &mut dest.css_module {
           css_module.reference(&s.0, dest.loc.source_index)
         }
-        s.to_css(dest)
+        s.to_css_with_options(dest, css_module_animation_enabled)
       }
       AnimationName::String(s) => {
-        let mut css_module_animation_enabled = false;
-        if let Some(css_module) = &mut dest.css_module {
-          css_module_animation_enabled = css_module.config.animation;
-          css_module.reference(&s, dest.loc.source_index)
+        if css_module_animation_enabled {
+          if let Some(css_module) = &mut dest.css_module {
+            css_module.reference(&s, dest.loc.source_index)
+          }
         }
 
         // CSS-wide keywords and `none` cannot remove quotes.

--- a/src/properties/animation.rs
+++ b/src/properties/animation.rs
@@ -59,13 +59,15 @@ impl<'i> ToCss for AnimationName<'i> {
     W: std::fmt::Write,
   {
     let css_module_animation_enabled =
-      dest.css_module.as_mut().map_or(false, |css_module| css_module.config.animation);
+      dest.css_module.as_ref().map_or(false, |css_module| css_module.config.animation);
 
     match self {
       AnimationName::None => dest.write_str("none"),
       AnimationName::Ident(s) => {
-        if let Some(css_module) = &mut dest.css_module {
-          css_module.reference(&s.0, dest.loc.source_index)
+        if css_module_animation_enabled {
+          if let Some(css_module) = &mut dest.css_module {
+            css_module.reference(&s.0, dest.loc.source_index)
+          }
         }
         s.to_css_with_options(dest, css_module_animation_enabled)
       }

--- a/src/properties/grid.rs
+++ b/src/properties/grid.rs
@@ -430,19 +430,22 @@ fn write_ident<W>(name: &str, dest: &mut Printer<W>) -> Result<(), PrinterError>
 where
   W: std::fmt::Write,
 {
-  let mut css_module_grid_enabled = false;
-  if let Some(css_module) = &mut dest.css_module {
-    css_module_grid_enabled = css_module.config.grid;
-    if let Some(last) = css_module.config.pattern.segments.last() {
-      if !matches!(last, crate::css_modules::Segment::Local) {
-        return Err(Error {
-          kind: PrinterErrorKind::InvalidCssModulesPatternInGrid,
-          loc: Some(ErrorLocation {
-            filename: dest.filename().into(),
-            line: dest.loc.line,
-            column: dest.loc.column,
-          }),
-        });
+  let css_module_grid_enabled = dest.css_module.as_mut().map_or(false, |css_module| css_module.config.grid);
+  if css_module_grid_enabled {
+    if let Some(css_module) = &mut dest.css_module {
+      if css_module_grid_enabled {
+        if let Some(last) = css_module.config.pattern.segments.last() {
+          if !matches!(last, crate::css_modules::Segment::Local) {
+            return Err(Error {
+              kind: PrinterErrorKind::InvalidCssModulesPatternInGrid,
+              loc: Some(ErrorLocation {
+                filename: dest.filename().into(),
+                line: dest.loc.line,
+                column: dest.loc.column,
+              }),
+            });
+          }
+        }
       }
     }
   }

--- a/src/properties/grid.rs
+++ b/src/properties/grid.rs
@@ -430,21 +430,19 @@ fn write_ident<W>(name: &str, dest: &mut Printer<W>) -> Result<(), PrinterError>
 where
   W: std::fmt::Write,
 {
-  let css_module_grid_enabled = dest.css_module.as_mut().map_or(false, |css_module| css_module.config.grid);
+  let css_module_grid_enabled = dest.css_module.as_ref().map_or(false, |css_module| css_module.config.grid);
   if css_module_grid_enabled {
     if let Some(css_module) = &mut dest.css_module {
-      if css_module_grid_enabled {
-        if let Some(last) = css_module.config.pattern.segments.last() {
-          if !matches!(last, crate::css_modules::Segment::Local) {
-            return Err(Error {
-              kind: PrinterErrorKind::InvalidCssModulesPatternInGrid,
-              loc: Some(ErrorLocation {
-                filename: dest.filename().into(),
-                line: dest.loc.line,
-                column: dest.loc.column,
-              }),
-            });
-          }
+      if let Some(last) = css_module.config.pattern.segments.last() {
+        if !matches!(last, crate::css_modules::Segment::Local) {
+          return Err(Error {
+            kind: PrinterErrorKind::InvalidCssModulesPatternInGrid,
+            loc: Some(ErrorLocation {
+              filename: dest.filename().into(),
+              line: dest.loc.line,
+              column: dest.loc.column,
+            }),
+          });
         }
       }
     }

--- a/src/properties/grid.rs
+++ b/src/properties/grid.rs
@@ -430,7 +430,9 @@ fn write_ident<W>(name: &str, dest: &mut Printer<W>) -> Result<(), PrinterError>
 where
   W: std::fmt::Write,
 {
+  let mut css_module_grid_enabled = false;
   if let Some(css_module) = &mut dest.css_module {
+    css_module_grid_enabled = css_module.config.grid;
     if let Some(last) = css_module.config.pattern.segments.last() {
       if !matches!(last, crate::css_modules::Segment::Local) {
         return Err(Error {
@@ -444,7 +446,7 @@ where
       }
     }
   }
-  dest.write_ident(name)?;
+  dest.write_ident(name, css_module_grid_enabled)?;
   Ok(())
 }
 

--- a/src/rules/keyframes.rs
+++ b/src/rules/keyframes.rs
@@ -93,7 +93,7 @@ impl<'i> ToCss for KeyframesName<'i> {
     W: std::fmt::Write,
   {
     let css_module_animation_enabled =
-      dest.css_module.as_mut().map_or(false, |css_module| css_module.config.animation);
+      dest.css_module.as_ref().map_or(false, |css_module| css_module.config.animation);
 
     match self {
       KeyframesName::Ident(ident) => {

--- a/src/rules/keyframes.rs
+++ b/src/rules/keyframes.rs
@@ -92,9 +92,12 @@ impl<'i> ToCss for KeyframesName<'i> {
   where
     W: std::fmt::Write,
   {
+    let css_module_animation_enabled =
+      dest.css_module.as_mut().map_or(false, |css_module| css_module.config.animation);
+
     match self {
       KeyframesName::Ident(ident) => {
-        dest.write_ident(ident.0.as_ref())?;
+        dest.write_ident(ident.0.as_ref(), css_module_animation_enabled)?;
       }
       KeyframesName::Custom(s) => {
         // CSS-wide keywords and `none` cannot remove quotes.
@@ -103,7 +106,7 @@ impl<'i> ToCss for KeyframesName<'i> {
             serialize_string(&s, dest)?;
           },
           _ => {
-            dest.write_ident(s.as_ref())?;
+            dest.write_ident(s.as_ref(), css_module_animation_enabled)?;
           }
         }
       }

--- a/src/selector.rs
+++ b/src/selector.rs
@@ -672,7 +672,7 @@ where
 
       if let Some(class) = class {
         dest.write_char('.')?;
-        dest.write_ident(class)
+        dest.write_ident(class, true)
       } else {
         dest.write_str($s)
       }
@@ -1551,11 +1551,11 @@ where
     Component::Nesting => serialize_nesting(dest, context, false),
     Component::Class(ref class) => {
       dest.write_char('.')?;
-      dest.write_ident(&class.0)
+      dest.write_ident(&class.0, true)
     }
     Component::ID(ref id) => {
       dest.write_char('#')?;
-      dest.write_ident(&id.0)
+      dest.write_ident(&id.0, true)
     }
     Component::Host(selector) => {
       dest.write_str(":host")?;

--- a/src/values/ident.rs
+++ b/src/values/ident.rs
@@ -49,11 +49,29 @@ impl<'i> ToCss for CustomIdent<'i> {
   where
     W: std::fmt::Write,
   {
-    let css_module_custom_idents_enabled = dest
-      .css_module
-      .as_mut()
-      .map_or(false, |css_module| css_module.config.custom_idents);
-    dest.write_ident(&self.0, css_module_custom_idents_enabled)
+    self.to_css_with_options(dest, true)
+  }
+}
+
+impl<'i> CustomIdent<'i> {
+  /// Write the custom ident to CSS.
+  pub fn to_css_with_options<W>(
+    &self,
+    dest: &mut Printer<W>,
+    enabled_css_modules: bool,
+  ) -> Result<(), PrinterError>
+  where
+    W: std::fmt::Write,
+  {
+    if enabled_css_modules {
+      let css_module_custom_idents_enabled = dest
+        .css_module
+        .as_mut()
+        .map_or(false, |css_module| css_module.config.custom_idents);
+      dest.write_ident(&self.0, css_module_custom_idents_enabled)
+    } else {
+      dest.write_ident(&self.0, false)
+    }
   }
 }
 

--- a/src/values/ident.rs
+++ b/src/values/ident.rs
@@ -49,7 +49,11 @@ impl<'i> ToCss for CustomIdent<'i> {
   where
     W: std::fmt::Write,
   {
-    dest.write_ident(&self.0)
+    let css_module_custom_idents_enabled = dest
+      .css_module
+      .as_mut()
+      .map_or(false, |css_module| css_module.config.custom_idents);
+    dest.write_ident(&self.0, css_module_custom_idents_enabled)
   }
 }
 

--- a/website/pages/css-modules.md
+++ b/website/pages/css-modules.md
@@ -13,16 +13,16 @@ CSS modules treat the classes defined in each file as unique. Each class name or
 To enable CSS modules, provide the `cssModules` option when calling the Lightning CSS API. When using the CLI, enable the `--css-modules` flag.
 
 ```js
-import { transform } from 'lightningcss';
+import {transform} from 'lightningcss';
 
-let { code, map, exports } = transform({
+let {code, map, exports} = transform({
   // ...
   cssModules: true,
   code: Buffer.from(`
     .logo {
       background: skyblue;
     }
-  `)
+  `),
 });
 ```
 
@@ -89,7 +89,7 @@ You can also reference class names defined in a different CSS file using the `fr
 
 ```css
 .logo {
-  composes: bg-indigo from "./colors.module.css";
+  composes: bg-indigo from './colors.module.css';
 }
 ```
 
@@ -150,10 +150,10 @@ compiles to:
 By default, class names, id selectors, and the names of `@keyframes`, `@counter-style`, and CSS grid lines and areas are scoped to the module they are defined in. Scoping for CSS variables and other [`<dashed-ident>`](https://www.w3.org/TR/css-values-4/#dashed-idents) names can also be enabled using the `dashedIdents` option when calling the Lightning CSS API. When using the CLI, enable the `--css-modules-dashed-idents` flag.
 
 ```js
-let { code, map, exports } = transform({
+let {code, map, exports} = transform({
   // ...
   cssModules: {
-    dashedIdents: true
+    dashedIdents: true,
   },
 });
 ```
@@ -186,7 +186,7 @@ You can also reference variables defined in other files using the `from` keyword
 
 ```css
 .button {
-  background: var(--accent-color from "./vars.module.css");
+  background: var(--accent-color from './vars.module.css');
 }
 ```
 
@@ -207,19 +207,19 @@ By default, Lightning CSS prepends the hash of the filename to each class name a
 A pattern is a string with placeholders that will be filled in by Lightning CSS. This allows you to add custom prefixes or adjust the naming convention for scoped classes.
 
 ```js
-let { code, map, exports } = transform({
+let {code, map, exports} = transform({
   // ...
   cssModules: {
-    pattern: 'my-company-[name]-[hash]-[local]'
-  }
+    pattern: 'my-company-[name]-[hash]-[local]',
+  },
 });
 ```
 
 The following placeholders are currently supported:
 
-* `[name]` - The base name of the file, without the extension.
-* `[hash]` - A hash of the full file path.
-* `[local]` - The original class name or identifier.
+- `[name]` - The base name of the file, without the extension.
+- `[hash]` - A hash of the full file path.
+- `[local]` - The original class name or identifier.
 
 <div class="warning">
 
@@ -231,7 +231,7 @@ The following placeholders are currently supported:
 let { code, map, exports } = transform({
   // ...
   cssModules: {
-    // ❌ [local] must be at the end so that 
+    // ❌ [local] must be at the end so that
     // auto-generated grid line names work
     pattern: '[local]-[hash]'
     // ✅ do this instead
@@ -242,7 +242,7 @@ let { code, map, exports } = transform({
 
 ```css
 .grid {
-  grid-template-areas: "nav main";
+  grid-template-areas: 'nav main';
 }
 
 .nav {
@@ -252,10 +252,25 @@ let { code, map, exports } = transform({
 
 </div>
 
+## Turning off feature scoping
+
+Scoping of grid, animations, and custom identifiers can be turned off. By default all of these are scoped.
+
+```js
+let {code, map, exports} = transform({
+  // ...
+  cssModules: {
+    animation: true,
+    grid: true,
+    customIdents: true,
+  },
+});
+```
+
 ## Unsupported features
 
 Lightning CSS does not currently implement all CSS modules features available in other implementations. Some of these may be added in the future.
 
-* Non-function syntax for the `:local` and `:global` pseudo classes.
-* The `@value` rule – superseded by standard CSS variables.
-* The `:import` and `:export` ICSS rules.
+- Non-function syntax for the `:local` and `:global` pseudo classes.
+- The `@value` rule – superseded by standard CSS variables.
+- The `:import` and `:export` ICSS rules.


### PR DESCRIPTION
## Change in this PR

Adds granular options to switch on/off CSS module scoping for CSS features that are prefixed by default in Lightning CSS currently. For example animation, grid, and custom identifiers.

```js
let { code, map, exports } = transform({
  // ...
  cssModules: {
    animation: true,
    grid: true,
    customIdents: true,
  }
});
```

The reason this is useful is that for example Webpack's CSS modules implementation does not do prefixing of `grid`. If you're migrating to Lightning CSS, like we're doing in Next.js / Turbopack it's helpful to disable the grid prefixing feature to ensure people have a smooth experience migrating.

### Last test failure

The PR is mostly done, just one more case with `animation: false` where it somehow uses `CustomIdent` which in turn means it still prefixes.

![CleanShot 2024-05-12 at 23 12 33@2x](https://github.com/parcel-bundler/lightningcss/assets/6324199/20bb378a-e634-4573-8a4e-55e336cd5626)

### PR feedback

I'm not proficient in writing Rust currently, using working on these smaller changes in Turbopack and other deps of Turbopack to learn as well, let me know if anything should be changed 👍

### Improved `assert_eq` failure reports in tests

While investigating mismatches it was quite hard to read the `assert_eq` for these outputs when they mismatch. Added `pretty_assertions` to add much better diffs for these cases:

Before:

![CleanShot 2024-05-12 at 23 17 36@2x](https://github.com/parcel-bundler/lightningcss/assets/6324199/150424a9-e723-4332-836c-366d43ec1c59)

After:

![CleanShot 2024-05-12 at 23 18 21@2x](https://github.com/parcel-bundler/lightningcss/assets/6324199/e14f0622-f279-4f53-bc9c-b86cd2ff2c3a)



