### PR TITLE
feat(parser): Improve error recovery of parser

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,6 +66,7 @@ mod tests {
   use indoc::indoc;
   use pretty_assertions::assert_eq;
   use std::collections::HashMap;
+  use std::sync::{Arc, RwLock};
 
   fn test(source: &str, expected: &str) {
     test_with_options(source, expected, ParserOptions::default())
@@ -233,6 +234,21 @@ mod tests {
     match res {
       Ok(_) => unreachable!(),
       Err(e) => assert_eq!(e.kind, error),
+    }
+  }
+
+  fn error_recovery_test(source: &str) {
+    let warnings = Arc::new(RwLock::default());
+    let res = StyleSheet::parse(
+      &source,
+      ParserOptions {
+        warnings: Some(warnings.clone()),
+        ..Default::default()
+      },
+    );
+    match res {
+      Ok(v) => {}
+      Err(e) => unreachable!("parser error should be recovered, but got {e:?}"),
     }
   }
 
@@ -24393,7 +24409,7 @@ mod tests {
 
   #[test]
   fn test_nesting_error_recovery() {
-    nesting_test(
+    error_recovery_test(
       "
     .container {
       padding: 3rem;
@@ -24404,9 +24420,6 @@ mod tests {
       }
     }
     ",
-      indoc! {
-        ""
-      },
     );
   }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24456,23 +24456,6 @@ mod tests {
   }
 
   #[test]
-  fn test_nesting_selector_error_recovery() {
-    error_recovery_test(
-      "
-    .scope---styled-jsx-placeholder-0__ {
-      --styled-jsx-placeholder-1__: 0 button {
-        color: --styled-jsx-placeholder-2__;
-      }
-
-      div {
-        background-color: --styled-jsx-placeholder-3__;
-      }
-    }
-    ",
-    );
-  }
-
-  #[test]
   fn test_css_variable_error_recovery() {
     error_recovery_test("
     .container {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24425,6 +24425,37 @@ mod tests {
   }
 
   #[test]
+  fn test_keyframes_error_recovery() {
+    error_recovery_test(
+      "
+    .wrapper {
+      @keyframes customAnimation {
+        0% {
+          opacity: 0;
+          transform: scale(0);
+        }
+
+        50% {
+          opacity: --styled-jsx-placeholder-0__;
+          transform: rotate(--styled-jsx-placeholder-1__deg);
+        }
+
+        100% {
+          opacity: 1;
+          transform: scale(1);
+        }
+      }
+
+      .animated {
+        animation: customAnimation --styled-jsx-placeholder-2__ms --styled-jsx-placeholder-3__ forwards;
+        animation-delay: --styled-jsx-placeholder-4__ms;
+      }
+    }
+    ",
+    );
+  }
+
+  #[test]
   fn test_css_modules() {
     css_modules_test(
       r#"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24392,6 +24392,25 @@ mod tests {
   }
 
   #[test]
+  fn test_nesting_error_recovery() {
+    nesting_test(
+      "
+    .container {
+      padding: 3rem;
+      @media (max-width: --styled-jsx-placeholder-0__) {
+        .responsive {
+          color: purple;
+        }
+      }
+    }
+    ",
+      indoc! {
+        ""
+      },
+    );
+  }
+
+  #[test]
   fn test_css_modules() {
     css_modules_test(
       r#"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -242,12 +242,13 @@ mod tests {
     let res = StyleSheet::parse(
       &source,
       ParserOptions {
+        error_recovery: true,
         warnings: Some(warnings.clone()),
         ..Default::default()
       },
     );
     match res {
-      Ok(v) => {}
+      Ok(..) => {}
       Err(e) => unreachable!("parser error should be recovered, but got {e:?}"),
     }
   }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24425,37 +24425,6 @@ mod tests {
   }
 
   #[test]
-  fn test_keyframes_error_recovery() {
-    error_recovery_test(
-      "
-    .wrapper {
-      @keyframes customAnimation {
-        0% {
-          opacity: 0;
-          transform: scale(0);
-        }
-
-        50% {
-          opacity: --styled-jsx-placeholder-0__;
-          transform: rotate(--styled-jsx-placeholder-1__deg);
-        }
-
-        100% {
-          opacity: 1;
-          transform: scale(1);
-        }
-      }
-
-      .animated {
-        animation: customAnimation --styled-jsx-placeholder-2__ms --styled-jsx-placeholder-3__ forwards;
-        animation-delay: --styled-jsx-placeholder-4__ms;
-      }
-    }
-    ",
-    );
-  }
-
-  #[test]
   fn test_css_variable_error_recovery() {
     error_recovery_test("
     .container {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24456,6 +24456,23 @@ mod tests {
   }
 
   #[test]
+  fn test_nesting_selector_error_recovery() {
+    error_recovery_test(
+      "
+    .scope---styled-jsx-placeholder-0__ {
+      --styled-jsx-placeholder-1__: 0 button {
+        color: --styled-jsx-placeholder-2__;
+      }
+
+      div {
+        background-color: --styled-jsx-placeholder-3__;
+      }
+    }
+    ",
+    );
+  }
+
+  #[test]
   fn test_css_modules() {
     css_modules_test(
       r#"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24473,6 +24473,25 @@ mod tests {
   }
 
   #[test]
+  fn test_css_variable_error_recovery() {
+    error_recovery_test("
+    .container {
+      --local-var: --styled-jsx-placeholder-0__;
+      color: var(--text-color);
+      background: linear-gradient(to right, --styled-jsx-placeholder-1__, --styled-jsx-placeholder-2__);
+
+      .item {
+        transform: translate(calc(var(--x) + --styled-jsx-placeholder-3__px), calc(var(--y) + --styled-jsx-placeholder-4__px));
+      }
+
+      div {
+        margin: calc(10px + --styled-jsx-placeholder-5__px);
+      }
+    }
+  ");
+  }
+
+  #[test]
   fn test_css_modules() {
     css_modules_test(
       r#"

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -33,7 +33,7 @@ use crate::rules::{
   CssRule, CssRuleList, Location,
 };
 use crate::selector::{SelectorList, SelectorParser};
-use crate::traits::Parse;
+use crate::traits::{Parse, ParseWithOptions};
 use crate::values::ident::{CustomIdent, DashedIdent};
 use crate::values::string::CowArcStr;
 use crate::vendor_prefix::VendorPrefix;
@@ -295,7 +295,7 @@ impl<'a, 'o, 'i, T: crate::traits::AtRuleParser<'i>> AtRuleParser<'i> for TopLev
         } else {
           None
         };
-        let media = MediaList::parse(input)?;
+        let media = MediaList::parse(input, &self.options)?;
         return Ok(AtRulePrelude::Import(url_string, media, supports, layer));
       },
       "namespace" => {
@@ -317,7 +317,7 @@ impl<'a, 'o, 'i, T: crate::traits::AtRuleParser<'i>> AtRuleParser<'i> for TopLev
       },
       "custom-media" if self.options.flags.contains(ParserFlags::CUSTOM_MEDIA) => {
         let name = DashedIdent::parse(input)?;
-        let media = MediaList::parse(input)?;
+        let media = MediaList::parse(input, &self.options)?;
         return Ok(AtRulePrelude::CustomMedia(name, media))
       },
       "property" => {
@@ -553,11 +553,11 @@ impl<'a, 'o, 'b, 'i, T: crate::traits::AtRuleParser<'i>> AtRuleParser<'i> for Ne
   ) -> Result<Self::Prelude, ParseError<'i, Self::Error>> {
     let result = match_ignore_ascii_case! { &*name,
       "media" => {
-        let media = MediaList::parse(input)?;
+        let media = MediaList::parse(input, &self.options)?;
         AtRulePrelude::Media(media)
       },
       "supports" => {
-        let cond = SupportsCondition::parse(input)?;
+        let cond = SupportsCondition::parse(input, )?;
         AtRulePrelude::Supports(cond)
       },
       "font-face" => {
@@ -645,7 +645,7 @@ impl<'a, 'o, 'b, 'i, T: crate::traits::AtRuleParser<'i>> AtRuleParser<'i> for Ne
       },
       "container" => {
         let name = input.try_parse(ContainerName::parse).ok();
-        let condition = ContainerCondition::parse(input)?;
+        let condition = ContainerCondition::parse_with_options(input, &self.options)?;
         AtRulePrelude::Container(name, condition)
       },
       "starting-style" => {


### PR DESCRIPTION
I'm trying to get some feedback before adding more test cases for error recovery.

Do you think this change sounds good to you?

# Context

 - https://github.com/swc-project/plugins/pull/430

I'm trying to replace `swc_css` with `lightningcss` in `styled-jsx` (and turbopack), but I found an edge case where some more error recovery is necessary due to the way `styled-jsx` works.