### PR TITLE
Bump browserslist-rs 0.17.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -140,9 +140,9 @@ dependencies = [
 
 [[package]]
 name = "browserslist-rs"
-version = "0.16.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdf0ca73de70c3da94e4194e4a01fe732378f55d47cf4c0588caab22a0dbfa14"
+checksum = "74c973b79d9b6b89854493185ab760c6ef8e54bcfad10ad4e33991e46b374ac8"
 dependencies = [
  "ahash 0.8.11",
  "chrono",
@@ -150,7 +150,6 @@ dependencies = [
  "indexmap 2.7.0",
  "itertools 0.13.0",
  "nom",
- "once_cell",
  "serde",
  "serde_json",
  "thiserror",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,7 +77,7 @@ indexmap = { version = "2.2.6", features = ["serde"] }
 # CLI deps
 atty = { version = "0.2", optional = true }
 clap = { version = "3.0.6", features = ["derive"], optional = true }
-browserslist-rs = { version = "0.16.0", optional = true }
+browserslist-rs = { version = "0.17.0", optional = true }
 rayon = { version = "1.5.1", optional = true }
 dashmap = { version = "5.0.0", optional = true }
 serde_json = { version = "1.0.78", optional = true }

--- a/c/Cargo.toml
+++ b/c/Cargo.toml
@@ -11,7 +11,7 @@ crate-type = ["cdylib"]
 [dependencies]
 lightningcss = { path = "../", features = ["browserslist"] }
 parcel_sourcemap = { version = "2.1.1", features = ["json"] }
-browserslist-rs = { version = "0.16.0" }
+browserslist-rs = { version = "0.17.0" }
 
 [build-dependencies]
 cbindgen = "0.24.3"


### PR DESCRIPTION
Bump browserslist-rs 0.17.0, be consistent with SWC:

- https://github.com/swc-project/swc/pull/9918

Changes:

- https://github.com/browserslist/browserslist-rs/releases/tag/v0.16.1
- https://github.com/browserslist/browserslist-rs/releases/tag/v0.17.0
