### PR TITLE
feat: Improve error message for pseudo elements followed by selectors

### DIFF
--- a/selectors/parser.rs
+++ b/selectors/parser.rs
@@ -3069,7 +3069,7 @@ where
         };
 
         // Use better error message
-        if let Ok(token @ Token::Ident(..) | token @ Token::IDHash(..)) = token {
+        if let Ok(token @ Token::Ident(..) | token @ Token::IDHash(..) | token @ Token::Delim('.')) = token {
           return Err(source_location.new_custom_error(
             SelectorParseErrorKind::UnexpectedSelectorAfterPseudoElements(token.clone()),
           ));

--- a/selectors/parser.rs
+++ b/selectors/parser.rs
@@ -2637,8 +2637,6 @@ fn parse_attribute_flags<'i, 't>(input: &mut CssParser<'i, 't>) -> Result<Attrib
     }
   };
 
-  dbg!(token);
-
   let ident = match *token {
     Token::Ident(ref i) => i,
     ref other => return Err(location.new_basic_unexpected_token_error(other.clone())),
@@ -2710,9 +2708,6 @@ where
   }
 
   loop {
-    if state.intersects(SelectorParsingState::AFTER_PSEUDO_ELEMENT) {
-      dbg!(&input.current_line());
-    }
     let result = match parse_one_simple_selector(parser, input, state)? {
       None => break,
       Some(result) => result,
@@ -2969,7 +2964,6 @@ where
       return Ok(None);
     }
   };
