### PR TITLE
feat: add option to switch between parsers

### DIFF
--- a/website/playground/index.html
+++ b/website/playground/index.html
@@ -197,6 +197,13 @@
           <textarea id="unusedSymbols" rows="4" placeholder="Separate items with newlines"></textarea>
         </label>
         <label>
+          <h3>Parser</h3>
+          <select id="parser" value="style-sheet">
+            <option value="style-sheet">Style-Sheet</option>
+            <option value="style-attribute">Style-Attribute</option>
+          </select>
+        </label>
+        <label>
           <h3>Version</h3>
           <select id="version"><option value="local">local</option></select>
         </label>

--- a/website/playground/playground.js
+++ b/website/playground/playground.js
@@ -74,6 +74,7 @@ function loadPlaygroundState() {
   }
 }`,
       version: version.value,
+      parser: parser.value,
       visitor: `{
   Color(color) {
     if (color.type === 'rgb') {
@@ -149,6 +150,7 @@ function savePlaygroundState() {
     visitorEnabled: visitorEnabled.checked,
     visitor: visitorEditor.state.doc.toString(),
     unusedSymbols: unusedSymbols.value.split('\n').map(v => v.trim()).filter(Boolean),
+    parser: parser.value,
     version: version.value,
   };
 
@@ -195,14 +197,18 @@ function updateFeatures(elements, include) {
 }
 
 function update() {
-  const { transform } = wasm;
+  const { transform, transformStyleAttribute } = wasm;
+  let transformMethod = transform;
+  if (parser.value === 'style-attribute') {
+    transformMethod = transformStyleAttribute;
+  }
 
   const targets = getTargets();
   let data = new FormData(sidebar);
   let include = getFeatures(data.getAll('include'));
   let exclude = getFeatures(data.getAll('exclude'));
   try {
-    let res = transform({
+    let res = transformMethod({
       filename: 'test.css',
       code: enc.encode(editor.state.doc.toString()),
       minify: minify.checked,


### PR DESCRIPTION
This PR adds an option to the playground to be able to choose between the style-sheet parser or the style-attribute parser. Made so I can easily fiddle with the attribute parser.