### PR TITLE
allow to opt-out from css pure linting

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7111,6 +7111,16 @@ mod tests {
       "@scope(._8Z4fiW_a) to (._8Z4fiW_b){._8Z4fiW_foo{color:red}}",
       pure_css_module_options.clone(),
     );
+    minify_test_with_options(
+      "/* cssmodules-pure-no-check */ :global(.foo) { color: red }",
+      ".foo{color:red}",
+      pure_css_module_options.clone(),
+    );
+    minify_test_with_options(
+      "/*! some license */ /* cssmodules-pure-no-check */ :global(.foo) { color: red }",
+      "/*! some license */\n.foo{color:red}",
+      pure_css_module_options.clone(),
+    );
 
     error_test(
       "input.defaultCheckbox::before h1 {width: 20px}",

--- a/src/stylesheet.rs
+++ b/src/stylesheet.rs
@@ -172,6 +172,11 @@ where
         cssparser::Token::Comment(comment) if comment.starts_with('!') => {
           license_comments.push((*comment).into());
         }
+        cssparser::Token::Comment(comment) if comment.contains("cssmodules-pure-no-check") => {
+          if let Some(css_modules) = &mut options.css_modules {
+            css_modules.pure = false;
+          }
+        }
         _ => break,
       }
       state = parser.state();


### PR DESCRIPTION
This PR adds support for the `/* cssmodules-pure-no-check */` comment which allows users to disable the `pure` CSS modules check for the entire file (similar to `// @ts-nocheck`)

The feature is a port from [postcss](https://github.com/css-modules/postcss-modules-local-by-default?tab=readme-ov-file#pure-mode)

#### Details

- **Parsing Change**: Detects the `/* cssmodules-pure-no-check */` comment at the beginning of the CSS file and sets `pure` to `false` in `css_modules` options.
- **Test Cases**: Added tests to verify the functionality, ensuring the comment works as expected even with preceding comments.

Solves #889 