### PR TITLE
Add support for `::grammar-error` and `::spelling-error`

### DIFF
--- a/scripts/build-prefixes.js
+++ b/scripts/build-prefixes.js
@@ -341,6 +341,8 @@ let mdnFeatures = {
   picker: mdn.css.selectors.picker.__compat.support,
   pickerIcon: mdn.css.selectors['picker-icon'].__compat.support,
   checkmark: mdn.css.selectors.checkmark.__compat.support,
+  grammarError: mdn.css.selectors['grammar-error'].__compat.support,
+  spellingError: mdn.css.selectors['spelling-error'].__compat.support,
 };
 
 for (let key in mdn.css.types.length) {

--- a/selectors/parser.rs
+++ b/selectors/parser.rs
@@ -3938,6 +3938,11 @@ pub mod tests {
     assert!(parse("::picker(select)").is_ok());
     assert!(parse("select::picker-icon").is_ok());
     assert!(parse("option::checkmark").is_ok());
+
+    assert!(parse("::grammar-error").is_ok());
+    assert!(parse("::spelling-error").is_ok());
+    assert!(parse("::part(mypart)::grammar-error").is_ok());
+    assert!(parse("::part(mypart)::spelling-error").is_ok());
   }
 
   #[test]

--- a/src/compat.rs
+++ b/src/compat.rs
@@ -87,6 +87,7 @@ pub enum Feature {
   Gencontent,
   GeorgianListStyleType,
   GradientInterpolationHints,
+  GrammarError,
   GujaratiListStyleType,
   GurmukhiListStyleType,
   HasSelector,
@@ -189,6 +190,7 @@ pub enum Feature {
   SimpChineseFormalListStyleType,
   SimpChineseInformalListStyleType,
   SomaliListStyleType,
+  SpellingError,
   SpaceSeparatedColorNotation,
   SquareListStyleType,
   StretchSize,
@@ -5595,6 +5597,46 @@ impl Feature {
           return false;
         }
       }
+      Feature::GrammarError | Feature::SpellingError => {
+        if let Some(version) = browsers.chrome {
+          if version < 7929856 { // Chrome 121
+            return false;
+          }
+        }
+        if let Some(version) = browsers.edge {
+          if version < 7929856 { // Edge 121
+            return false;
+          }
+        }
+        if let Some(version) = browsers.opera {
+          if version < 7929856 { // Opera 121
+            return false;
+          }
+        }
+        if let Some(version) = browsers.safari {
+          if version < 1115136 { // Safari 17.4
+            return false;
+          }
+        }
+        if let Some(version) = browsers.ios_saf {
+          if version < 1115136 { // iOS Safari 17.4
+            return false;
+          }
+        }
+        if let Some(version) = browsers.android {
+          if version < 7929856 { // Android Chrome 121
+            return false;
+          }
+        }
+        if let Some(version) = browsers.samsung {
+          if version < 7929856 { // Samsung Internet 121
+            return false;
+          }
+        }
+        if browsers.firefox.is_some() || browsers.ie.is_some() {
+          return false;
+        }
+      }      
       Feature::P3Colors | Feature::LangSelectorList => {
         if let Some(version) = browsers.safari {
           if version < 655616 {

--- a/src/selector.rs
+++ b/src/selector.rs
@@ -297,6 +297,9 @@ impl<'a, 'o, 'i> parcel_selectors::parser::Parser<'i> for SelectorParser<'a, 'o,
 
       "view-transition" => ViewTransition,
 
+      "grammar-error" => GrammarError,
+      "spelling-error" => SpellingError,
+
       _ => {
         if !name.starts_with('-') {
           self.options.warn(loc.new_custom_error(SelectorParseErrorKind::UnsupportedPseudoElement(name.clone())));
@@ -966,6 +969,10 @@ pub enum PseudoElement<'i> {
   PickerIcon,
   /// The [::checkmark](https://drafts.csswg.org/css-forms-1/#styling-checkmarks-the-checkmark-pseudo-element) pseudo element.
   Checkmark,
+  /// The [::grammar-error](https://drafts.csswg.org/css-pseudo/#selectordef-grammar-error) pseudo element.
+  GrammarError,
+  /// The [::spelling-error](https://drafts.csswg.org/css-pseudo/#selectordef-spelling-error) pseudo element.
+  SpellingError,
   /// An unknown pseudo element.
   Custom {
     /// The name of the pseudo element.
@@ -1233,6 +1240,8 @@ where
     }
     PickerIcon => dest.write_str("::picker-icon"),
     Checkmark => dest.write_str("::checkmark"),
+    GrammarError => dest.write_str("::grammar-error"),
+    SpellingError => dest.write_str("::spelling-error"),
     Custom { name: val } => {
       dest.write_str("::")?;
       return dest.write_str(val);
@@ -1947,6 +1956,8 @@ pub(crate) fn is_compatible(selectors: &[Selector], targets: Targets) -> bool {
           PseudoElement::PickerFunction { identifier: _ } => Feature::Picker,
           PseudoElement::PickerIcon => Feature::PickerIcon,
           PseudoElement::Checkmark => Feature::Checkmark,
+          PseudoElement::GrammarError => Feature::GrammarError,
+          PseudoElement::SpellingError => Feature::SpellingError,
           PseudoElement::Custom { name: _ } | _ => return false,
         },
 


### PR DESCRIPTION
- https://developer.mozilla.org/en-US/docs/Web/CSS/::grammar-error
- https://developer.mozilla.org/en-US/docs/Web/CSS/::spelling-error

Closes: #1021