### PR TITLE
Fix broken minification for non-opaque oklab colors 

### DIFF
--- a/src/values/number.rs
+++ b/src/values/number.rs
@@ -40,7 +40,7 @@ impl ToCss for CSSNumber {
       cssparser::ToCss::to_css(self, &mut s)?;
       if number < 0.0 {
         dest.write_char('-')?;
-        dest.write_str(s.trim_start_matches("-0"))
+        dest.write_str(s.trim_start_matches("-").trim_start_matches("0"))
       } else {
         dest.write_str(s.trim_start_matches('0'))
       }


### PR DESCRIPTION
Fixes incorrect addition of an extra hyphen to CSS output for floating-point values that are sufficiently low to be represented by scientific notation.

### Context

If a value is represented by scientific notation, it may not be prefixed by "-0" but rather "-D", where D is some digit. In the code block below, if `number < 0` but `s` is not prefixed by "-0", then two hyphens are written. 

https://github.com/parcel-bundler/lightningcss/blob/0afd5d67196c1363e9f70aec8a763e786691255e/src/values/number.rs#L38C1-L49C13

This changes fixes this incorrect behavior by trimming additional leading hyphens ("-") from the string representation of the negative number.

### Resolves Issue
This resolves issue with incorrect conversion from color-mix to oklab() (#899) resulting from double negative sign. 
This issue is urgent for myself, as it causes Tailwind v4 classes using custom hex colors and non-100% opacity to break, as is seen in the reproduction [here](https://lightningcss.dev/playground/#%7B%22minify%22%3Afalse%2C%22customMedia%22%3Afalse%2C%22cssModules%22%3Afalse%2C%22analyzeDependencies%22%3Afalse%2C%22targets%22%3A%7B%22chrome%22%3A7274496%7D%2C%22include%22%3A0%2C%22exclude%22%3A0%2C%22source%22%3A%22body%20%7B%5Cn%20%20background%3A%20color-mix(in%20oklab%2C%20%23101010%2085%25%2C%20transparent)%3B%5Cn%7D%5Cn%22%2C%22visitorEnabled%22%3Afalse%2C%22visitor%22%3A%22%7B%5Cn%20%20Color(color)%20%7B%5Cn%20%20%20%20if%20(color.type%20%3D%3D%3D%20'rgb')%20%7B%5Cn%20%20%20%20%20%20color.g%20%3D%200%3B%5Cn%20%20%20%20%20%20return%20color%3B%5Cn%20%20%20%20%7D%5Cn%20%20%7D%5Cn%7D%22%2C%22unusedSymbols%22%3A%5B%5D%2C%22version%22%3A%22local%22%7D) provided in the GH issue.
