### PR TITLE
feat: Improve error message of `input:placeholder`

### DIFF
--- a/selectors/parser.rs
+++ b/selectors/parser.rs
@@ -337,7 +337,7 @@ pub trait Parser<'i> {
     name: CowRcStr<'i>,
     arguments: &mut CssParser<'i, 't>,
   ) -> Result<<Self::Impl as SelectorImpl<'i>>::PseudoElement, ParseError<'i, Self::Error>> {
-    Err(arguments.new_custom_error(SelectorParseErrorKind::UnsupportedPseudoClass(name)))
+    Err(arguments.new_custom_error(SelectorParseErrorKind::UnsupportedPseudoElement(name)))
   }
 
   fn default_namespace(&self) -> Option<<Self::Impl as SelectorImpl<'i>>::NamespaceUrl> {

--- a/selectors/parser.rs
+++ b/selectors/parser.rs
@@ -197,7 +197,8 @@ pub enum SelectorParseErrorKind<'i> {
   MissingNestingPrefix,
   UnexpectedTokenInAttributeSelector(Token<'i>),
   PseudoElementExpectedIdent(Token<'i>),
-  UnsupportedPseudoClassOrElement(CowRcStr<'i>),
+  UnsupportedPseudoElement(CowRcStr<'i>),
+  UnsupportedPseudoClass(CowRcStr<'i>),
   AmbiguousCssModuleClass(CowRcStr<'i>),
   UnexpectedIdent(CowRcStr<'i>),
   ExpectedNamespace(CowRcStr<'i>),
@@ -312,7 +313,7 @@ pub trait Parser<'i> {
     location: SourceLocation,
     name: CowRcStr<'i>,
   ) -> Result<<Self::Impl as SelectorImpl<'i>>::NonTSPseudoClass, ParseError<'i, Self::Error>> {
-    Err(location.new_custom_error(SelectorParseErrorKind::UnsupportedPseudoClassOrElement(name)))
+    Err(location.new_custom_error(SelectorParseErrorKind::UnsupportedPseudoClass(name)))
   }
 
   fn parse_non_ts_functional_pseudo_class<'t>(
@@ -320,7 +321,7 @@ pub trait Parser<'i> {
     name: CowRcStr<'i>,
     arguments: &mut CssParser<'i, 't>,
   ) -> Result<<Self::Impl as SelectorImpl<'i>>::NonTSPseudoClass, ParseError<'i, Self::Error>> {
-    Err(arguments.new_custom_error(SelectorParseErrorKind::UnsupportedPseudoClassOrElement(name)))
+    Err(arguments.new_custom_error(SelectorParseErrorKind::UnsupportedPseudoClass(name)))
   }
 
   fn parse_pseudo_element(
@@ -328,7 +329,7 @@ pub trait Parser<'i> {
     location: SourceLocation,
     name: CowRcStr<'i>,
   ) -> Result<<Self::Impl as SelectorImpl<'i>>::PseudoElement, ParseError<'i, Self::Error>> {
-    Err(location.new_custom_error(SelectorParseErrorKind::UnsupportedPseudoClassOrElement(name)))
+    Err(location.new_custom_error(SelectorParseErrorKind::UnsupportedPseudoElement(name)))
   }
 
   fn parse_functional_pseudo_element<'t>(
@@ -336,7 +337,7 @@ pub trait Parser<'i> {
     name: CowRcStr<'i>,
     arguments: &mut CssParser<'i, 't>,
   ) -> Result<<Self::Impl as SelectorImpl<'i>>::PseudoElement, ParseError<'i, Self::Error>> {
-    Err(arguments.new_custom_error(SelectorParseErrorKind::UnsupportedPseudoClassOrElement(name)))
+    Err(arguments.new_custom_error(SelectorParseErrorKind::UnsupportedPseudoClass(name)))
   }
 
   fn default_namespace(&self) -> Option<<Self::Impl as SelectorImpl<'i>>::NamespaceUrl> {
@@ -3353,7 +3354,7 @@ pub mod tests {
           "active" => return Ok(PseudoClass::Active),
           _ => {}
       }
-      Err(location.new_custom_error(SelectorParseErrorKind::UnsupportedPseudoClassOrElement(name)))
+      Err(location.new_custom_error(SelectorParseErrorKind::UnsupportedPseudoClass(name)))
     }
 
     fn parse_non_ts_functional_pseudo_class<'t>(
@@ -3368,7 +3369,7 @@ pub mod tests {
           },
           _ => {}
       }
-      Err(parser.new_custom_error(SelectorParseErrorKind::UnsupportedPseudoClassOrElement(name)))
+      Err(parser.new_custom_error(SelectorParseErrorKind::UnsupportedPseudoClass(name)))
     }
 
     fn parse_pseudo_element(
@@ -3381,7 +3382,7 @@ pub mod tests {
           "after" => return Ok(PseudoElement::After),
           _ => {}
       }
-      Err(location.new_custom_error(SelectorParseErrorKind::UnsupportedPseudoClassOrElement(name)))
+      Err(location.new_custom_error(SelectorParseErrorKind::UnsupportedPseudoElement(name)))
     }
 
     fn default_namespace(&self) -> Option<DummyAtom> {

--- a/src/error.rs
+++ b/src/error.rs
@@ -277,7 +277,6 @@ impl<'i> fmt::Display for SelectorError<'i> {
           "Pseudo-elements like '::before' or '::after' can't be followed by selectors like '{token:?}'"
         )
       },
-      
     }
   }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -240,6 +240,9 @@ pub enum SelectorError<'i> {
   UnexpectedSelectorAfterPseudoElement(
     #[cfg_attr(any(feature = "serde", feature = "nodejs"), serde(skip))] Token<'i>,
   ),
