### PR TITLE
Docs: Fix color function compiled output

### DIFF
--- a/website/pages/transpilation.md
+++ b/website/pages/transpilation.md
@@ -286,8 +286,8 @@ compiles to:
 
 ```css
 .foo {
-  background-color: #6a805d;
-  background-color: color(a98-rgb .44091 .49971 .37408);
+  color: #6a805d;
+  color: color(a98-rgb .44091 .49971 .37408);
 }
 ```
 


### PR DESCRIPTION
in https://lightningcss.dev/transpilation.html#color-function, the source example sets the `color` property but the compiled output has `background-color`. this makes them both set the `color` property.