### PR TITLE
fix(website): Update copyright year on main page

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -196,7 +196,7 @@
       </section>
     </main>
     <footer>
-      Copyright © 2022 Devon Govett and Parcel Contributors.
+      Copyright © 2024 Devon Govett and Parcel Contributors.
     </footer>
     <style>
       html {


### PR DESCRIPTION
The copyright year is outdated. Simply update it with 2024.