### PR TITLE
Add custom serialize_string function producing shorter representation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -766,6 +766,7 @@ dependencies = [
  "const-str",
  "cssparser",
  "cssparser-color",
+ "cssparser-macros",
  "dashmap",
  "data-encoding",
  "getrandom 0.3.3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,7 @@ substitute_variables = ["visitor", "into_owned"]
 [dependencies]
 serde = { version = "1.0.201", features = ["derive"], optional = true }
 cssparser = "0.33.0"
+cssparser-macros = "*"
 cssparser-color = "0.1.0"
 parcel_selectors = { version = "0.28.2", path = "./selectors" }
 itertools = "0.10.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,6 +35,7 @@ pub mod printer;
 pub mod properties;
 pub mod rules;
 pub mod selector;
+mod serialize;
 pub mod stylesheet;
 pub mod targets;
 pub mod traits;

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -7,7 +7,6 @@ use crate::rules::{Location, StyleContext};
 use crate::selector::SelectorList;
 use crate::targets::{Targets, TargetsWithSupportsScope};
 use crate::vendor_prefix::VendorPrefix;
-use cssparser::{serialize_identifier, serialize_name};
 #[cfg(feature = "sourcemap")]
 use parcel_sourcemap::{OriginalLocation, SourceMap};
 
@@ -305,9 +304,9 @@ impl<'a, 'b, 'c, W: std::fmt::Write + Sized> Printer<'a, 'b, 'c, W> {
             self.col += s.len() as u32;
             if first {
               first = false;
-              serialize_identifier(s, dest)
+              crate::serialize::identifier(s, dest)
             } else {
-              serialize_name(s, dest)
+              crate::serialize::name(s, dest)
             }
           },
         )?;
@@ -317,7 +316,7 @@ impl<'a, 'b, 'c, W: std::fmt::Write + Sized> Printer<'a, 'b, 'c, W> {
       }
     }
 
-    serialize_identifier(ident, self)?;
+    crate::serialize::identifier(ident, self)?;
     Ok(())
   }
 
@@ -338,7 +337,7 @@ impl<'a, 'b, 'c, W: std::fmt::Write + Sized> Printer<'a, 'b, 'c, W> {
           },
           |s| {
             self.col += s.len() as u32;
-            serialize_name(s, dest)
+            crate::serialize::name(s, dest)
           },
         )?;
 
@@ -347,7 +346,7 @@ impl<'a, 'b, 'c, W: std::fmt::Write + Sized> Printer<'a, 'b, 'c, W> {
         }
       }
       _ => {
-        serialize_name(&ident[2..], self)?;
+        crate::serialize::name(&ident[2..], self)?;
       }
     }
 

--- a/src/properties/animation.rs
+++ b/src/properties/animation.rs
@@ -73,7 +73,7 @@ impl<'i> ToCss for AnimationName<'i> {
         // CSS-wide keywords and `none` cannot remove quotes.
         match_ignore_ascii_case! { &*s,
           "none" | "initial" | "inherit" | "unset" | "default" | "revert" | "revert-layer" => {
-            serialize_string(&s, dest)?;
+            crate::serialize::string(&s, dest)?;
             Ok(())
           },
           _ => {

--- a/src/properties/css_modules.rs
+++ b/src/properties/css_modules.rs
@@ -128,7 +128,7 @@ impl<'i> ToCss for Specifier<'i> {
   {
     match self {
       Specifier::Global => dest.write_str("global")?,
-      Specifier::File(file) => serialize_string(&file, dest)?,
+      Specifier::File(file) => crate::serialize::string(&file, dest)?,
       Specifier::SourceIndex(..) => {}
     }
     Ok(())

--- a/src/properties/font.rs
+++ b/src/properties/font.rs
@@ -429,13 +429,13 @@ impl<'i> ToCss for FamilyName<'i> {
         } else {
           id.push(' ');
         }
-        serialize_identifier(slice, &mut id)?;
+        crate::serialize::identifier(slice, &mut id)?;
       }
       if id.len() < val.len() + 2 {
         return dest.write_str(&id);
       }
     }
-    serialize_string(&val, dest)?;
+    crate::serialize::string(&val, dest)?;
     Ok(())
   }
 }

--- a/src/rules/font_face.rs
+++ b/src/rules/font_face.rs
@@ -244,7 +244,7 @@ impl<'i> ToCss for FontFormat<'i> {
     };
     // Browser support for keywords rather than strings is very limited.
     // https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/src
-    serialize_string(&s, dest)?;
+    crate::serialize::string(&s, dest)?;
     Ok(())
   }
 }