-  dbg!(&token);
 
   Ok(Some(match token {
     Token::IDHash(id) => {
@@ -3085,7 +3079,6 @@ where
         return Ok(None);
       }
 
-      dbg!(&token);
       input.reset(&start);
       return Ok(None);
     }

--- a/selectors/parser.rs
+++ b/selectors/parser.rs
@@ -206,7 +206,7 @@ pub enum SelectorParseErrorKind<'i> {
   InvalidQualNameInAttr(Token<'i>),
   ExplicitNamespaceUnexpectedToken(Token<'i>),
   ClassNeedsIdent(Token<'i>),
-  UnexpectedTokenAfterPseudoElements(Token<'i>),
+  UnexpectedSelectorAfterPseudoElements(Token<'i>),
 }
 
 macro_rules! with_all_bounds {
@@ -3077,7 +3077,7 @@ where
         // Use better error message
         if let Ok(token @ Token::Ident(..) | token @ Token::IDHash(..)) = token {
           return Err(source_location.new_custom_error(
-            SelectorParseErrorKind::UnexpectedTokenAfterPseudoElements(token.clone()),
+            SelectorParseErrorKind::UnexpectedSelectorAfterPseudoElements(token.clone()),
           ));
         }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -269,7 +269,7 @@ impl<'i> fmt::Display for SelectorError<'i> {
       UnexpectedSelectorAfterPseudoElements(token) => {
         write!(
           f,
-          "Pseudo-elements like '::before' or '::after' can't be followed by selecrors like {token:?}"
+          "Pseudo-elements like '::before' or '::after' can't be followed by selectors like {token:?}"
         )
       },
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -104,6 +104,13 @@ pub enum ParserError<'i> {
   UnexpectedToken(#[cfg_attr(any(feature = "serde", feature = "nodejs"), serde(skip))] Token<'i>),
   /// Maximum nesting depth was reached.
   MaximumNestingDepth,
+  /// Pseudo-elements like "::before" can't be followed by tokens like "h1".
+  ///
+  /// `(pseudo_element_selector, token)`
+  UnexpectedTokenAfterPseudoElements(
+    #[cfg_attr(any(feature = "serde", feature = "nodejs"), serde(skip))] Token<'i>,
+    #[cfg_attr(any(feature = "serde", feature = "nodejs"), serde(skip))] Token<'i>,
+  ),
 }
 
 impl<'i> fmt::Display for ParserError<'i> {
@@ -132,6 +139,12 @@ impl<'i> fmt::Display for ParserError<'i> {
       ),
       UnexpectedToken(token) => write!(f, "Unexpected token {:?}", token),
       MaximumNestingDepth => write!(f, "Overflowed the maximum nesting depth"),
+      UnexpectedTokenAfterPseudoElements(selector, token) => {
+        write!(
+          f,
+          "Pseudo-elements like '{selector:?}' can't be followed by tokens like {token:?}"
+        )
+      }
     }
   }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -269,7 +269,7 @@ impl<'i> fmt::Display for SelectorError<'i> {
       UnexpectedSelectorAfterPseudoElements(token) => {
         write!(
           f,
-          "Pseudo-elements like '::before' or '::after' can't be followed by selectors like {token:?}"
+          "Pseudo-elements like '::before' or '::after' can't be followed by selectors like '{token:?}'"
         )
       },
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -237,7 +237,7 @@ pub enum SelectorError<'i> {
   AmbiguousCssModuleClass(CowArcStr<'i>),
 
   /// An unexpected token was encountered after a pseudo element.
-  UnexpectedSelectorAfterPseudoElements(
+  UnexpectedSelectorAfterPseudoElement(
     #[cfg_attr(any(feature = "serde", feature = "nodejs"), serde(skip))] Token<'i>,
   ),
 }
@@ -266,7 +266,7 @@ impl<'i> fmt::Display for SelectorError<'i> {
       UnexpectedTokenInAttributeSelector(token) => write!(f, "Unexpected token in attribute selector: {:?}", token),
       UnsupportedPseudoClassOrElement(name) => write!(f, "Unsupported pseudo class or element: {}", name),
       AmbiguousCssModuleClass(_) => write!(f, "Ambiguous CSS module class not supported"),
-      UnexpectedSelectorAfterPseudoElements(token) => {
+      UnexpectedSelectorAfterPseudoElement(token) => {
         write!(
           f,
           "Pseudo-elements like '::before' or '::after' can't be followed by selectors like '{token:?}'"
@@ -313,8 +313,8 @@ impl<'i> From<SelectorParseErrorKind<'i>> for SelectorError<'i> {
       }
       SelectorParseErrorKind::ClassNeedsIdent(t) => SelectorError::ClassNeedsIdent(t.into()),
       SelectorParseErrorKind::AmbiguousCssModuleClass(name) => SelectorError::AmbiguousCssModuleClass(name.into()),
-      SelectorParseErrorKind::UnexpectedSelectorAfterPseudoElements(t) => {
-        SelectorError::UnexpectedSelectorAfterPseudoElements(t.into())
+      SelectorParseErrorKind::UnexpectedSelectorAfterPseudoElement(t) => {
+        SelectorError::UnexpectedSelectorAfterPseudoElement(t.into())
       }
     }
   }

--- a/src/error.rs
+++ b/src/error.rs
@@ -141,7 +141,7 @@ impl<'i> Error<ParserError<'i>> {
   pub fn from(err: ParseError<'i, ParserError<'i>>, filename: String) -> Error<ParserError<'i>> {
     let kind = match err.kind {
       ParseErrorKind::Basic(b) => match &b {
-        BasicParseErrorKind::UnexpectedToken(t) => ParserError::UnexpectedToken(dbg!(t).into()),
+        BasicParseErrorKind::UnexpectedToken(t) => ParserError::UnexpectedToken(t.into()),
         BasicParseErrorKind::EndOfInput => ParserError::EndOfInput,
         BasicParseErrorKind::AtRuleInvalid(a) => ParserError::AtRuleInvalid(a.into()),
         BasicParseErrorKind::AtRuleBodyInvalid => ParserError::AtRuleBodyInvalid,

--- a/src/error.rs
+++ b/src/error.rs
@@ -104,12 +104,6 @@ pub enum ParserError<'i> {
   UnexpectedToken(#[cfg_attr(any(feature = "serde", feature = "nodejs"), serde(skip))] Token<'i>),
   /// Maximum nesting depth was reached.
   MaximumNestingDepth,
-  /// Pseudo-elements like "::before" can't be followed by tokens like "h1".
-  ///
-  /// `(token)`
-  UnexpectedTokenAfterPseudoElements(
-    #[cfg_attr(any(feature = "serde", feature = "nodejs"), serde(skip))] Token<'i>,
-  ),
 }
 
 impl<'i> fmt::Display for ParserError<'i> {
@@ -138,12 +132,6 @@ impl<'i> fmt::Display for ParserError<'i> {
       ),
       UnexpectedToken(token) => write!(f, "Unexpected token {:?}", token),
       MaximumNestingDepth => write!(f, "Overflowed the maximum nesting depth"),
-      UnexpectedTokenAfterPseudoElements(token) => {
-        write!(
-          f,
-          "Pseudo-elements like '::before' or '::after' can't be followed by tokens like {token:?}"
-        )
-      }
     }
   }
 }
@@ -249,7 +237,7 @@ pub enum SelectorError<'i> {
   AmbiguousCssModuleClass(CowArcStr<'i>),
 
   /// An unexpected token was encountered after a pseudo element.
-  UnexpectedTokenAfterPseudoElements(
+  UnexpectedSelectorAfterPseudoElements(
     #[cfg_attr(any(feature = "serde", feature = "nodejs"), serde(skip))] Token<'i>,
   ),
 }
@@ -278,7 +266,12 @@ impl<'i> fmt::Display for SelectorError<'i> {
       UnexpectedTokenInAttributeSelector(token) => write!(f, "Unexpected token in attribute selector: {:?}", token),
       UnsupportedPseudoClassOrElement(name) => write!(f, "Unsupported pseudo class or element: {}", name),
       AmbiguousCssModuleClass(_) => write!(f, "Ambiguous CSS module class not supported"),
-      UnexpectedTokenAfterPseudoElements(token) => write!(f, "Unexpected token after pseudo element: {:?}", token),
+      UnexpectedSelectorAfterPseudoElements(token) => {
+        write!(
+          f,
+          "Pseudo-elements like '::before' or '::after' can't be followed by selecrors like {token:?}"
+        )
+      },
     }
   }
 }
@@ -320,8 +313,8 @@ impl<'i> From<SelectorParseErrorKind<'i>> for SelectorError<'i> {
       }
       SelectorParseErrorKind::ClassNeedsIdent(t) => SelectorError::ClassNeedsIdent(t.into()),
       SelectorParseErrorKind::AmbiguousCssModuleClass(name) => SelectorError::AmbiguousCssModuleClass(name.into()),
-      SelectorParseErrorKind::UnexpectedTokenAfterPseudoElements(t) => {
-        SelectorError::UnexpectedTokenAfterPseudoElements(t.into())
+      SelectorParseErrorKind::UnexpectedSelectorAfterPseudoElements(t) => {
+        SelectorError::UnexpectedSelectorAfterPseudoElements(t.into())
       }
     }
   }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6903,21 +6903,41 @@ mod tests {
 
     error_test(
       "input.defaultCheckbox::before h1 {width: 20px}",
-      ParserError::SelectorError(SelectorError::UnexpectedSelectorAfterPseudoElements(Token::Ident(
+      ParserError::SelectorError(SelectorError::UnexpectedSelectorAfterPseudoElement(Token::Ident(
         "h1".into(),
       ))),
     );
-
     error_test(
       "input.defaultCheckbox::before .my-class {width: 20px}",
-      ParserError::SelectorError(SelectorError::UnexpectedSelectorAfterPseudoElements(Token::Delim('.'))),
+      ParserError::SelectorError(SelectorError::UnexpectedSelectorAfterPseudoElement(Token::Delim('.'))),
     );
-
+    error_test(
+      "input.defaultCheckbox::before.my-class {width: 20px}",
+      ParserError::SelectorError(SelectorError::UnexpectedSelectorAfterPseudoElement(Token::Delim('.'))),
+    );
     error_test(
       "input.defaultCheckbox::before #id {width: 20px}",
-      ParserError::SelectorError(SelectorError::UnexpectedSelectorAfterPseudoElements(Token::IDHash(
+      ParserError::SelectorError(SelectorError::UnexpectedSelectorAfterPseudoElement(Token::IDHash(
         "id".into(),
       ))),
+    );
+    error_test(
+      "input.defaultCheckbox::before#id {width: 20px}",
+      ParserError::SelectorError(SelectorError::UnexpectedSelectorAfterPseudoElement(Token::IDHash(
+        "id".into(),
+      ))),
+    );
+    error_test(
+      "input.defaultCheckbox::before [attr] {width: 20px}",
+      ParserError::SelectorError(SelectorError::UnexpectedSelectorAfterPseudoElement(
+        Token::SquareBracketBlock,
+      )),
+    );
+    error_test(
+      "input.defaultCheckbox::before[attr] {width: 20px}",
+      ParserError::SelectorError(SelectorError::UnexpectedSelectorAfterPseudoElement(
+        Token::SquareBracketBlock,
+      )),
     );
   }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6907,6 +6907,18 @@ mod tests {
         "h1".into(),
       ))),
     );
+
+    error_test(
+      "input.defaultCheckbox::before .my-class {width: 20px}",
+      ParserError::SelectorError(SelectorError::UnexpectedSelectorAfterPseudoElements(Token::Delim('.'))),
+    );
+
+    error_test(
+      "input.defaultCheckbox::before #id {width: 20px}",
+      ParserError::SelectorError(SelectorError::UnexpectedSelectorAfterPseudoElements(Token::IDHash(
+        "id".into(),
+      ))),
+    );
   }
 
   #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6903,7 +6903,7 @@ mod tests {
 
     error_test(
       "input.defaultCheckbox::before h1 {width: 20px}",
-      ParserError::UnexpectedTokenAfterPseudoElements(Token::Ident("before".into()), Token::Ident("h1".into())),
+      ParserError::UnexpectedTokenAfterPseudoElements(Token::Ident("h1".into())),
     );
   }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6903,7 +6903,9 @@ mod tests {
 
     error_test(
       "input.defaultCheckbox::before h1 {width: 20px}",
-      ParserError::UnexpectedTokenAfterPseudoElements(Token::Ident("h1".into())),
+      ParserError::SelectorError(SelectorError::UnexpectedSelectorAfterPseudoElements(Token::Ident(
+        "h1".into(),
+      ))),
     );
   }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6900,6 +6900,11 @@ mod tests {
       ".foo /deep/ .bar{width:20px}",
       deep_options.clone(),
     );
+
+    error_test(
+      "input.defaultCheckbox::before h1 {width: 20px}",
+      ParserError::UnexpectedTokenAfterPseudoElements(Token::Ident("before".into()), Token::Ident("h1".into())),
+    );
   }
 
   #[test]

--- a/src/properties/custom.rs
+++ b/src/properties/custom.rs
@@ -346,7 +346,9 @@ impl<'i> TokenList<'i> {
         }
         Ok(token) if token.is_parse_error() => {
           return Err(ParseError {
-            kind: ParseErrorKind::Basic(BasicParseErrorKind::UnexpectedToken(token.clone())),
+            kind: dbg!(ParseErrorKind::Basic(BasicParseErrorKind::UnexpectedToken(
+              token.clone()
+            ))),
             location: state.source_location(),
           })
         }
@@ -480,7 +482,9 @@ impl<'i> TokenList<'i> {
         }
         Ok(token) if token.is_parse_error() => {
           return Err(ParseError {
-            kind: ParseErrorKind::Basic(BasicParseErrorKind::UnexpectedToken(token.clone())),
+            kind: dbg!(ParseErrorKind::Basic(BasicParseErrorKind::UnexpectedToken(
+              token.clone()
+            ))),
             location: state.source_location(),
           })
         }

--- a/src/properties/custom.rs
+++ b/src/properties/custom.rs
@@ -346,9 +346,7 @@ impl<'i> TokenList<'i> {
         }
         Ok(token) if token.is_parse_error() => {
           return Err(ParseError {
-            kind: dbg!(ParseErrorKind::Basic(BasicParseErrorKind::UnexpectedToken(
-              token.clone()
-            ))),
+            kind: ParseErrorKind::Basic(BasicParseErrorKind::UnexpectedToken(token.clone())),
             location: state.source_location(),
           })
         }
@@ -482,9 +480,7 @@ impl<'i> TokenList<'i> {
         }
         Ok(token) if token.is_parse_error() => {
           return Err(ParseError {
-            kind: dbg!(ParseErrorKind::Basic(BasicParseErrorKind::UnexpectedToken(
-              token.clone()
-            ))),
+            kind: ParseErrorKind::Basic(BasicParseErrorKind::UnexpectedToken(token.clone())),
             location: state.source_location(),
           })
         }


### PR DESCRIPTION
The previous error message was not human-readable.

```
Unexpected token Ident("h1")
```
