### PR TITLE
feat: add path parsing to BasicShape

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -991,12 +991,14 @@ checksum = "7f222829ae9293e33a9f5e9f440c6760a3d450a64affe1846486b140db81c1f4"
 
 [[package]]
 name = "oxvg_path"
-version = "0.0.1-beta.2"
+version = "0.0.1-beta.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00fb8e08be2a3fcb2ff98de9122a82295dd6ef2cc9596f3c14a8c7fcf3d5a5bc"
+checksum = "87e451f3fe3d6a997e83f0557b03b00175a946e41f155712eff9adc4088d3aac"
 dependencies = [
  "bitflags 2.6.0",
  "ryu",
+ "schemars",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -121,9 +121,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.4.1"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "327762f6e5a765692301e5bb513e0d9fef63be86bbc14528052b1cd3e6f03e07"
+checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
 
 [[package]]
 name = "bitvec"
@@ -762,7 +762,7 @@ dependencies = [
  "assert_cmd",
  "assert_fs",
  "atty",
- "bitflags 2.4.1",
+ "bitflags 2.6.0",
  "browserslist-rs",
  "clap",
  "const-str",
@@ -776,6 +776,7 @@ dependencies = [
  "jemallocator",
  "lazy_static",
  "lightningcss-derive",
+ "oxvg_path",
  "parcel_selectors",
  "parcel_sourcemap",
  "paste",
@@ -892,7 +893,7 @@ version = "2.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72e0dc78e0524286630914db66e31bad70160e379705a9ce92e0161ce2389d89"
 dependencies = [
- "bitflags 2.4.1",
+ "bitflags 2.6.0",
  "ctor",
  "napi-derive",
  "napi-sys",
@@ -989,10 +990,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f222829ae9293e33a9f5e9f440c6760a3d450a64affe1846486b140db81c1f4"
 
 [[package]]
+name = "oxvg_path"
+version = "0.0.1-beta.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00fb8e08be2a3fcb2ff98de9122a82295dd6ef2cc9596f3c14a8c7fcf3d5a5bc"
+dependencies = [
+ "bitflags 2.6.0",
+ "ryu",
+]
+
+[[package]]
 name = "parcel_selectors"
 version = "0.27.0"
 dependencies = [
- "bitflags 2.4.1",
+ "bitflags 2.6.0",
  "cssparser",
  "fxhash",
  "log",
@@ -1387,7 +1398,7 @@ version = "0.38.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b426b0506e5d50a7d8dafcf2e81471400deb602392c7dd110815afb4eaf02a3"
 dependencies = [
- "bitflags 2.4.1",
+ "bitflags 2.6.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -1396,9 +1407,9 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.15"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ad4cc8da4ef723ed60bced201181d83791ad433213d8c24efffda1eec85d741"
+checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
 
 [[package]]
 name = "same-file"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,6 +62,7 @@ const-str = "0.3.1"
 pathdiff = "0.2.1"
 ahash = "0.8.7"
 paste = "1.0.12"
+oxvg_path = "0.0.1-beta.2"
 # CLI deps
 atty = { version = "0.2", optional = true }
 clap = { version = "3.0.6", features = ["derive"], optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,9 +39,9 @@ browserslist = ["browserslist-rs"]
 bundler = ["dashmap", "sourcemap", "rayon"]
 cli = ["atty", "clap", "serde_json", "browserslist", "jemallocator"]
 grid = []
-jsonschema = ["schemars", "serde", "parcel_selectors/jsonschema"]
+jsonschema = ["schemars", "serde", "parcel_selectors/jsonschema", "oxvg_path/jsonschema"]
 nodejs = ["dep:serde"]
-serde = ["dep:serde", "smallvec/serde", "cssparser/serde", "parcel_selectors/serde", "into_owned"]
+serde = ["dep:serde", "smallvec/serde", "cssparser/serde", "parcel_selectors/serde", "oxvg_path/serde", "into_owned"]
 sourcemap = ["parcel_sourcemap"]
 visitor = []
 into_owned = ["static-self", "static-self/smallvec", "parcel_selectors/into_owned"]
@@ -62,7 +62,7 @@ const-str = "0.3.1"
 pathdiff = "0.2.1"
 ahash = "0.8.7"
 paste = "1.0.12"
-oxvg_path = "0.0.1-beta.2"
+oxvg_path = "0.0.1-beta.4"
 # CLI deps
 atty = { version = "0.2", optional = true }
 clap = { version = "3.0.6", features = ["derive"], optional = true }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24828,6 +24828,18 @@ mod tests {
       ".foo{clip-path:polygon(evenodd,50% 0%,100% 50%,50% 100%,0% 50%)}",
     );
     minify_test(
+      r#".foo { clip-path: path("M 0 0 L 0 10"); }"#,
+      r#".foo{clip-path:path("M0 0v10")}"#,
+    );
+    minify_test(
+      r#".foo { clip-path: path(nonzero, "M 0 0 L 10 20"); }"#,
+      r#".foo{clip-path:path("m0 0 10 20")}"#,
+    );
+    minify_test(
+      r#".foo { clip-path: path(evenodd, "M 0 0 L 10 20"); }"#,
+      r#".foo{clip-path:path(evenodd,"m0 0 10 20")}"#,
+    );
+    minify_test(
       ".foo { clip-path: padding-box circle(50px at 0 100px); }",
       ".foo{clip-path:circle(50px at 0 100px) padding-box}",
     );

--- a/src/values/shape.rs
+++ b/src/values/shape.rs
@@ -11,7 +11,7 @@ use crate::printer::Printer;
 use crate::properties::border_radius::BorderRadius;
 use crate::traits::{Parse, ToCss};
 #[cfg(feature = "visitor")]
-use crate::visitor::Visit;
+use crate::visitor::{Visit, VisitTypes, Visitor};
 use cssparser::*;
 use oxvg_path;
 
@@ -129,11 +129,10 @@ pub struct Point {
   y: LengthPercentage,
 }
 
-/// A path within a `path()` shape.
+/// An SVG path within a `path()` shape.
 ///
 /// See [Path](oxvg_path::Path).
 #[derive(Debug, Clone, PartialEq)]
-#[cfg_attr(feature = "visitor", derive(Visit))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "jsonschema", derive(schemars::JsonSchema))]
 pub struct Path(pub oxvg_path::Path);
@@ -396,5 +395,14 @@ impl ToCss for Path {
     W: std::fmt::Write,
   {
     Ok(write!(dest, "{}", self.0)?)
+  }
+}
+
+#[cfg(feature = "visitor")]
+#[cfg_attr(docsrs, doc(cfg(feature = "visitor")))]
+impl<'i, V: ?Sized + Visitor<'i, T>, T: Visit<'i, T, V>> Visit<'i, T, V> for Path {
+  const CHILD_TYPES: VisitTypes = VisitTypes::empty();
+  fn visit_children(&mut self, _: &mut V) -> Result<(), V::Error> {
+    Ok(())
   }
 }


### PR DESCRIPTION
This PR adds support for parsing and minifying path definitions, such as `clip-path: path('M0 0L10 10')` which would be minified as `clip-path: path('M0 0 10 10')`

See [here](https://github.com/noahbald/oxvg/blob/main/crates/oxvg_optimiser/src/jobs/convert_path_data.rs#L168) for tests, which covers all the path optimization related tests from SVGO

---
To finish for this PR
- [x] Implement serde derives
- [x] Implement Visit derive
- [x] Implement json-schema