### PR TITLE
fix: should not panic when passing system-color to color-mix

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19311,6 +19311,14 @@ mod tests {
       ".foo { color: color-mix(in srgb, blue, currentColor); }",
       ".foo{color:color-mix(in srgb,blue,currentColor)}",
     );
+    minify_test(
+      ".foo { color: color-mix(in srgb, accentcolor, blue); }",
+      ".foo{color:color-mix(in srgb,accentcolor,blue)}",
+    );
+    minify_test(
+      ".foo { color: color-mix(in srgb, blue, accentcolor); }",
+      ".foo{color:color-mix(in srgb,blue,accentcolor)}",
+    );
 
     // regex for converting web platform tests:
     // test_computed_value\(.*?, `(.*?)`, `(.*?)`\);

--- a/src/values/color.rs
+++ b/src/values/color.rs
@@ -3253,7 +3253,9 @@ impl CssColor {
       + From<OKLCH>
       + Copy,
   {
-    if matches!(self, CssColor::CurrentColor) || matches!(other, CssColor::CurrentColor) {
+    if matches!(self, CssColor::CurrentColor | CssColor::System(..))
+      || matches!(other, CssColor::CurrentColor | CssColor::System(..))
+    {
       return Err(());
     }
 


### PR DESCRIPTION
fix #685 

[playground repo](https://lightningcss.dev/playground/index.html#%7B%22minify%22%3Afalse%2C%22customMedia%22%3Atrue%2C%22cssModules%22%3Afalse%2C%22analyzeDependencies%22%3Afalse%2C%22targets%22%3A%7B%22chrome%22%3A6225920%7D%2C%22include%22%3A0%2C%22exclude%22%3A0%2C%22source%22%3A%22.foo%20%7B%5Cn%20%20background%3A%20color-mix(in%20srgb%2C%20blue%2C%20accentcolor)%3B%5Cn%7D%22%2C%22visitorEnabled%22%3Afalse%2C%22visitor%22%3A%22%7B%5Cn%20%20Color(color)%20%7B%5Cn%20%20%20%20if%20(color.type%20%3D%3D%3D%20'rgb')%20%7B%5Cn%20%20%20%20%20%20color.g%20%3D%200%3B%5Cn%20%20%20%20%20%20return%20color%3B%5Cn%20%20%20%20%7D%5Cn%20%20%7D%5Cn%7D%22%2C%22unusedSymbols%22%3A%5B%5D%2C%22version%22%3A%22local%22%7D)