### PR TITLE
Replace currentColor with currentcolor (lowercase)

### DIFF
--- a/node/test/visitor.test.mjs
+++ b/node/test/visitor.test.mjs
@@ -978,13 +978,13 @@ test('supports returning raw values as variables', () => {
   assert.equal(res.code.toString(), '.EgL3uq_foo{color:var(--EgL3uq_foo)}');
 });
 
-test('works with currentColor', () => {
+test('works with currentcolor', () => {
   let res = transform({
     filename: 'test.css',
     minify: true,
     code: Buffer.from(`
       .foo {
-        color: currentColor;
+        color: currentcolor;
       }
     `),
     visitor: {
@@ -994,7 +994,7 @@ test('works with currentColor', () => {
     }
   });
 
-  assert.equal(res.code.toString(), '.foo{color:currentColor}');
+  assert.equal(res.code.toString(), '.foo{color:currentcolor}');
 });
 
 test('nth of S to nth-of-type', () => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -902,7 +902,7 @@ mod tests {
     test(
       r#"
       .foo {
-        border: 1px solid currentColor;
+        border: 1px solid currentcolor;
       }
     "#,
       indoc! {r#"
@@ -916,7 +916,7 @@ mod tests {
     minify_test(
       r#"
       .foo {
-        border: 1px solid currentColor;
+        border: 1px solid currentcolor;
       }
     "#,
       ".foo{border:1px solid}",
@@ -16998,7 +16998,7 @@ mod tests {
     minify_test(".foo { color: hsla(100, 100%, 50%, .8) }", ".foo{color:#5f0c}");
     minify_test(".foo { color: hsla(100 100% 50% / .8) }", ".foo{color:#5f0c}");
     minify_test(".foo { color: transparent }", ".foo{color:#0000}");
-    minify_test(".foo { color: currentColor }", ".foo{color:currentColor}");
+    minify_test(".foo { color: currentcolor }", ".foo{color:currentcolor}");
     minify_test(".foo { color: ButtonBorder }", ".foo{color:buttonborder}");
     minify_test(".foo { color: hwb(194 0% 0%) }", ".foo{color:#00c4ff}");
     minify_test(".foo { color: hwb(194 0% 0% / 50%) }", ".foo{color:#00c4ff80}");
@@ -17890,8 +17890,8 @@ mod tests {
     test("lch(from indianred l sqrt(c) h)", "lch(53.9252% 7.16084 26.8448)");
     test("lch(from indianred l c sin(h))", "lch(53.9252% 51.2776 .990043)");
     minify_test(
-      ".foo{color:lch(from currentColor l c sin(h))}",
-      ".foo{color:lch(from currentColor l c sin(h))}",
+      ".foo{color:lch(from currentcolor l c sin(h))}",
+      ".foo{color:lch(from currentcolor l c sin(h))}",
     );
 
     // The following tests were converted from WPT: https://github.com/web-platform-tests/wpt/blob/master/css/css-color/parsing/relative-color-valid.html
@@ -19745,12 +19745,12 @@ mod tests {
       },
     );
     minify_test(
-      ".foo { color: color-mix(in srgb, currentColor, blue); }",
-      ".foo{color:color-mix(in srgb,currentColor,blue)}",
+      ".foo { color: color-mix(in srgb, currentcolor, blue); }",
+      ".foo{color:color-mix(in srgb,currentcolor,blue)}",
     );
     minify_test(
-      ".foo { color: color-mix(in srgb, blue, currentColor); }",
-      ".foo{color:color-mix(in srgb,blue,currentColor)}",
+      ".foo { color: color-mix(in srgb, blue, currentcolor); }",
+      ".foo{color:color-mix(in srgb,blue,currentcolor)}",
     );
     minify_test(
       ".foo { color: color-mix(in srgb, accentcolor, blue); }",
@@ -28747,7 +28747,7 @@ mod tests {
       .foo {
         box-shadow:
             oklch(100% 0 0deg / 50%) 0 0.63rem 0.94rem -0.19rem,
-            currentColor 0 0.44rem 0.8rem -0.58rem;
+            currentcolor 0 0.44rem 0.8rem -0.58rem;
       }
     "#,
       indoc! { r#"
@@ -28766,7 +28766,7 @@ mod tests {
       .foo {
         box-shadow:
             oklch(100% 0 0deg / 50%) 0 0.63rem 0.94rem -0.19rem,
-            currentColor 0 0.44rem 0.8rem -0.58rem;
+            currentcolor 0 0.44rem 0.8rem -0.58rem;
       }
     "#,
       indoc! { r#"

--- a/src/properties/ui.rs
+++ b/src/properties/ui.rs
@@ -188,7 +188,7 @@ impl<'i> ToCss for Cursor<'i> {
 #[cfg_attr(feature = "jsonschema", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "into_owned", derive(static_self::IntoOwned))]
 pub enum ColorOrAuto {
-  /// The `currentColor`, adjusted by the UA to ensure contrast against the background.
+  /// The `currentcolor`, adjusted by the UA to ensure contrast against the background.
   Auto,
   /// A color.
   Color(CssColor),

--- a/src/values/color.rs
+++ b/src/values/color.rs
@@ -44,7 +44,7 @@ use std::fmt::Write;
 #[cfg_attr(feature = "jsonschema", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "into_owned", derive(static_self::IntoOwned))]
 pub enum CssColor {
-  /// The [`currentColor`](https://www.w3.org/TR/css-color-4/#currentcolor-color) keyword.
+  /// The [`currentcolor`](https://www.w3.org/TR/css-color-4/#currentcolor-color) keyword.
   #[cfg_attr(feature = "serde", serde(with = "CurrentColor"))]
   CurrentColor,
   /// An value in the RGB color space, including values parsed as hex colors, or the `rgb()`, `hsl()`, and `hwb()` functions.
@@ -318,7 +318,7 @@ impl ColorFallbackKind {
 }
 
 impl CssColor {
-  /// Returns the `currentColor` keyword.
+  /// Returns the `currentcolor` keyword.
   pub fn current_color() -> CssColor {
     CssColor::CurrentColor
   }
@@ -526,7 +526,7 @@ impl ToCss for CssColor {
     W: std::fmt::Write,
   {
     match self {
-      CssColor::CurrentColor => dest.write_str("currentColor"),
+      CssColor::CurrentColor => dest.write_str("currentcolor"),
       CssColor::RGBA(color) => {
         if color.alpha == 255 {
           let hex: u32 = ((color.red as u32) << 16) | ((color.green as u32) << 8) | (color.blue as u32);

--- a/website/playground/index.html
+++ b/website/playground/index.html
@@ -37,7 +37,7 @@
       }
 
       header .github {
-        fill: currentColor;
+        fill: currentcolor;
       }
 
       header .logo {


### PR DESCRIPTION
Replaces `currentColor` with `currentcolor` (lowercase) to match what's defined in [CSS Color Module Level 4](https://www.w3.org/TR/css-color-4/#currentcolor-color) and [MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value#currentcolor_keyword) (see: https://github.com/mdn/content/pull/16592). Also: https://github.com/tailwindlabs/tailwindcss/pull/17510.