### PR TITLE
feat: Add an error for the deprecated `@value` at-rule of CSS Modules

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -88,6 +88,8 @@ pub enum ParserError<'i> {
   InvalidNesting,
   /// The @nest rule is deprecated.
   DeprecatedNestRule,
+  /// The @value rule (of CSS modules) is deprecated.
+  DeprecatedCssModulesValueRule,
   /// An invalid selector in an `@page` rule.
   InvalidPageSelector,
   /// An invalid value was encountered.
@@ -118,6 +120,7 @@ impl<'i> fmt::Display for ParserError<'i> {
       InvalidMediaQuery => write!(f, "Invalid media query"),
       InvalidNesting => write!(f, "Invalid nesting"),
       DeprecatedNestRule => write!(f, "The @nest rule is deprecated"),
+      DeprecatedCssModulesValueRule => write!(f, "The @value rule is deprecated"),
       InvalidPageSelector => write!(f, "Invalid page selector"),
       InvalidValue => write!(f, "Invalid value"),
       QualifiedRuleInvalid => write!(f, "Invalid qualified rule"),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -230,6 +230,20 @@ mod tests {
     }
   }
 
+  fn css_modules_error_test(source: &str, error: ParserError) {
+    let res = StyleSheet::parse(
+      &source,
+      ParserOptions {
+        css_modules: Some(Default::default()),
+        ..Default::default()
+      },
+    );
+    match res {
+      Ok(_) => unreachable!(),
+      Err(e) => assert_eq!(e.kind, error),
+    }
+  }
+
   macro_rules! map(
     { $($key:expr => $name:literal $(referenced: $referenced: literal)? $($value:literal $(global: $global: literal)? $(from $from:literal)?)*),* } => {
       {
@@ -27610,6 +27624,14 @@ mod tests {
     error_test(
       "@container style(style(--foo: bar)) {}",
       ParserError::UnexpectedToken(crate::properties::custom::Token::Function("style".into())),
+    );
+  }
+
+  #[test]
+  fn test_css_modules_value_rule() {
+    css_modules_error_test(
+      "@value compact: (max-width: 37.4375em);",
+      ParserError::DeprecatedCssModulesValueRule,
     );
   }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -680,9 +680,7 @@ impl<'a, 'o, 'b, 'i, T: crate::traits::AtRuleParser<'i>> AtRuleParser<'i> for Ne
       },
 
       "value" if self.options.css_modules.is_some() => {
-        self.options.warn(input.new_custom_error(ParserError::DeprecatedCssModulesValueRule));
-
-        parse_custom_at_rule_prelude(&name, input, self.options, self.at_rule_parser)?
+        return Err(input.new_custom_error(ParserError::DeprecatedCssModulesValueRule));
       },
 
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -678,6 +678,14 @@ impl<'a, 'o, 'b, 'i, T: crate::traits::AtRuleParser<'i>> AtRuleParser<'i> for Ne
         let selectors = SelectorList::parse(&selector_parser, input, ParseErrorRecovery::DiscardList, NestingRequirement::Contained)?;
         AtRulePrelude::Nest(selectors)
       },
+
+      "value" if self.options.css_modules.is_some() => {
+        self.options.warn(input.new_custom_error(ParserError::DeprecatedCssModulesValueRule));
+
+        parse_custom_at_rule_prelude(&name, input, self.options, self.at_rule_parser)?
+      },
+
+
       _ => parse_custom_at_rule_prelude(&name, input, self.options, self.at_rule_parser)?
     };
 


### PR DESCRIPTION
It may cause confusion to the users because those are silently ignored.

https://github.com/vercel/next.js/issues/71479