### PR TITLE
fix: fix `box-shadow` combination of `oklch` and `currentColor`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27841,6 +27841,25 @@ mod tests {
         ..Browsers::default()
       },
     );
+    prefix_test(
+      r#"
+      .foo {
+        box-shadow:
+            oklch(100% 0 0deg / 50%) 0 0.63rem 0.94rem -0.19rem,
+            currentColor 0 0.44rem 0.8rem -0.58rem;
+      }
+    "#,
+      indoc! { r#"
+      .foo {
+        box-shadow: 0 .63rem .94rem -.19rem color(display-p3 1 1 1 / .5), 0 .44rem .8rem -.58rem;
+        box-shadow: 0 .63rem .94rem -.19rem lab(100% 0 0 / .5), 0 .44rem .8rem -.58rem;
+      }
+      "#},
+      Browsers {
+        safari: Some(14 << 16),
+        ..Browsers::default()
+      },
+    );
 
     prefix_test(
       ".foo { color: light-dark(var(--light), var(--dark)); }",

--- a/src/properties/box_shadow.rs
+++ b/src/properties/box_shadow.rs
@@ -225,7 +225,7 @@ impl BoxShadowHandler {
           let p3 = box_shadows
             .iter()
             .map(|shadow| BoxShadow {
-              color: shadow.color.to_p3().unwrap(),
+              color: shadow.color.to_p3().unwrap_or_else(|_| shadow.color.clone()),
               ..shadow.clone()
             })
             .collect();


### PR DESCRIPTION
- closes https://github.com/parcel-bundler/lightningcss/issues/800

I'm not entirely sure but looking at the last PR https://github.com/parcel-bundler/lightningcss/pull/722, it seems `ColorFallbackKind::P3` case's `unwrap` was not handled.