### PR TITLE
Update detect-libc for better compatibility

### DIFF
--- a/cli/postinstall.js
+++ b/cli/postinstall.js
@@ -3,7 +3,8 @@ let path = require('path');
 
 let parts = [process.platform, process.arch];
 if (process.platform === 'linux') {
-  const {MUSL, family} = require('detect-libc');
+  const {MUSL, familySync} = require('detect-libc');
+  const family = familySync();
   if (family === MUSL) {
     parts.push('musl');
   } else if (process.arch === 'arm') {

--- a/node/index.js
+++ b/node/index.js
@@ -1,6 +1,7 @@
 let parts = [process.platform, process.arch];
 if (process.platform === 'linux') {
-  const { MUSL, family } = require('detect-libc');
+  const { MUSL, familySync } = require('detect-libc');
+  const family = familySync();
   if (family === MUSL) {
     parts.push('musl');
   } else if (process.arch === 'arm') {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "node/*.flow"
   ],
   "dependencies": {
-    "detect-libc": "^1.0.3"
+    "detect-libc": "^2.0.3"
   },
   "devDependencies": {
     "@babel/parser": "7.21.4",


### PR DESCRIPTION
This updates the detect-libc library to latest version for better compatibility. My specific issue was that this version is not compatible with the bun runtime.
