### PR TITLE
Mark import as external

### DIFF
--- a/tests/testdata/has_external.css
+++ b/tests/testdata/has_external.css
@@ -1,0 +1,3 @@
+@import url('https://fonts.googleapis.com/css2?family=Roboto&display=swap');
+@import './does_not_exist.css';
+@import './b.css';


### PR DESCRIPTION
This PR adds a way to mark an `import` as external with `resolver`.

closes #479
closes #555 
