### PR TITLE
Add wasm compilation cfg for `Browsers::load_browserslist`

### DIFF
--- a/src/targets.rs
+++ b/src/targets.rs
@@ -51,6 +51,7 @@ impl Browsers {
     Self::from_distribs(resolve(query, &Opts::default())?)
   }
 
+  #[cfg(not(target_arch = "wasm32"))]
   /// Finds browserslist configuration, selects queries by environment and loads the resulting queries into LightningCSS targets.
   ///
   /// Configuration resolution is modeled after the original `browserslist` nodeJS package.


### PR DESCRIPTION
`browserslist::execute` is not available for wasm target, which breaks the compilation when enabling `browserslist` feature under wasm target.