### PR TITLE
Allow passing browserslist options to `from_browserslist`

### DIFF
--- a/src/targets.rs
+++ b/src/targets.rs
@@ -42,15 +42,26 @@ pub struct Browsers {
 }
 
 #[cfg(feature = "browserslist")]
+pub use browserslist::Opts as BrowserslistConfig;
+
+#[cfg(feature = "browserslist")]
 #[cfg_attr(docsrs, doc(cfg(feature = "browserslist")))]
 impl Browsers {
   /// Parses a list of browserslist queries into Lightning CSS targets.
   pub fn from_browserslist<S: AsRef<str>, I: IntoIterator<Item = S>>(
     query: I,
   ) -> Result<Option<Browsers>, browserslist::Error> {
+    Self::from_browserslist_with_config(query, None)
+  }
+
+  /// Parses a list of browserslist queries into Lightning CSS targets.
+  pub fn from_browserslist_with_config<S: AsRef<str>, I: IntoIterator<Item = S>>(
+    query: I,
+    config: Option<BrowserslistConfig>,
+  ) -> Result<Option<Browsers>, browserslist::Error> {
     use browserslist::{resolve, Opts};
 
-    Self::from_distribs(resolve(query, &Opts::default())?)
+    Self::from_distribs(resolve(query, &config.unwrap_or(Opts::default()))?)
   }
 
   #[cfg(not(target_arch = "wasm32"))]

--- a/src/targets.rs
+++ b/src/targets.rs
@@ -51,17 +51,17 @@ impl Browsers {
   pub fn from_browserslist<S: AsRef<str>, I: IntoIterator<Item = S>>(
     query: I,
   ) -> Result<Option<Browsers>, browserslist::Error> {
-    Self::from_browserslist_with_config(query, None)
+    Self::from_browserslist_with_config(query, BrowserslistConfig::default())
   }
 
   /// Parses a list of browserslist queries into Lightning CSS targets.
   pub fn from_browserslist_with_config<S: AsRef<str>, I: IntoIterator<Item = S>>(
     query: I,
-    config: Option<BrowserslistConfig>,
+    config: BrowserslistConfig,
   ) -> Result<Option<Browsers>, browserslist::Error> {
-    use browserslist::{resolve, Opts};
+    use browserslist::resolve;
 
-    Self::from_distribs(resolve(query, &config.unwrap_or(Opts::default()))?)
+    Self::from_distribs(resolve(query, &config)?)
   }
 
   #[cfg(not(target_arch = "wasm32"))]


### PR DESCRIPTION
For Turbopack we want to pass `ignore_unknown_versions` but that currently can't be passed to the browserslist parsing because it always defaults to the default options.

Initially thought about making `from_distribs` public but this can cause issues where browserslist versions mismatch when the application browserslist is a different version than the lightningcss browserslist.

Instead opted for re-exporting the browserslist config options from lightningcss and adding a new method for `from_browserslist_with_config`. The `_with_config` suffix because `from_browserslist` currently takes one argument and introducing a second argument would be a breaking change.