### PR TITLE
fix: size prop can't order corretly.

### DIFF
--- a/src/declaration.rs
+++ b/src/declaration.rs
@@ -495,7 +495,7 @@ pub(crate) struct DeclarationHandler<'i> {
   flex: FlexHandler,
   grid: GridHandler<'i>,
   align: AlignHandler,
-  size: SizeHandler,
+  size: SizeHandler<'i>,
   margin: MarginHandler<'i>,
   padding: PaddingHandler<'i>,
   scroll_margin: ScrollMarginHandler<'i>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3970,14 +3970,6 @@ mod tests {
       ".foo { width: 100%; width: calc(100% - constant(safe-area-inset-left)); width: calc(100% - env(safe-area-inset-left));}",
       ".foo{width:calc(100% - env(safe-area-inset-left))}"
     );
-    minify_test(
-      ".foo { height: 16px; height: var(--header-height); }",
-      ".foo{height:var(--header-height)}",
-    );
-    minify_test(
-      ".foo { height: auto; height: calc(100vh - var(--header-height, 0rem)); }",
-      ".foo{height:calc(100vh - var(--header-height,0rem))}",
-    );
   }
 
   #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3971,8 +3971,12 @@ mod tests {
       ".foo{width:calc(100% - env(safe-area-inset-left))}"
     );
     minify_test(
-      ".foo { height: 16px, var(--header-height); }",
+      ".foo { height: 16px; height: var(--header-height); }",
       ".foo{height:var(--header-height)}",
+    );
+    minify_test(
+      ".foo { height: auto; height: calc(100vh - var(--header-height, 0rem)); }",
+      ".foo{height:calc(100vh - var(--header-height,0rem))}",
     );
   }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3966,6 +3966,14 @@ mod tests {
     minify_test(".foo { aspect-ratio: 2 / 3 }", ".foo{aspect-ratio:2/3}");
     minify_test(".foo { aspect-ratio: auto 2 / 3 }", ".foo{aspect-ratio:auto 2/3}");
     minify_test(".foo { aspect-ratio: 2 / 3 auto }", ".foo{aspect-ratio:auto 2/3}");
+    minify_test(
+      ".foo { width: 100%; width: calc(100% - constant(safe-area-inset-left)); width: calc(100% - env(safe-area-inset-left));}",
+      ".foo{width:calc(100% - env(safe-area-inset-left))}"
+    );
+    minify_test(
+      ".foo { height: 16px, var(--header-height); }",
+      ".foo{height:var(--header-height)}",
+    );
   }
 
   #[test]


### PR DESCRIPTION
## Example
```css
.foo { 
   height: auto; 
   height: calc(100vh - var(--header-height, 0rem)); 
}
```
After lightningcss minify, css code would like this 
```css
.foo { 
   height: calc(100vh - var(--header-height, 0rem)); 
   height: auto; 
}
```
But it's not expect.
we can maintain the last prop, then delete the repeat prop. Like bellow:
```
.foo { 
   height: calc(100vh - var(--header-height, 0rem)); 
}
```

fix: https://github.com/parcel-bundler/lightningcss/issues/805

