### PR TITLE
Prevent new lines written by `write_str` from breaking source maps

### DIFF
--- a/src/printer.rs
+++ b/src/printer.rs
@@ -137,7 +137,17 @@ impl<'a, 'b, 'c, W: std::fmt::Write + Sized> Printer<'a, 'b, 'c, W> {
   }
 
   /// Writes a raw string to the underlying destination.
+  ///
+  /// NOTE: Is is assumed that the string does not contain any newline characters.
+  /// If such a string is written, it will break source maps.
   pub fn write_str(&mut self, s: &str) -> Result<(), PrinterError> {
+    self.col += s.len() as u32;
+    self.dest.write_str(s)?;
+    Ok(())
+  }
+
+  /// Writes a raw string which may contain newlines to the underlying destination.
+  pub fn write_str_with_newlines(&mut self, s: &str) -> Result<(), PrinterError> {
     let mut last_line_start: usize = 0;
 
     for (idx, n) in s.char_indices() {
@@ -146,7 +156,7 @@ impl<'a, 'b, 'c, W: std::fmt::Write + Sized> Printer<'a, 'b, 'c, W> {
         self.col = 0;
 
         // Keep track of where the *next* line starts
-        last_line_start = idx+1;
+        last_line_start = idx + 1;
       }
     }
 

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -137,11 +137,20 @@ impl<'a, 'b, 'c, W: std::fmt::Write + Sized> Printer<'a, 'b, 'c, W> {
   }
 
   /// Writes a raw string to the underlying destination.
-  ///
-  /// NOTE: Is is assumed that the string does not contain any newline characters.
-  /// If such a string is written, it will break source maps.
   pub fn write_str(&mut self, s: &str) -> Result<(), PrinterError> {
-    self.col += s.len() as u32;
+    let mut last_line_start: usize = 0;
+
+    for (idx, n) in s.char_indices() {
+      if n == '\n' {
+        self.line += 1;
+        self.col = 0;
+
+        // Keep track of where the *next* line starts
+        last_line_start = idx+1;
+      }
+    }
+
+    self.col += (s.len() - last_line_start) as u32;
     self.dest.write_str(s)?;
     Ok(())
   }

--- a/src/stylesheet.rs
+++ b/src/stylesheet.rs
@@ -287,8 +287,8 @@ where
 
     for comment in &self.license_comments {
       printer.write_str("/*")?;
-      printer.write_str(comment)?;
-      printer.write_str("*/\n")?;
+      printer.write_str_with_newlines(comment)?;
+      printer.write_str_with_newlines("*/\n")?;
     }
 
     if let Some(config) = &self.options.css_modules {


### PR DESCRIPTION
Right now putting license comments in a file causes invalid source maps to be generated.

For example, running this file through lightning with source maps will produce [incorrect generated locations](https://evanw.github.io/source-map-visualization/#NDQ4AC8qISBmb28gCiBmb28gCiBmb28gCiBmb28gKi8KLyohIGJhciAqLwouZmxleCB7CiAgZGlzcGxheTogZmxleDsKfQoKLmhpZGRlbiB7CiAgZGlzcGxheTogbm9uZTsKfQoKLyojIHNvdXJjZU1hcHBpbmdVUkw9ZGF0YTphcHBsaWNhdGlvbi9qc29uO2Jhc2U2NCxleUoyWlhKemFXOXVJam96TENKemIzVnlZMlZTYjI5MElqcHVkV3hzTENKdFlYQndhVzVuY3lJNkluZERRVXRCT3pzN08wRkJSMEVpTENKemIzVnlZMlZ6SWpwYkltbHVjSFYwTG1OemN5SmRMQ0p6YjNWeVkyVnpRMjl1ZEdWdWRDSTZXeUl2S2lFZ1ptOXZJRnh1SUdadmJ5QmNiaUJtYjI4Z1hHNGdabTl2SUNvdlhHNHZLaUVnWW1GeUlDb3ZYRzR1Wm14bGVDQjdYRzRnSUdScGMzQnNZWGs2SUdac1pYZzdYRzU5WEc0dWFHbGtaR1Z1SUh0Y2JpQWdaR2x6Y0d4aGVUb2dibTl1WlR0Y2JuMWNiaUpkTENKdVlXMWxjeUk2VzExOSAqLwoyMjIAeyJ2ZXJzaW9uIjozLCJzb3VyY2VSb290IjpudWxsLCJtYXBwaW5ncyI6IndDQUtBOzs7O0FBR0EiLCJzb3VyY2VzIjpbImlucHV0LmNzcyJdLCJzb3VyY2VzQ29udGVudCI6WyIvKiEgZm9vIFxuIGZvbyBcbiBmb28gXG4gZm9vICovXG4vKiEgYmFyICovXG4uZmxleCB7XG4gIGRpc3BsYXk6IGZsZXg7XG59XG4uaGlkZGVuIHtcbiAgZGlzcGxheTogbm9uZTtcbn1cbiJdLCJuYW1lcyI6W119):
```css
/*! foo 
 foo 
 foo 
 foo */
/*! bar */
.flex {
  display: flex;
}
.hidden {
  display: none;
}
```

Here's a screenshot of the source map visualizer for the generated CSS:
<img width="1255" alt="Screenshot showing incorrectly generated source locations" src="https://github.com/user-attachments/assets/a1bddc4b-a3bf-4a21-bacc-53058c01abb2" />


This happens because Lightning computes the column offset to be the length of the comment _plus_ the new line character at the end _and_ this happens for each license comment in the file. Additionally, license comments are one of the few things that basically preserve the content as is including new lines. So if the license comment itself contains new lines than the generated mappings can be pretty far off — as the screenshot above shows.

This PR fixes this by tracking new lines and resetting the appropriate state when printing the CSS in `write_str`.
