### PR TITLE
Add support for `::picker`, `::picker-icon` and `::checkmark`

### DIFF
--- a/scripts/build-prefixes.js
+++ b/scripts/build-prefixes.js
@@ -334,6 +334,9 @@ let mdnFeatures = {
   viewTransition: mdn.css.selectors['view-transition'].__compat.support,
   detailsContent: mdn.css.selectors['details-content'].__compat.support,
   targetText: mdn.css.selectors['target-text'].__compat.support,
+  picker: mdn.css.selectors.picker.__compat.support,
+  pickerIcon: mdn.css.selectors['picker-icon'].__compat.support,
+  checkmark: mdn.css.selectors.checkmark.__compat.support,
 };
 
 for (let key in mdn.css.types.length) {

--- a/selectors/parser.rs
+++ b/selectors/parser.rs
@@ -3933,7 +3933,8 @@ pub mod tests {
     assert!(parse("foo::details-content").is_ok());
     assert!(parse("foo::target-text").is_ok());
 
-    assert!(parse("select::picker").is_ok());
+    assert!(parse("select::picker").is_err());
+    assert!(parse("::picker()").is_err());
     assert!(parse("::picker(select)").is_ok());
     assert!(parse("select::picker-icon").is_ok());
     assert!(parse("option::checkmark").is_ok());

--- a/selectors/parser.rs
+++ b/selectors/parser.rs
@@ -3932,6 +3932,11 @@ pub mod tests {
 
     assert!(parse("foo::details-content").is_ok());
     assert!(parse("foo::target-text").is_ok());
+
+    assert!(parse("select::picker").is_ok());
+    assert!(parse("::picker(select)").is_ok());
+    assert!(parse("select::picker-icon").is_ok());
+    assert!(parse("option::checkmark").is_ok());
   }
 
   #[test]

--- a/src/compat.rs
+++ b/src/compat.rs
@@ -28,6 +28,7 @@ pub enum Feature {
   CapUnit,
   CaseInsensitive,
   ChUnit,
+  Checkmark,
   CircleListStyleType,
   CjkDecimalListStyleType,
   CjkEarthlyBranchListStyleType,
@@ -158,6 +159,8 @@ pub enum Feature {
   P3Colors,
   PartPseudo,
   PersianListStyleType,
+  Picker,
+  PickerIcon,
   PlaceContent,
   PlaceItems,
   PlaceSelf,
@@ -3593,6 +3596,32 @@ impl Feature {
           }
         }
         if browsers.ie.is_some() {
+          return false;
+        }
+      }
+      Feature::Picker | Feature::PickerIcon | Feature::Checkmark => {
+        if let Some(version) = browsers.chrome {
+          if version < 8781824 {
+            return false;
+          }
+        }
+        if let Some(version) = browsers.edge {
+          if version < 8781824 {
+            return false;
+          }
+        }
+        if let Some(version) = browsers.android {
+          if version < 8781824 {
+            return false;
+          }
+        }
+        if browsers.firefox.is_some()
+          || browsers.ie.is_some()
+          || browsers.ios_saf.is_some()
+          || browsers.opera.is_some()
+          || browsers.safari.is_some()
+          || browsers.samsung.is_some()
+        {
           return false;
         }
       }

--- a/src/selector.rs
+++ b/src/selector.rs
@@ -292,7 +292,6 @@ impl<'a, 'o, 'i> parcel_selectors::parser::Parser<'i> for SelectorParser<'a, 'o,
       "-webkit-scrollbar-corner" => WebKitScrollbar(WebKitScrollbarPseudoElement::Corner),
       "-webkit-resizer" => WebKitScrollbar(WebKitScrollbarPseudoElement::Resizer),
 
-      "picker" => Picker,
       "picker-icon" => PickerIcon,
       "checkmark" => Checkmark,
 
@@ -958,8 +957,6 @@ pub enum PseudoElement<'i> {
     /// A part name selector.
     part: ViewTransitionPartSelector<'i>,
   },
-  /// The [::picker](https://drafts.csswg.org/css-forms-1/#the-picker-pseudo-element) pseudo element.
-  Picker,
   /// The [::picker()](https://drafts.csswg.org/css-forms-1/#the-picker-pseudo-element) functional pseudo element.
   PickerFunction {
     /// A form control identifier.
@@ -1229,7 +1226,6 @@ where
       part.to_css(dest)?;
       dest.write_char(')')
     }
-    Picker => dest.write_str("::picker"),
     PickerFunction { identifier } => {
       dest.write_str("::picker(")?;
       identifier.to_css(dest)?;
@@ -1948,7 +1944,7 @@ pub(crate) fn is_compatible(selectors: &[Selector], targets: Targets) -> bool {
           | PseudoElement::ViewTransitionOld { .. }
           | PseudoElement::ViewTransitionGroup { .. }
           | PseudoElement::ViewTransitionImagePair { .. } => Feature::ViewTransition,
-          PseudoElement::Picker | PseudoElement::PickerFunction { identifier: _ } => Feature::Picker,
+          PseudoElement::PickerFunction { identifier: _ } => Feature::Picker,
           PseudoElement::PickerIcon => Feature::PickerIcon,
           PseudoElement::Checkmark => Feature::Checkmark,
           PseudoElement::Custom { name: _ } | _ => return false,


### PR DESCRIPTION
Closes https://github.com/parcel-bundler/lightningcss/issues/942

Adds support for
  - https://developer.mozilla.org/en-US/docs/Web/CSS/::picker
  - https://developer.mozilla.org/en-US/docs/Web/CSS/::picker-icon
  - https://developer.mozilla.org/en-US/docs/Web/CSS/::checkmark