### PR TITLE
feat: Add a lint for unsupported CSS Module selector

### DIFF
--- a/selectors/parser.rs
+++ b/selectors/parser.rs
@@ -198,6 +198,7 @@ pub enum SelectorParseErrorKind<'i> {
   UnexpectedTokenInAttributeSelector(Token<'i>),
   PseudoElementExpectedIdent(Token<'i>),
   UnsupportedPseudoClassOrElement(CowRcStr<'i>),
+  AmbiguosCssModuleClass(CowRcStr<'i>),
   UnexpectedIdent(CowRcStr<'i>),
   ExpectedNamespace(CowRcStr<'i>),
   ExpectedBarInAttr(Token<'i>),

--- a/selectors/parser.rs
+++ b/selectors/parser.rs
@@ -198,7 +198,7 @@ pub enum SelectorParseErrorKind<'i> {
   UnexpectedTokenInAttributeSelector(Token<'i>),
   PseudoElementExpectedIdent(Token<'i>),
   UnsupportedPseudoClassOrElement(CowRcStr<'i>),
-  AmbiguosCssModuleClass(CowRcStr<'i>),
+  AmbiguousCssModuleClass(CowRcStr<'i>),
   UnexpectedIdent(CowRcStr<'i>),
   ExpectedNamespace(CowRcStr<'i>),
   ExpectedBarInAttr(Token<'i>),

--- a/src/error.rs
+++ b/src/error.rs
@@ -234,7 +234,7 @@ pub enum SelectorError<'i> {
   UnsupportedPseudoClassOrElement(CowArcStr<'i>),
 
   /// Ambiguous CSS module class.
-  AmbiguosCssModuleClass(CowArcStr<'i>),
+  AmbiguousCssModuleClass(CowArcStr<'i>),
 }
 
 impl<'i> fmt::Display for SelectorError<'i> {
@@ -260,7 +260,7 @@ impl<'i> fmt::Display for SelectorError<'i> {
       UnexpectedIdent(name) => write!(f, "Unexpected identifier: {}", name),
       UnexpectedTokenInAttributeSelector(token) => write!(f, "Unexpected token in attribute selector: {:?}", token),
       UnsupportedPseudoClassOrElement(name) => write!(f, "Unsupported pseudo class or element: {}", name),
-      AmbiguosCssModuleClass(_) => write!(f, "Ambiguous CSS module class not supoorted"),
+      AmbiguousCssModuleClass(_) => write!(f, "Ambiguous CSS module class not supoorted"),
     }
   }
 }
@@ -301,7 +301,7 @@ impl<'i> From<SelectorParseErrorKind<'i>> for SelectorError<'i> {
         SelectorError::ExplicitNamespaceUnexpectedToken(t.into())
       }
       SelectorParseErrorKind::ClassNeedsIdent(t) => SelectorError::ClassNeedsIdent(t.into()),
-      SelectorParseErrorKind::AmbiguosCssModuleClass(name) => SelectorError::AmbiguosCssModuleClass(name.into()),
+      SelectorParseErrorKind::AmbiguousCssModuleClass(name) => SelectorError::AmbiguousCssModuleClass(name.into()),
     }
   }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -232,6 +232,9 @@ pub enum SelectorError<'i> {
   ),
   /// An unsupported pseudo class or pseudo element was encountered.
   UnsupportedPseudoClassOrElement(CowArcStr<'i>),
+
+  /// Ambiguous CSS module class.
+  AmbiguosCssModuleClass(CowArcStr<'i>),
 }
 
 impl<'i> fmt::Display for SelectorError<'i> {
@@ -257,6 +260,7 @@ impl<'i> fmt::Display for SelectorError<'i> {
       UnexpectedIdent(name) => write!(f, "Unexpected identifier: {}", name),
       UnexpectedTokenInAttributeSelector(token) => write!(f, "Unexpected token in attribute selector: {:?}", token),
       UnsupportedPseudoClassOrElement(name) => write!(f, "Unsupported pseudo class or element: {}", name),
+      AmbiguosCssModuleClass(_) => write!(f, "Ambiguous CSS module class not supoorted"),
     }
   }
 }
@@ -297,6 +301,7 @@ impl<'i> From<SelectorParseErrorKind<'i>> for SelectorError<'i> {
         SelectorError::ExplicitNamespaceUnexpectedToken(t.into())
       }
       SelectorParseErrorKind::ClassNeedsIdent(t) => SelectorError::ClassNeedsIdent(t.into()),
+      SelectorParseErrorKind::AmbiguosCssModuleClass(name) => SelectorError::AmbiguosCssModuleClass(name.into()),
     }
   }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -260,7 +260,7 @@ impl<'i> fmt::Display for SelectorError<'i> {
       UnexpectedIdent(name) => write!(f, "Unexpected identifier: {}", name),
       UnexpectedTokenInAttributeSelector(token) => write!(f, "Unexpected token in attribute selector: {:?}", token),
       UnsupportedPseudoClassOrElement(name) => write!(f, "Unsupported pseudo class or element: {}", name),
-      AmbiguousCssModuleClass(_) => write!(f, "Ambiguous CSS module class not supoorted"),
+      AmbiguousCssModuleClass(_) => write!(f, "Ambiguous CSS module class not supported"),
     }
   }
 }

--- a/src/selector.rs
+++ b/src/selector.rs
@@ -191,7 +191,7 @@ impl<'a, 'o, 'i> parcel_selectors::parser::Parser<'i> for SelectorParser<'a, 'o,
       "window-inactive" => WebKitScrollbar(WebKitScrollbarPseudoClass::WindowInactive),
 
       "local" | "global" => {
-        return Err(loc.new_custom_error(SelectorParseErrorKind::AmbiguosCssModuleClass(name.clone())))
+        return Err(loc.new_custom_error(SelectorParseErrorKind::AmbiguousCssModuleClass(name.clone())))
       },
 
       _ => {

--- a/src/selector.rs
+++ b/src/selector.rs
@@ -190,7 +190,7 @@ impl<'a, 'o, 'i> parcel_selectors::parser::Parser<'i> for SelectorParser<'a, 'o,
       "corner-present" => WebKitScrollbar(WebKitScrollbarPseudoClass::CornerPresent),
       "window-inactive" => WebKitScrollbar(WebKitScrollbarPseudoClass::WindowInactive),
 
-      "local" | "global" => {
+      "local" | "global" if self.options.css_modules.is_some() => {
         return Err(loc.new_custom_error(SelectorParseErrorKind::AmbiguousCssModuleClass(name.clone())))
       },
 

--- a/src/selector.rs
+++ b/src/selector.rs
@@ -190,6 +190,10 @@ impl<'a, 'o, 'i> parcel_selectors::parser::Parser<'i> for SelectorParser<'a, 'o,
       "corner-present" => WebKitScrollbar(WebKitScrollbarPseudoClass::CornerPresent),
       "window-inactive" => WebKitScrollbar(WebKitScrollbarPseudoClass::WindowInactive),
 
+      "local" | "global" => {
+        return Err(loc.new_custom_error(SelectorParseErrorKind::AmbiguosCssModuleClass(name.clone())))
+      },
+
       _ => {
         if !name.starts_with('-') {
           self.options.warn(loc.new_custom_error(SelectorParseErrorKind::UnsupportedPseudoClassOrElement(name.clone())));

--- a/tests/cli_integration_tests.rs
+++ b/tests/cli_integration_tests.rs
@@ -6,7 +6,7 @@ use lightningcss::css_modules::CssModuleExport;
 use predicates::prelude::*;
 use std::collections::HashMap;
 use std::fs;
-use std::process::Command;
+use std::process::{Command, Stdio};
 
 fn test_file() -> Result<assert_fs::NamedTempFile, FixtureError> {
   let file = assert_fs::NamedTempFile::new("test.css")?;
@@ -385,6 +385,37 @@ fn css_modules_pattern() -> Result<(), Box<dyn std::error::Error>> {
   cmd.arg("--css-modules");
   cmd.arg("--css-modules-pattern").arg("[name]-[hash]-[local]");
   cmd.assert().success().stdout(predicate::str::contains("test-EgL3uq-foo"));
+
+  Ok(())
+}
+
+#[test]
+fn css_modules_next_64299() -> Result<(), Box<dyn std::error::Error>> {
+  let file = assert_fs::NamedTempFile::new("test.css")?;
+  file.write_str(
+    "
+  .blue {
+    background: blue;
+
+    :global {
+      .red {
+        background: red;
+      }
+    }
+
+    &:global {
+      &.green {
+        background: green;
+      }
+    }
+  }
+  ",
+  )?;
+
+  let mut cmd = Command::cargo_bin("lightningcss")?;
+  cmd.arg(file.path());
+  cmd.stdout(Stdio::inherit()).stderr(Stdio::inherit());
+  cmd.assert().success();
 
   Ok(())
 }

--- a/tests/cli_integration_tests.rs
+++ b/tests/cli_integration_tests.rs
@@ -6,7 +6,7 @@ use lightningcss::css_modules::CssModuleExport;
 use predicates::prelude::*;
 use std::collections::HashMap;
 use std::fs;
-use std::process::{Command, Stdio};
+use std::process::Command;
 
 fn test_file() -> Result<assert_fs::NamedTempFile, FixtureError> {
   let file = assert_fs::NamedTempFile::new("test.css")?;

--- a/tests/cli_integration_tests.rs
+++ b/tests/cli_integration_tests.rs
@@ -414,7 +414,6 @@ fn css_modules_next_64299() -> Result<(), Box<dyn std::error::Error>> {
 
   let mut cmd = Command::cargo_bin("lightningcss")?;
   cmd.arg(file.path());
-  cmd.stdout(Stdio::inherit()).stderr(Stdio::inherit());
   cmd.assert().failure();
 
   Ok(())

--- a/tests/cli_integration_tests.rs
+++ b/tests/cli_integration_tests.rs
@@ -415,7 +415,7 @@ fn css_modules_next_64299() -> Result<(), Box<dyn std::error::Error>> {
   let mut cmd = Command::cargo_bin("lightningcss")?;
   cmd.arg(file.path());
   cmd.stdout(Stdio::inherit()).stderr(Stdio::inherit());
-  cmd.assert().success();
+  cmd.assert().failure();
 
   Ok(())
 }

--- a/tests/cli_integration_tests.rs
+++ b/tests/cli_integration_tests.rs
@@ -414,6 +414,7 @@ fn css_modules_next_64299() -> Result<(), Box<dyn std::error::Error>> {
 
   let mut cmd = Command::cargo_bin("lightningcss")?;
   cmd.arg(file.path());
+  cmd.arg("--css-modules");
   cmd.assert().failure();
 
   Ok(())


### PR DESCRIPTION
Related: https://github.com/vercel/next.js/issues/64299

I made it a parse error because the specification about it is ambiguous thus it's better to bail out.