### PR TITLE
fix: ensure directories exist before building with `--sourcemap`

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -175,6 +175,12 @@ pub fn main() -> Result<(), std::io::Error> {
         ..ParserOptions::default()
       };
 
+      if let (Some(_), Some(output_path)) = (&source_map, &output_file) {
+        if let Some(p) = output_path.parent() {
+          fs::create_dir_all(p)?
+        };
+      };
+
       let mut stylesheet = if cli_args.bundle {
         let mut bundler = Bundler::new(&fs, source_map.as_mut(), options);
         bundler.bundle(Path::new(&filename)).unwrap()

--- a/tests/cli_integration_tests.rs
+++ b/tests/cli_integration_tests.rs
@@ -218,6 +218,29 @@ fn output_file_option_create_missing_directories() -> Result<(), Box<dyn std::er
 }
 
 #[test]
+fn output_file_option_with_sourcemap_create_missing_directories() -> Result<(), Box<dyn std::error::Error>> {
+  let infile = test_file()?;
+  let outdir = assert_fs::TempDir::new()?;
+  let outfile = outdir.child("out.css");
+  outdir.close()?;
+  let mut cmd = Command::cargo_bin("lightningcss")?;
+  cmd.arg(infile.path());
+  cmd.arg("--sourcemap");
+  cmd.arg("--output-file").arg(outfile.path());
+  cmd.assert().success();
+  outfile.assert(predicate::str::contains(indoc! {
+    r#"
+      .foo {
+        border: none;
+      }
+    "#
+  }));
+  fs::remove_dir_all(outfile.parent().unwrap())?;
+
+  Ok(())
+}
+
+#[test]
 fn multiple_input_files() -> Result<(), Box<dyn std::error::Error>> {
   let infile = test_file()?;
   let infile2 = test_file2()?;


### PR DESCRIPTION
I'm not super familiar with Rust, feel free to give feedback if necessary.

Closes #1019 