### PR TITLE
fix: remove grid feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,11 +34,10 @@ path = "src/lib.rs"
 crate-type = ["rlib"]
 
 [features]
-default = ["bundler", "grid", "nodejs", "sourcemap"]
+default = ["bundler", "nodejs", "sourcemap"]
 browserslist = ["browserslist-rs"]
 bundler = ["dashmap", "sourcemap", "rayon"]
 cli = ["atty", "clap", "serde_json", "browserslist", "jemallocator"]
-grid = []
 jsonschema = ["schemars", "serde", "parcel_selectors/jsonschema"]
 nodejs = ["dep:serde"]
 serde = [

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21690,7 +21690,6 @@ mod tests {
     }
   }
 
-  #[cfg(feature = "grid")]
   #[test]
   fn test_grid() {
     minify_test(
@@ -24982,7 +24981,6 @@ mod tests {
       false,
     );
 
-    #[cfg(feature = "grid")]
     css_modules_test(
       r#"
       body {
@@ -25027,7 +25025,6 @@ mod tests {
       false,
     );
 
-    #[cfg(feature = "grid")]
     css_modules_test(
       r#"
         .grid {
@@ -25066,7 +25063,6 @@ mod tests {
       false,
     );
 
-    #[cfg(feature = "grid")]
     css_modules_test(
       r#"
         .grid {

--- a/src/properties/mod.rs
+++ b/src/properties/mod.rs
@@ -104,7 +104,6 @@ pub mod display;
 pub mod effects;
 pub mod flex;
 pub mod font;
-#[cfg(feature = "grid")]
 pub mod grid;
 pub mod list;
 pub(crate) mod margin_padding;
@@ -154,7 +153,6 @@ use display::*;
 use effects::*;
 use flex::*;
 use font::*;
-#[cfg(feature = "grid")]
 use grid::*;
 use list::*;
 use margin_padding::*;
@@ -1372,50 +1370,20 @@ define_properties! {
   "flex-negative": FlexNegative(CSSNumber, VendorPrefix) / Ms unprefixed: false,
   "flex-preferred-size": FlexPreferredSize(LengthPercentageOrAuto, VendorPrefix) / Ms unprefixed: false,
 
-  #[cfg(feature = "grid")]
-  #[cfg_attr(docsrs, doc(cfg(feature = "grid")))]
   "grid-template-columns": GridTemplateColumns(TrackSizing<'i>),
-  #[cfg(feature = "grid")]
-  #[cfg_attr(docsrs, doc(cfg(feature = "grid")))]
   "grid-template-rows": GridTemplateRows(TrackSizing<'i>),
-  #[cfg(feature = "grid")]
-  #[cfg_attr(docsrs, doc(cfg(feature = "grid")))]
   "grid-auto-columns": GridAutoColumns(TrackSizeList),
-  #[cfg(feature = "grid")]
-  #[cfg_attr(docsrs, doc(cfg(feature = "grid")))]
   "grid-auto-rows": GridAutoRows(TrackSizeList),
-  #[cfg(feature = "grid")]
-  #[cfg_attr(docsrs, doc(cfg(feature = "grid")))]
   "grid-auto-flow": GridAutoFlow(GridAutoFlow),
-  #[cfg(feature = "grid")]
-  #[cfg_attr(docsrs, doc(cfg(feature = "grid")))]
   "grid-template-areas": GridTemplateAreas(GridTemplateAreas),
-  #[cfg(feature = "grid")]
-  #[cfg_attr(docsrs, doc(cfg(feature = "grid")))]
   "grid-template": GridTemplate(GridTemplate<'i>) shorthand: true,
-  #[cfg(feature = "grid")]
-  #[cfg_attr(docsrs, doc(cfg(feature = "grid")))]
   "grid": Grid(Grid<'i>) shorthand: true,
-  #[cfg(feature = "grid")]
-  #[cfg_attr(docsrs, doc(cfg(feature = "grid")))]
   "grid-row-start": GridRowStart(GridLine<'i>),
-  #[cfg(feature = "grid")]
-  #[cfg_attr(docsrs, doc(cfg(feature = "grid")))]
   "grid-row-end": GridRowEnd(GridLine<'i>),
-  #[cfg(feature = "grid")]
-  #[cfg_attr(docsrs, doc(cfg(feature = "grid")))]
   "grid-column-start": GridColumnStart(GridLine<'i>),
-  #[cfg(feature = "grid")]
-  #[cfg_attr(docsrs, doc(cfg(feature = "grid")))]
   "grid-column-end": GridColumnEnd(GridLine<'i>),
-  #[cfg(feature = "grid")]
-  #[cfg_attr(docsrs, doc(cfg(feature = "grid")))]
   "grid-row": GridRow(GridRow<'i>) shorthand: true,
-  #[cfg(feature = "grid")]
-  #[cfg_attr(docsrs, doc(cfg(feature = "grid")))]
   "grid-column": GridColumn(GridColumn<'i>) shorthand: true,
-  #[cfg(feature = "grid")]
-  #[cfg_attr(docsrs, doc(cfg(feature = "grid")))]
   "grid-area": GridArea(GridArea<'i>) shorthand: true,
 
   "margin-top": MarginTop(LengthPercentageOrAuto) [logical_group: Margin, category: Physical],


### PR DESCRIPTION
Fix #376

I removed the grid feature because it cannot be compiled with it disabled.

> Probably should just get rid of the grid feature actually. I had it there when it was still under development. None of the other individual properties have flags, so grid probably shouldn't either. Don't think it should cause much difference in compilation times.

https://github.com/parcel-bundler/lightningcss/issues/376#issuecomment-1367953788