+
+  /// An unknown pseudo class was encountered.
+  UnknownPseudoClass(CowArcStr<'i>),
 }
 
 impl<'i> fmt::Display for SelectorError<'i> {
@@ -272,6 +275,7 @@ impl<'i> fmt::Display for SelectorError<'i> {
           "Pseudo-elements like '::before' or '::after' can't be followed by selectors like '{token:?}'"
         )
       },
+      UnknownPseudoClass(name) => write!(f, "Invalid CSS syntax: '{name}' is not recognized as a valid pseudo-class. Did you mean '::{name}' (pseudo-element) or is this a typo?"),
     }
   }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -230,8 +230,12 @@ pub enum SelectorError<'i> {
   UnexpectedTokenInAttributeSelector(
     #[cfg_attr(any(feature = "serde", feature = "nodejs"), serde(skip))] Token<'i>,
   ),
-  /// An unsupported pseudo class or pseudo element was encountered.
-  UnsupportedPseudoClassOrElement(CowArcStr<'i>),
+
+  /// An unsupported pseudo class was encountered.
+  UnsupportedPseudoClass(CowArcStr<'i>),
+
+  /// An unsupported pseudo element was encountered.
+  UnsupportedPseudoElement(CowArcStr<'i>),
 
   /// Ambiguous CSS module class.
   AmbiguousCssModuleClass(CowArcStr<'i>),
@@ -240,9 +244,6 @@ pub enum SelectorError<'i> {
   UnexpectedSelectorAfterPseudoElement(
     #[cfg_attr(any(feature = "serde", feature = "nodejs"), serde(skip))] Token<'i>,
   ),
-
-  /// An unknown pseudo class was encountered.
-  UnknownPseudoClass(CowArcStr<'i>),
 }
 
 impl<'i> fmt::Display for SelectorError<'i> {
@@ -267,7 +268,8 @@ impl<'i> fmt::Display for SelectorError<'i> {
       PseudoElementExpectedIdent(token) => write!(f, "Invalid token in pseudo element: {:?}", token),
       UnexpectedIdent(name) => write!(f, "Unexpected identifier: {}", name),
       UnexpectedTokenInAttributeSelector(token) => write!(f, "Unexpected token in attribute selector: {:?}", token),
-      UnsupportedPseudoClassOrElement(name) => write!(f, "Unsupported pseudo class or element: {}", name),
+      UnsupportedPseudoClass(name) =>write!(f, "Invalid CSS syntax: '{name}' is not recognized as a valid pseudo-class. Did you mean '::{name}' (pseudo-element) or is this a typo?"),
+      UnsupportedPseudoElement(name) => write!(f, "Unsupported pseudo element: {}", name),
       AmbiguousCssModuleClass(_) => write!(f, "Ambiguous CSS module class not supported"),
       UnexpectedSelectorAfterPseudoElement(token) => {
         write!(
@@ -275,7 +277,7 @@ impl<'i> fmt::Display for SelectorError<'i> {
           "Pseudo-elements like '::before' or '::after' can't be followed by selectors like '{token:?}'"
         )
       },
-      UnknownPseudoClass(name) => write!(f, "Invalid CSS syntax: '{name}' is not recognized as a valid pseudo-class. Did you mean '::{name}' (pseudo-element) or is this a typo?"),
+      
     }
   }
 }
@@ -304,9 +306,8 @@ impl<'i> From<SelectorParseErrorKind<'i>> for SelectorError<'i> {
         SelectorError::UnexpectedTokenInAttributeSelector(t.into())
       }
       SelectorParseErrorKind::PseudoElementExpectedIdent(t) => SelectorError::PseudoElementExpectedIdent(t.into()),
-      SelectorParseErrorKind::UnsupportedPseudoClassOrElement(t) => {
-        SelectorError::UnsupportedPseudoClassOrElement(t.into())
-      }
+      SelectorParseErrorKind::UnsupportedPseudoClass(t) => SelectorError::UnsupportedPseudoClass(t.into()),
+      SelectorParseErrorKind::UnsupportedPseudoElement(t) => SelectorError::UnsupportedPseudoElement(t.into()),
       SelectorParseErrorKind::UnexpectedIdent(t) => SelectorError::UnexpectedIdent(t.into()),
       SelectorParseErrorKind::ExpectedNamespace(t) => SelectorError::ExpectedNamespace(t.into()),
       SelectorParseErrorKind::ExpectedBarInAttr(t) => SelectorError::ExpectedBarInAttr(t.into()),

--- a/src/error.rs
+++ b/src/error.rs
@@ -268,8 +268,8 @@ impl<'i> fmt::Display for SelectorError<'i> {
       PseudoElementExpectedIdent(token) => write!(f, "Invalid token in pseudo element: {:?}", token),
       UnexpectedIdent(name) => write!(f, "Unexpected identifier: {}", name),
       UnexpectedTokenInAttributeSelector(token) => write!(f, "Unexpected token in attribute selector: {:?}", token),
-      UnsupportedPseudoClass(name) =>write!(f, "Invalid CSS syntax: '{name}' is not recognized as a valid pseudo-class. Did you mean '::{name}' (pseudo-element) or is this a typo?"),
-      UnsupportedPseudoElement(name) => write!(f, "Unsupported pseudo element: {}", name),
+      UnsupportedPseudoClass(name) =>write!(f, "'{name}' is not recognized as a valid pseudo-class. Did you mean '::{name}' (pseudo-element) or is this a typo?"),
+      UnsupportedPseudoElement(name) => write!(f, "'{name}' is not recognized as a valid pseudo-element. Did you mean ':{name}' (pseudo-class) or is this a typo?"),
       AmbiguousCssModuleClass(_) => write!(f, "Ambiguous CSS module class not supported"),
       UnexpectedSelectorAfterPseudoElement(token) => {
         write!(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27250,8 +27250,8 @@ mod tests {
           kind: ParserError::SelectorError(SelectorError::UnsupportedPseudoClass("placeholder".into())),
           loc: Some(ErrorLocation {
             filename: "test.css".into(),
-            line: 20,
-            column: 9
+            line: 24,
+            column: 13,
           }),
         },
       ]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7056,11 +7056,6 @@ mod tests {
         Token::SquareBracketBlock,
       )),
     );
-
-    error_test(
-      "input:placeholder{color: red;}",
-      ParserError::SelectorError(SelectorError::UnknownPseudoClass("placeholder".into())),
-    );
   }
 
   #[test]
@@ -27191,6 +27186,10 @@ mod tests {
           color: red;
         }
       }
+
+      input:placeholder {
+        color: red;
+      }
     "#,
       indoc! { r#"
       .foo {
@@ -27205,6 +27204,10 @@ mod tests {
         .bar {
           color: red;
         }
+      }
+
+      input:placeholder {
+        color: red;
       }
     "#},
       ParserOptions {
@@ -27242,6 +27245,14 @@ mod tests {
             line: 15,
             column: 9
           })
+        },
+        Error {
+          kind: ParserError::SelectorError(SelectorError::UnknownPseudoClass("placeholder".into())),
+          loc: Some(ErrorLocation {
+            filename: "test.css".into(),
+            line: 20,
+            column: 9
+          }),
         },
       ]
     )

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27247,7 +27247,7 @@ mod tests {
           })
         },
         Error {
-          kind: ParserError::SelectorError(SelectorError::UnknownPseudoClass("placeholder".into())),
+          kind: ParserError::SelectorError(SelectorError::UnsupportedPseudoClass("placeholder".into())),
           loc: Some(ErrorLocation {
             filename: "test.css".into(),
             line: 20,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7056,6 +7056,11 @@ mod tests {
         Token::SquareBracketBlock,
       )),
     );
+
+    error_test(
+      "input:placeholder{color: red;}",
+      ParserError::SelectorError(SelectorError::UnknownPseudoClass("placeholder".into())),
+    );
   }
 
   #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27190,6 +27190,10 @@ mod tests {
       input:placeholder {
         color: red;
       }
