### PR TITLE
docs: fix link to visitor type definitions

### DIFF
--- a/website/pages/transforms.md
+++ b/website/pages/transforms.md
@@ -12,7 +12,7 @@ Custom transforms have a build time cost: it can be around 2x slower to compile 
 
 ## Visitors
 
-Custom transforms are implemented by passing a `visitor` object to the Lightning CSS Node API. A visitor includes one or more functions which are called for specific value types such as `Rule`, `Property`, or `Length`. In general, you should try to be as specific as possible about the types of values you want to handle. This way, Lightning CSS needs to call into JS as infrequently as possible, with the smallest objects possible, which improves performance. See the [TypeScript definitions](https://github.com/parcel-bundler/lightningcss/blob/master/node/index.d.ts#L101-L129) for a full list of available visitor functions.
+Custom transforms are implemented by passing a `visitor` object to the Lightning CSS Node API. A visitor includes one or more functions which are called for specific value types such as `Rule`, `Property`, or `Length`. In general, you should try to be as specific as possible about the types of values you want to handle. This way, Lightning CSS needs to call into JS as infrequently as possible, with the smallest objects possible, which improves performance. See the [TypeScript definitions](https://github.com/parcel-bundler/lightningcss/blob/eb49015cf887ae720b80a2856ccbdf61bf940ef1/node/index.d.ts#L184-L214) for a full list of available visitor functions.
 
 Visitors can return a new value to update it. Each visitor accepts a different type of value, and usually expects the same type in return. This example multiplies all lengths by 2:
 


### PR DESCRIPTION
This PR fixes the "TypeScript definitions" link on the [Custom transforms](https://lightningcss.dev/transforms.html#visitors) page.

- Fixed the line numbers.
- Changed to permalink so that the it doesn't break if the code gets moved.