### PR TITLE
Fix duplicate `-webkit-backdrop-filter` output

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11302,6 +11302,77 @@ mod tests {
         ..Browsers::default()
       },
     );
+    prefix_test(
+      r#"
+       .foo {
+         transition-property: -webkit-backdrop-filter, backdrop-filter;
+       }
+       .bar {
+         transition-property: backdrop-filter;
+       }
+       .baz {
+         transition-property: -webkit-backdrop-filter;
+       }
+     "#,
+      indoc! {r#"
+       .foo, .bar {
+         transition-property: -webkit-backdrop-filter, backdrop-filter;
+       }
+
+       .baz {
+         transition-property: -webkit-backdrop-filter;
+       }
+     "#
+      },
+      Browsers {
+        safari: Some(15 << 16),
+        ..Browsers::default()
+      },
+    );
+    prefix_test(
+      r#"
+       .foo {
+         transition-property: -webkit-border-radius, -webkit-border-radius, -moz-border-radius;
+       }
+     "#,
+      indoc! {r#"
+       .foo {
+         transition-property: -webkit-border-radius, -moz-border-radius;
+       }
+     "#
+      },
+      Browsers {
+        safari: Some(15 << 16),
+        ..Browsers::default()
+      },
+    );
+    prefix_test(
+      r#"
+       .foo {
+         transition: -webkit-backdrop-filter, backdrop-filter;
+       }
+       .bar {
+         transition: backdrop-filter;
+       }
+       .baz {
+         transition: -webkit-backdrop-filter;
+       }
+     "#,
+      indoc! {r#"
+       .foo, .bar {
+         transition: -webkit-backdrop-filter, backdrop-filter;
+       }
+
+       .baz {
+         transition: -webkit-backdrop-filter;
+       }
+     "#
+      },
+      Browsers {
+        safari: Some(15 << 16),
+        ..Browsers::default()
+      },
+    );
   }
 
   #[test]
@@ -25739,33 +25810,6 @@ mod tests {
       "#},
       Browsers {
         chrome: Some(4 << 16),
-        ..Browsers::default()
-      },
-    );
-    prefix_test(
-      r#"
-       .foo {
-         transition-property: -webkit-backdrop-filter, backdrop-filter;
-       }
-       .bar {
-         transition-property: backdrop-filter;
-       }
-       .baz {
-         transition-property: -webkit-backdrop-filter;
-       }
-     "#,
-      indoc! {r#"
-       .foo, .bar {
-         transition-property: -webkit-backdrop-filter, backdrop-filter;
-       }
-
-       .baz {
-         transition-property: -webkit-backdrop-filter;
-       }
-     "#
-      },
-      Browsers {
-        safari: Some(15 << 16),
         ..Browsers::default()
       },
     );

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -241,10 +241,11 @@ impl<'a, 'b, 'c, W: std::fmt::Write + Sized> Printer<'a, 'b, 'c, W> {
           if let Some(orig) = mapping.original {
             let sources_len = map.get_sources().len();
             let source_index = map.add_source(sm.get_source(orig.source).unwrap());
+            let name = orig.name.map(|name| map.add_name(sm.get_name(name).unwrap()));
             original.original_line = orig.original_line;
             original.original_column = orig.original_column;
             original.source = source_index;
-            original.name = orig.name;
+            original.name = name;
 
             if map.get_sources().len() > sources_len {
               let content = sm.get_source_content(orig.source).unwrap().to_owned();

--- a/src/properties/transition.rs
+++ b/src/properties/transition.rs
@@ -155,28 +155,14 @@ impl<'i> PropertyHandler<'i> for TransitionHandler<'i> {
 
     match property {
       TransitionProperty(val, vp) => {
-        let none_prefixed_names = val
-          .iter()
-          .filter(|p| p.prefix() == VendorPrefix::None)
-          .map(|p| p.name())
-          .collect::<Vec<_>>();
-
-        if none_prefixed_names.is_empty() {
-          property!(TransitionProperty, properties, val, vp)
-        } else {
-          let filtered_val = val
-            .iter()
-            .filter(|p| !(none_prefixed_names.contains(&p.name()) && p.prefix() != VendorPrefix::None))
-            .cloned()
-            .collect::<SmallVec<[PropertyId<'_>; 1]>>();
-          property!(TransitionProperty, properties, &filtered_val, vp)
-        }
+        let merged_values = merge_properties(val.iter());
+        property!(TransitionProperty, properties, &merged_values, vp);
       }
       TransitionDuration(val, vp) => property!(TransitionDuration, durations, val, vp),
       TransitionDelay(val, vp) => property!(TransitionDelay, delays, val, vp),
       TransitionTimingFunction(val, vp) => property!(TransitionTimingFunction, timing_functions, val, vp),
       Transition(val, vp) => {
-        let properties: SmallVec<[PropertyId; 1]> = val.iter().map(|b| b.property.clone()).collect();
+        let properties: SmallVec<[PropertyId; 1]> = merge_properties(val.iter().map(|b| &b.property));
         maybe_flush!(properties, &properties, vp);
 
         let durations: SmallVec<[Time; 1]> = val.iter().map(|b| b.duration.clone()).collect();
@@ -343,6 +329,23 @@ fn is_transition_property(property_id: &PropertyId) -> bool {
     | PropertyId::Transition(_) => true,
     _ => false,
   }
+}
+
+fn merge_properties<'i: 'a, 'a>(val: impl Iterator<Item = &'a PropertyId<'i>>) -> SmallVec<[PropertyId<'i>; 1]> {
+  let mut merged_values = SmallVec::<[PropertyId<'_>; 1]>::with_capacity(val.size_hint().1.unwrap_or(1));
+  for p in val {
+    let without_prefix = p.with_prefix(VendorPrefix::empty());
+    if let Some(idx) = merged_values
+      .iter()
+      .position(|c| c.with_prefix(VendorPrefix::empty()) == without_prefix)
+    {
+      merged_values[idx].add_prefix(p.prefix());
+    } else {
+      merged_values.push(p.clone());
+    }
+  }
+
+  merged_values
 }
 
 fn expand_properties<'i>(


### PR DESCRIPTION
This PR fixes an issue where using CSS that looks like this:
```css
.foo {
  transition-property: -webkit-backdrop-filter, backdrop-filter;
}
```

Results in CSS that looks like this:
```css
.foo {
  transition-property: -webkit-backdrop-filter, -webkit-backdrop-filter, backdrop-filter;
}
```

This PR solves it for the `transition-property` (internally `TransitionProperty`, so I think it's also solved for `transition` that uses that) only.

We currently do this by checking whether a `PropertyId` exists with `VendorPrefix::None`. If it does, then we will make sure to remove all other `PropertyId`'s (with the same name). The idea is that the `PropertyId` with `VendorPrefix::None` will print the property with the correct values, including the vendor prefix.

If however you only use CSS that looks like this:
```css
.foo {
  transition-property: -webkit-backdrop-filter;
}
```

Which is without the unprefixed version, then this is maintained in the output because no `VendorPrefix::None` exists in this case.

I feel like there might be a better spot to handle this (maybe even in parsing, or during printing) but wasn't to sure. I also explicitly scoped it to the `transition-property` for now but maybe this can be more generalized?

I also started from the failing tests (and slightly adjusted with more test cases) from this PR: https://github.com/parcel-bundler/lightningcss/pull/551, I also made sure that the original author is marked as a co-author.

Fixes: https://github.com/parcel-bundler/lightningcss/issues/403
Closes: https://github.com/parcel-bundler/lightningcss/pull/551
