### PR TITLE
fix: calc::Sum add calc::Number will go into circle

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7526,6 +7526,7 @@ mod tests {
     minify_test(".foo { width: calc(20px + 30px) }", ".foo{width:50px}");
     minify_test(".foo { width: calc(20px + 30px + 40px) }", ".foo{width:90px}");
     minify_test(".foo { width: calc(100% - 30px) }", ".foo{width:calc(100% - 30px)}");
+    minify_test(".foo { width: calc(100% - 30px - 0) }", ".foo{width:calc(100% - 30px - 0)}");
     minify_test(
       ".foo { width: calc(100% - 30px + 20px) }",
       ".foo{width:calc(100% - 10px)}",

--- a/src/values/calc.rs
+++ b/src/values/calc.rs
@@ -910,6 +910,7 @@ impl<V: AddInternal + std::convert::Into<Calc<V>> + std::convert::From<Calc<V>> 
       (Calc::Number(a), Calc::Number(b)) => Calc::Number(a + b),
       (Calc::Value(a), b) => (a.add(V::from(b))).into(),
       (a, Calc::Value(b)) => (V::from(a).add(*b)).into(),
+      (a, Calc::Number(b)) => Calc::Sum(Box::new(a), Box::new(Calc::Number(b))),
       (Calc::Function(a), b) => Calc::Sum(Box::new(Calc::Function(a)), Box::new(b)),
       (a, Calc::Function(b)) => Calc::Sum(Box::new(a), Box::new(Calc::Function(b))),
       (a, b) => V::from(a).add(V::from(b)).into(),


### PR DESCRIPTION
fix https://github.com/parcel-bundler/lightningcss/issues/827

[playground repo](https://lightningcss.dev/playground/index.html#%7B%22minify%22%3Afalse%2C%22customMedia%22%3Atrue%2C%22cssModules%22%3Afalse%2C%22analyzeDependencies%22%3Afalse%2C%22targets%22%3A%7B%22chrome%22%3A6225920%7D%2C%22include%22%3A0%2C%22exclude%22%3A0%2C%22source%22%3A%22.foo%20%7B%5Cn%20%20left%3A%20calc(100%25%20-%2016px%20-%200)%5Cn%7D%22%2C%22visitorEnabled%22%3Afalse%2C%22visitor%22%3A%22%7B%5Cn%20%20Color(color)%20%7B%5Cn%20%20%20%20if%20(color.type%20%3D%3D%3D%20'rgb')%20%7B%5Cn%20%20%20%20%20%20color.g%20%3D%200%3B%5Cn%20%20%20%20%20%20return%20color%3B%5Cn%20%20%20%20%7D%5Cn%20%20%7D%5Cn%7D%22%2C%22unusedSymbols%22%3A%5B%5D%2C%22version%22%3A%22local%22%7D)