### PR TITLE
fix: upgrade browserslist

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -156,6 +156,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "browserslist-rs"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f95aff901882c66e4b642f3f788ceee152ef44f8a5ef12cb1ddee5479c483be"
+dependencies = [
+ "ahash 0.8.11",
+ "chrono",
+ "either",
+ "indexmap 2.7.0",
+ "itertools 0.13.0",
+ "nom",
+ "serde",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
 name = "bstr"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -736,7 +753,7 @@ dependencies = [
  "assert_fs",
  "atty",
  "bitflags 2.6.0",
- "browserslist-rs",
+ "browserslist-rs 0.18.1",
  "clap",
  "const-str",
  "cssparser",
@@ -794,7 +811,7 @@ dependencies = [
 name = "lightningcss_c_bindings"
 version = "0.1.0"
 dependencies = [
- "browserslist-rs",
+ "browserslist-rs 0.17.0",
  "cbindgen",
  "lightningcss",
  "parcel_sourcemap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,7 +77,7 @@ indexmap = { version = "2.2.6", features = ["serde"] }
 # CLI deps
 atty = { version = "0.2", optional = true }
 clap = { version = "3.0.6", features = ["derive"], optional = true }
-browserslist-rs = { version = "0.17.0", optional = true }
+browserslist-rs = { version = "0.18.1", optional = true }
 rayon = { version = "1.5.1", optional = true }
 dashmap = { version = "5.0.0", optional = true }
 serde_json = { version = "1.0.78", optional = true }


### PR DESCRIPTION
browerslist-rs@0.18.1 supports `android 135` which aligns with browserslist which is needed in next-rspack https://github.com/vercel/next.js/discussions/77800#discussioncomment-12796398