--- a/src/rules/import.rs
+++ b/src/rules/import.rs
@@ -11,7 +11,6 @@ use crate::traits::ToCss;
 use crate::values::string::CowArcStr;
 #[cfg(feature = "visitor")]
 use crate::visitor::Visit;
-use cssparser::*;
 
 /// A [@import](https://drafts.csswg.org/css-cascade/#at-import) rule.
 #[derive(Debug, PartialEq, Clone)]
@@ -52,13 +51,13 @@ impl<'i> ToCss for ImportRule<'i> {
     dest.add_mapping(self.loc);
     dest.write_str("@import ")?;
     if let Some(dep) = dep {
-      serialize_string(&dep.placeholder, dest)?;
+      crate::serialize::string(&dep.placeholder, dest)?;
 
       if let Some(dependencies) = &mut dest.dependencies {
         dependencies.push(Dependency::Import(dep))
       }
     } else {
-      serialize_string(&self.url, dest)?;
+      crate::serialize::string(&self.url, dest)?;
     }
 
     if let Some(layer) = &self.layer {

--- a/src/rules/keyframes.rs
+++ b/src/rules/keyframes.rs
@@ -104,7 +104,7 @@ impl<'i> ToCss for KeyframesName<'i> {
         // CSS-wide keywords and `none` cannot remove quotes.
         match_ignore_ascii_case! { &*s,
           "none" | "initial" | "inherit" | "unset" | "default" | "revert" | "revert-layer" => {
-            serialize_string(&s, dest)?;
+            crate::serialize::string(&s, dest)?;
           },
           _ => {
             dest.write_ident(s.as_ref(), css_module_animation_enabled)?;

--- a/src/rules/layer.rs
+++ b/src/rules/layer.rs
@@ -73,7 +73,7 @@ impl<'i> ToCss for LayerName<'i> {
         dest.write_char('.')?;
       }
 
-      serialize_identifier(name, dest)?;
+      crate::serialize::identifier(name, dest)?;
     }
 
     Ok(())

--- a/src/rules/supports.rs
+++ b/src/rules/supports.rs
@@ -404,7 +404,7 @@ impl<'i> ToCss for SupportsCondition<'i> {
           }
 
           p.to_css(dest)?;
-          serialize_name(name, dest)?;
+          crate::serialize::name(name, dest)?;
           dest.delim(':', false)?;
           dest.write_str(value)?;
         }

--- a/src/selector.rs
+++ b/src/selector.rs
@@ -664,7 +664,7 @@ where
         } else {
           dest.delim(',', false)?;
         }
-        serialize_identifier(lang, dest)?;
+        crate::serialize::identifier(lang, dest)?;
       }
       return dest.write_str(")");
     }
