### PR TITLE
feat: support options serialize and deserialize

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ serde = [
   "cssparser/serde",
   "parcel_selectors/serde",
   "into_owned",
+  "bitflags/serde"
 ]
 sourcemap = ["parcel_sourcemap"]
 visitor = []

--- a/src/css_modules.rs
+++ b/src/css_modules.rs
@@ -26,9 +26,15 @@ use std::path::Path;
 
 /// Configuration for CSS modules.
 #[derive(Clone, Debug)]
+#[cfg_attr(
+  feature = "serde",
+  derive(serde::Serialize, serde::Deserialize),
+  serde(rename_all = "camelCase")
+)]
 pub struct Config<'i> {
   /// The name pattern to use when renaming class names and other identifiers.
   /// Default is `[hash]_[local]`.
+  #[cfg_attr(feature = "serde", serde(bound(deserialize = "'de: 'i")))]
   pub pattern: Pattern<'i>,
   /// Whether to rename dashed identifiers, e.g. custom properties.
   pub dashed_idents: bool,
@@ -64,7 +70,13 @@ impl<'i> Default for Config<'i> {
 
 /// A CSS modules class name pattern.
 #[derive(Clone, Debug)]
+#[cfg_attr(
+  feature = "serde",
+  derive(serde::Serialize, serde::Deserialize),
+  serde(rename_all = "camelCase")
+)]
 pub struct Pattern<'i> {
+  #[cfg_attr(feature = "serde", serde(bound(deserialize = "'de: 'i")))]
   /// The list of segments in the pattern.
   pub segments: SmallVec<[Segment<'i>; 2]>,
 }
@@ -196,6 +208,11 @@ impl<'i> Pattern<'i> {
 ///
 /// See [Pattern](Pattern).
 #[derive(Clone, Debug)]
+#[cfg_attr(
+  feature = "serde",
+  derive(serde::Serialize, serde::Deserialize),
+  serde(rename_all = "camelCase")
+)]
 pub enum Segment<'i> {
   /// A literal string segment.
   Literal(&'i str),

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -47,6 +47,11 @@ use std::sync::{Arc, RwLock};
 bitflags! {
   /// Parser feature flags to enable.
   #[derive(Clone, Debug, Default)]
+  #[cfg_attr(
+    feature = "serde",
+    derive(serde::Serialize, serde::Deserialize),
+    serde(rename_all = "camelCase")
+  )]
   pub struct ParserFlags: u8 {
     /// Whether the enable the [CSS nesting](https://www.w3.org/TR/css-nesting-1/) draft syntax.
     const NESTING = 1 << 0;
@@ -59,9 +64,15 @@ bitflags! {
 
 /// CSS parsing options.
 #[derive(Clone, Debug, Default)]
+#[cfg_attr(
+  feature = "serde",
+  derive(serde::Serialize, serde::Deserialize),
+  serde(rename_all = "camelCase")
+)]
 pub struct ParserOptions<'o, 'i> {
   /// Filename to use in error messages.
   pub filename: String,
+  #[cfg_attr(feature = "serde", serde(bound(deserialize = "'de: 'o")))]
   /// Whether the enable [CSS modules](https://github.com/css-modules/css-modules).
   pub css_modules: Option<crate::css_modules::Config<'o>>,
   /// The source index to assign to all parsed rules. Impacts the source map when
@@ -70,6 +81,7 @@ pub struct ParserOptions<'o, 'i> {
   /// Whether to ignore invalid rules and declarations rather than erroring.
   pub error_recovery: bool,
   /// A list that will be appended to when a warning occurs.
+  #[cfg_attr(feature = "serde", serde(skip))]
   pub warnings: Option<Arc<RwLock<Vec<Error<ParserError<'i>>>>>>,
   /// Feature flags to enable.
   pub flags: ParserFlags,

--- a/src/stylesheet.rs
+++ b/src/stylesheet.rs
@@ -85,8 +85,9 @@ pub struct StyleSheet<'i, 'o, T = DefaultAtRule> {
   /// This is only set if CSS modules are enabled and the pattern includes [content-hash].
   #[cfg_attr(feature = "serde", serde(skip))]
   pub(crate) content_hashes: Option<Vec<String>>,
-  #[cfg_attr(feature = "serde", serde(skip))]
+  // #[cfg_attr(feature = "serde", serde(skip))]
   /// The options the style sheet was originally parsed with.
+  #[cfg_attr(feature = "serde", serde(bound(deserialize = "'de: 'o")))]
   options: ParserOptions<'o, 'i>,
 }
 

--- a/src/stylesheet.rs
+++ b/src/stylesheet.rs
@@ -85,7 +85,6 @@ pub struct StyleSheet<'i, 'o, T = DefaultAtRule> {
   /// This is only set if CSS modules are enabled and the pattern includes [content-hash].
   #[cfg_attr(feature = "serde", serde(skip))]
   pub(crate) content_hashes: Option<Vec<String>>,
-  // #[cfg_attr(feature = "serde", serde(skip))]
   /// The options the style sheet was originally parsed with.
   #[cfg_attr(feature = "serde", serde(bound(deserialize = "'de: 'o")))]
   options: ParserOptions<'o, 'i>,


### PR DESCRIPTION
`options` will be discarded during the serialization of `stylesheet`, and `options` will use the default value after deserialization

This change of `pr` will also include `option` in the serialization, so that its parameters before and after serialization are consistent