### PR TITLE
fix: Fix codegen of `:is(input:checked)`

### DIFF
--- a/src/selector.rs
+++ b/src/selector.rs
@@ -1624,8 +1624,13 @@ where
 
 #[inline]
 fn has_type_selector(selector: &Selector) -> bool {
-  let mut iter = selector.iter_raw_parse_order_from(0);
+  // For input:checked the component vector is
+  // [input, :checked] so we have to check it using matching order.
+  //
+  // This both happens for input:checked and is(input:checked)
+  let mut iter = selector.iter_raw_match_order();
   let first = iter.next();
+
   if is_namespace(first) {
     is_type_selector(iter.next())
   } else {

--- a/tests/cli_integration_tests.rs
+++ b/tests/cli_integration_tests.rs
@@ -759,3 +759,26 @@ fn browserslist_environment_from_browserslist_env() -> Result<(), Box<dyn std::e
 
   Ok(())
 }
+
+#[test]
+fn next_66191() -> Result<(), Box<dyn std::error::Error>> {
+  let infile = assert_fs::NamedTempFile::new("test.css")?;
+  infile.write_str(
+    r#"
+      .cb:is(input:checked) {
+        margin: 3rem;
+      }
+    "#,
+  )?;
+  let outfile = assert_fs::NamedTempFile::new("test.out")?;
+  let mut cmd = Command::cargo_bin("lightningcss")?;
+  cmd.arg(infile.path());
+  cmd.arg("--output-file").arg(outfile.path());
+  cmd.assert().success();
+  outfile.assert(predicate::str::contains(indoc! {r#"
+        .cb:is(input:checked) {
+          margin: 3rem;
+      }"#}));
+
+  Ok(())
+}

--- a/tests/cli_integration_tests.rs
+++ b/tests/cli_integration_tests.rs
@@ -775,10 +775,7 @@ fn next_66191() -> Result<(), Box<dyn std::error::Error>> {
   cmd.arg(infile.path());
   cmd.arg("--output-file").arg(outfile.path());
   cmd.assert().success();
-  outfile.assert(predicate::str::contains(indoc! {r#"
-        .cb:is(input:checked) {
-          margin: 3rem;
-      }"#}));
+  outfile.assert(predicate::str::contains(indoc! {r#".cb:is(input:checked)"#}));
 
   Ok(())
 }


### PR DESCRIPTION
 - See: https://github.com/vercel/next.js/issues/66191
 - Closes https://github.com/parcel-bundler/lightningcss/issues/661