### PR TITLE
update broken selectors link in homepage

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -170,7 +170,7 @@
       <section class="parser">
         <div>
           <h3>Browser grade</h3>
-          <p><strong>Lightning CSS is written in Rust, using the <a href="https://github.com/servo/rust-cssparser" target="_blank">cssparser</a> and <a href="https://github.com/servo/servo/tree/master/components/selectors" target="_blank">selectors</a> crates created by Mozilla and used by Firefox.</strong> These provide a solid CSS-parsing foundation on top of which Lightning CSS implements support for all specific CSS rules and properties.</p>
+          <p><strong>Lightning CSS is written in Rust, using the <a href="https://github.com/servo/rust-cssparser" target="_blank">cssparser</a> and <a href="https://github.com/servo/stylo/tree/main/selectors" target="_blank">selectors</a> crates created by Mozilla and used by Firefox.</strong> These provide a solid CSS-parsing foundation on top of which Lightning CSS implements support for all specific CSS rules and properties.</p>
           <p style="font-size: 0.85em">Lightning CSS fully parses every CSS rule, property, and value just as a browser would. This reduces duplicate work for transformers, leading to improved performance and minification.</p>
           <p><a href="transforms.html">Custom transforms →</a></p>
         </div>


### PR DESCRIPTION
The link at the bottom of the [Lightning CSS home page](https://lightningcss.dev/) is broken. I updated it to reflect the current location of selector logic

old link: https://github.com/servo/servo/tree/main/components/selectors
new link: https://github.com/servo/stylo/tree/main/selectors

![The main branch of servo does not contain the path components/selectors.](https://github.com/parcel-bundler/lightningcss/assets/78604367/0025c75f-7a77-4bb0-8bdb-5eb56219b437)