@@ -1559,7 +1559,7 @@ where
       if dest.minify {
         // Serialize as both an identifier and a string and choose the shorter one.
         let mut id = String::new();
-        serialize_identifier(&value, &mut id)?;
+        crate::serialize::identifier(&value, &mut id)?;
 
         let s = value.to_css_string(Default::default())?;
 

--- a/src/serialize.rs
+++ b/src/serialize.rs
@@ -1,0 +1,93 @@
+pub use cssparser::{serialize_identifier as identifier, serialize_name as name};
+
+/// Write a quoted CSS string token, escaping content as necessary.
+///
+/// Uses single or double quotes depending on the presence of quote characters
+/// in the `value`.
+pub fn string(value: &str, dest: &mut impl core::fmt::Write) -> core::fmt::Result {
+    let count = value.bytes().fold(0isize, |count, ch| {
+        match ch {
+          b'"'  => count + 1,
+          b'\'' => count - 1,
+          _     => count,
+    }});
+    let (quote, quote_str, escaped_quote) = if count <= 0 {
+        (b'"', "\"", "\\\"")
+    } else {
+        (b'\'', "'", "\\'")
+    };
+
+    // Based on cssparser::serialize_string but with less indirection and
+    // generic code, and added handling for custom quote character.
+    dest.write_str(quote_str)?;
+    let bytes = value.as_bytes();
+    let mut chunk_start = 0;
+    for (i, byte) in bytes.iter().copied().enumerate() {
+        let mut buf = [0; 4];
+        let escaped = cssparser_macros::match_byte! { byte,
+            b'"' | b'\'' => if byte == quote {
+                escaped_quote
+            } else {
+                continue
+            },
+            b'\\' => "\\\\",
+            b'\0' => "\u{FFFD}",
+            b'\x01'..=b'\x1F' | b'\x7F' => hex_escape(byte, &mut buf, bytes.get(i + 1)),
+            _ => continue,
+        };
+        dest.write_str(&value[chunk_start..i])?;
+        dest.write_str(escaped)?;
+        chunk_start = i + 1;
+    }
+    dest.write_str(&value[chunk_start..])?;
+    dest.write_str(quote_str)
+}
+
+
+/// Escapes an ASCII character using hex encoding.
+///
+/// `next` indicates character in the string that followers the byte we’re
+/// escaping.  If it’s a hexadecimal digit, escaped representation will be
+/// followed by a space.  Otherwise (including if `next` is `None`), no space
+/// will be included.
+// Based on cssparser::hex_escape
+fn hex_escape<'a>(byte: u8, buf: &'a mut [u8; 4], next: Option<&u8>) -> &'a str {
+    static HEX_DIGITS: &[u8; 16] = b"0123456789abcdef";
+    let mut len = if byte <= 0x0F {
+        buf[0] = b'\\';
+        buf[1] = HEX_DIGITS[usize::from(byte)];
+        buf[2] = b' ';
+        buf[3] = b' ';
+        2
+    } else {
+        buf[0] = b'\\';
+        buf[1] = HEX_DIGITS[usize::from(byte >> 4)];
+        buf[2] = HEX_DIGITS[usize::from(byte & 0xF)];
+        buf[3] = b' ';
+        3
+    };
+    if next.map_or(false, u8::is_ascii_hexdigit) {
+        len += 1;
+    };
+    // SAFETY: We’ve written only ASCII characters to `buf`.
+    unsafe { core::str::from_utf8_unchecked(&buf[..len]) }
+}
+
+#[test]
+fn test_string() {
+    for (value, quoted) in [
+        ("foo", "\"foo\""),
+        (r#""Hejże," he exclaimed."#, r#"'"Hejże," he exclaimed.'"#),
+        ("rock'n'roll", r#""rock'n'roll""#),
+        (r#""I love Rock'n'Roll," she shouted."#,
+         r#""\"I love Rock'n'Roll,\" she shouted.""#),
+
+        ("\x01",  r#""\1""#),
+        ("\x01A", r#""\1 A""#),
+        ("\x01Z", r#""\1Z""#),
+    ] {
+        let mut got = String::new();
+        string(value, &mut got).unwrap();
+        assert_eq!(quoted, got);
+    }
+}

--- a/src/values/ident.rs
+++ b/src/values/ident.rs
@@ -238,7 +238,7 @@ impl<'i> ToCss for DashedIdentReference<'i> {
       Some(css_module) if css_module.config.dashed_idents => {
         if let Some(name) = css_module.reference_dashed(&self.ident.0, &self.from, dest.loc.source_index) {
           dest.write_str("--")?;
-          serialize_name(&name, dest)?;
+          crate::serialize::name(&name, dest)?;
           return Ok(());
         }
       }
@@ -269,7 +269,7 @@ impl<'i> ToCss for Ident<'i> {
   where
     W: std::fmt::Write,
   {
-    serialize_identifier(&self.0, dest)?;
+    crate::serialize::identifier(&self.0, dest)?;
     Ok(())
   }
 }
@@ -279,7 +279,7 @@ impl<'i> cssparser::ToCss for Ident<'i> {
   where
     W: std::fmt::Write,
   {
-    serialize_identifier(&self.0, dest)
+    crate::serialize::identifier(&self.0, dest)
   }
 }
 

--- a/src/values/image.rs
+++ b/src/values/image.rs
@@ -459,12 +459,12 @@ impl<'i> ImageSetOption<'i> {
           None
         };
         if let Some(dep) = dep {
-          serialize_string(&dep.placeholder, dest)?;
+          crate::serialize::string(&dep.placeholder, dest)?;
           if let Some(dependencies) = &mut dest.dependencies {
             dependencies.push(Dependency::Url(dep))
           }
         } else {
-          serialize_string(&url.url, dest)?;
+          crate::serialize::string(&url.url, dest)?;
         }
       }
       _ => self.image.to_css(dest)?,
@@ -484,7 +484,7 @@ impl<'i> ImageSetOption<'i> {
 
     if let Some(file_type) = &self.file_type {
       dest.write_str(" type(")?;
-      serialize_string(&file_type, dest)?;
+      crate::serialize::string(&file_type, dest)?;
       dest.write_char(')')?;
     }
 

--- a/src/values/string.rs
+++ b/src/values/string.rs
@@ -3,7 +3,7 @@
 use crate::traits::{Parse, ToCss};
 #[cfg(feature = "visitor")]
 use crate::visitor::{Visit, VisitTypes, Visitor};
-use cssparser::{serialize_string, CowRcStr};
+use cssparser::CowRcStr;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Deserializer};
 #[cfg(any(feature = "serde", feature = "nodejs"))]
@@ -342,7 +342,7 @@ impl<'i> ToCss for CSSString<'i> {
   where
     W: std::fmt::Write,
   {
-    serialize_string(&self.0, dest)?;
+    crate::serialize::string(&self.0, dest)?;
     Ok(())
   }
 }
@@ -352,7 +352,7 @@ impl<'i> cssparser::ToCss for CSSString<'i> {
   where
     W: fmt::Write,
   {
-    serialize_string(&self.0, dest)
+    crate::serialize::string(&self.0, dest)
   }
 }
 

--- a/src/values/url.rs
+++ b/src/values/url.rs
@@ -53,7 +53,7 @@ impl<'i> ToCss for Url<'i> {
     // be replaced without escaping more easily. Quotes may be removed later during minification.
     if let Some(dep) = dep {
       dest.write_str("url(")?;
-      serialize_string(&dep.placeholder, dest)?;
+      crate::serialize::string(&dep.placeholder, dest)?;
       dest.write_char(')')?;
 
       if let Some(dependencies) = &mut dest.dependencies {
@@ -72,7 +72,7 @@ impl<'i> ToCss for Url<'i> {
       // then serialize as a string and choose the shorter version.
       if buf.len() > self.url.len() + 7 {
         let mut buf2 = String::new();
-        serialize_string(&self.url, &mut buf2)?;
+        crate::serialize::string(&self.url, &mut buf2)?;
         if buf2.len() + 5 < buf.len() {
           dest.write_str("url(")?;
           dest.write_str(&buf2)?;
@@ -83,7 +83,7 @@ impl<'i> ToCss for Url<'i> {
       dest.write_str(&buf)?;
     } else {
       dest.write_str("url(")?;
-      serialize_string(&self.url, dest)?;
+      crate::serialize::string(&self.url, dest)?;
       dest.write_char(')')?;
     }
 


### PR DESCRIPTION
Provide custom implementation of the serilaize_string function found in cssparser which takes more care to use shortest possible string representation.  This is done with through two changes.

Firstly, the function figures out whether double or single quotes are better.  For example, `Holmes never said "Elementary, my dear Watson."` is best quoted using apostrophes to avoid escaping the double quotes inside.

Secondly, the function avoids unnecessary space after hex encoding of control characters.  For example, `\x01Z` is escaped as `"\1Z"` rather than `"\1 Z"`.

To make this all more consistent throughout the code-base, introduce serialize module with symbols corresponding to serialise_* functions in cssparse crate.