+
+      input::hover {
+        color: red;
+      }
     "#,
       indoc! { r#"
       .foo {
@@ -27207,6 +27211,10 @@ mod tests {
       }
 
       input:placeholder {
+        color: red;
+      }
+
+      input::hover {
         color: red;
       }
     "#},
@@ -27251,6 +27259,14 @@ mod tests {
           loc: Some(ErrorLocation {
             filename: "test.css".into(),
             line: 24,
+            column: 13,
+          }),
+        },
+        Error {
+          kind: ParserError::SelectorError(SelectorError::UnsupportedPseudoElement("hover".into())),
+          loc: Some(ErrorLocation {
+            filename: "test.css".into(),
+            line: 28,
             column: 13,
           }),
         },

--- a/src/properties/animation.rs
+++ b/src/properties/animation.rs
@@ -406,7 +406,11 @@ pub enum TimelineRangeName {
 /// or [animation-range-end](https://drafts.csswg.org/scroll-animations/#animation-range-end) property.
 #[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "visitor", derive(Visit))]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize), serde(rename_all = "lowercase"))]
+#[cfg_attr(
+  feature = "serde",
+  derive(serde::Serialize, serde::Deserialize),
+  serde(rename_all = "lowercase")
+)]
 #[cfg_attr(feature = "jsonschema", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "into_owned", derive(static_self::IntoOwned))]
 pub enum AnimationAttachmentRange {

--- a/src/selector.rs
+++ b/src/selector.rs
@@ -285,7 +285,7 @@ impl<'a, 'o, 'i> parcel_selectors::parser::Parser<'i> for SelectorParser<'a, 'o,
 
       _ => {
         if !name.starts_with('-') {
-          self.options.warn(loc.new_custom_error(SelectorParseErrorKind::UnsupportedPseudoClass(name.clone())));
+          self.options.warn(loc.new_custom_error(SelectorParseErrorKind::UnsupportedPseudoElement(name.clone())));
         }
         Custom { name: name.into() }
       }
@@ -309,7 +309,7 @@ impl<'a, 'o, 'i> parcel_selectors::parser::Parser<'i> for SelectorParser<'a, 'o,
       "view-transition-new" => ViewTransitionNew { part_name: ViewTransitionPartName::parse(arguments)? },
       _ => {
         if !name.starts_with('-') {
-          self.options.warn(arguments.new_custom_error(SelectorParseErrorKind::UnsupportedPseudoClass(name.clone())));
+          self.options.warn(arguments.new_custom_error(SelectorParseErrorKind::UnsupportedPseudoElement(name.clone())));
         }
         let mut args = Vec::new();
         TokenList::parse_raw(arguments, &mut args, &self.options, 0)?;

--- a/src/selector.rs
+++ b/src/selector.rs
@@ -196,7 +196,7 @@ impl<'a, 'o, 'i> parcel_selectors::parser::Parser<'i> for SelectorParser<'a, 'o,
 
       _ => {
         if !name.starts_with('-') {
-          self.options.warn(loc.new_custom_error(SelectorParseErrorKind::UnsupportedPseudoClassOrElement(name.clone())));
+          self.options.warn(loc.new_custom_error(SelectorParseErrorKind::UnsupportedPseudoClass(name.clone())));
         }
         Custom { name: name.into() }
       }
@@ -225,7 +225,7 @@ impl<'a, 'o, 'i> parcel_selectors::parser::Parser<'i> for SelectorParser<'a, 'o,
       "global" if self.options.css_modules.is_some() => Global { selector: Box::new(Selector::parse(self, parser)?) },
       _ => {
         if !name.starts_with('-') {
-          self.options.warn(parser.new_custom_error(SelectorParseErrorKind::UnsupportedPseudoClassOrElement(name.clone())));
+          self.options.warn(parser.new_custom_error(SelectorParseErrorKind::UnsupportedPseudoClass(name.clone())));
         }
         let mut args = Vec::new();
         TokenList::parse_raw(parser, &mut args, &self.options, 0)?;
@@ -285,7 +285,7 @@ impl<'a, 'o, 'i> parcel_selectors::parser::Parser<'i> for SelectorParser<'a, 'o,
 
       _ => {
         if !name.starts_with('-') {
-          self.options.warn(loc.new_custom_error(SelectorParseErrorKind::UnsupportedPseudoClassOrElement(name.clone())));
+          self.options.warn(loc.new_custom_error(SelectorParseErrorKind::UnsupportedPseudoClass(name.clone())));
         }
         Custom { name: name.into() }
       }
@@ -309,7 +309,7 @@ impl<'a, 'o, 'i> parcel_selectors::parser::Parser<'i> for SelectorParser<'a, 'o,
       "view-transition-new" => ViewTransitionNew { part_name: ViewTransitionPartName::parse(arguments)? },
       _ => {
         if !name.starts_with('-') {
-          self.options.warn(arguments.new_custom_error(SelectorParseErrorKind::UnsupportedPseudoClassOrElement(name.clone())));
+          self.options.warn(arguments.new_custom_error(SelectorParseErrorKind::UnsupportedPseudoClass(name.clone())));
         }
         let mut args = Vec::new();
         TokenList::parse_raw(arguments, &mut args, &self.options, 0)?;


### PR DESCRIPTION
Another PR for improving the error message of selector parsing error.

I split `UnsupportedPseudoClassOrElement` into `UnsupportedPseudoClass` and `UnsupportedPseudoElement` so I can provide detailed error messages and suggestions for fix.


side note: I used ChatGPT to get an informative error message.