### PR TITLE
feat: add wasm file to file exports

### DIFF
--- a/scripts/build-wasm.js
+++ b/scripts/build-wasm.js
@@ -54,14 +54,23 @@ wasmPkg.type = 'module';
 wasmPkg.main = 'index.mjs';
 wasmPkg.module = 'index.mjs';
 wasmPkg.exports = {
-  types: './index.d.ts',
-  node: {
-    import: './wasm-node.mjs',
-    require: './wasm-node.cjs',
+  '.': {
+    types: './index.d.ts',
+    node: {
+      import: './wasm-node.mjs',
+      require: './wasm-node.cjs'
+    },
+    default: {
+      import: './index.mjs',
+      require: './index.cjs'
+    }
   },
-  default: {
-    import: './index.mjs',
-    require: './index.cjs',
+  // Allow esbuild to import the wasm file 
+  // without copying it in the src directory.
+  // Simplifies loading it in the browser when used in a library.
+  './lightningcss_node.wasm': {
+    import: './lightningcss_node.wasm',
+    require: './lightningcss_node.wasm'
   }
 };
 wasmPkg.types = 'index.d.ts';


### PR DESCRIPTION
This pull request adds the wasm file to the file exports. It allows esbuild to import the wasm file without copying it in the src directory, simplifying loading it in the browser when used in a library.

## Use case

The tool I help maintain, updates CSS on the fly. Using lightningCSS in the browser was surprisingly easy.

The only true issue I had was init. When I run the init function:

```js
import initLightningCSS from 'lightningcss-wasm'

async function whereItsUsed(){
  await initLightningCSS()
  // ... the rest
}
```

I get an error about invalid URL when creating a URL object. Indeed, since I bundle using esbuild, `import.meta.url` is null. The `wasm` file cannot be resolved.

**Fortunately** the function accepts a parameter to tell it where the asset might be. This url is inside of `node_modules` which should not be accessed by the server directly. But **static assets** can be nhandled very well in ESBuild using imports. If you import a file that is marked as a static asset it will copy it into the assets directory and update its url in the code.

Last step: I needed to import the wasm in my file and "voila", problem solved!... 

```js
import initLightningCSS from 'lightningcss-wasm'
import lightningCSSurl from 'lightningcss-wasm/lightningcss_node.wasm'

async function whereItsUsed(){
  await initLightningCSS(lightningCSSurl)
  // ... the rest
}
```

But... since ESBuild stricty respects esm, given the exports property in the current `package.json` one cannot import the wasm file without getting an error.

Hence my very naive PR to add the export to the list.

If you have any question, I'll be happy to answer them here.