### PR TITLE
Add support for global() function in CSS Modules animation names

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23988,6 +23988,7 @@ mod tests {
       r#"
       :global(.foo) {
         color: red;
+        animation: global(baz) 2s;
       }
 
       :local(.bar) {
@@ -24001,6 +24002,7 @@ mod tests {
       indoc! {r#"
       .foo {
         color: red;
+        animation: baz 2s;
       }
 
       .EgL3uq_bar {

--- a/src/properties/custom.rs
+++ b/src/properties/custom.rs
@@ -1474,10 +1474,15 @@ impl<'i> Function<'i> {
   where
     W: std::fmt::Write,
   {
-    self.name.to_css(dest)?;
-    dest.write_char('(')?;
-    self.arguments.to_css(dest, is_custom_property)?;
-    dest.write_char(')')
+    match self.name.as_ref() {
+      "global" if !is_custom_property => self.arguments.to_css(dest, is_custom_property),
+      _ => {
+        self.name.to_css(dest)?;
+        dest.write_char('(')?;
+        self.arguments.to_css(dest, is_custom_property)?;
+        dest.write_char(')')
+      }
+    }
   }
 
   fn get_fallback(&self, kind: ColorFallbackKind) -> Self {


### PR DESCRIPTION
lightningcss localalizes animations for css modules with quite well - for example

Input:
```css
  animation: baz 2s;
```

Output:
```css
  animation: EgL3uq_baz 2s;
```

However in some cases we were running into issues with animation names getting localized when we didn't want them to. This is problamatic when using third-party animation libraries or sharing animations across components.

For selectors there is the `:global` specifier so we added support for a `global()` function that can be used directly in animation properties to match with postcss-modules-local-by-default: https://github.com/css-modules/postcss-modules-local-by-default/pull/76

Input:
```css
  animation: global(baz) 2s;
```

Output:
```css
  animation: baz 2s;
```


The current solution handles the `global` function in properties/custom.rs but I'm open to moving it if there's a better spot for this logic

Please let me know what you think