### PR TITLE
migrate to maintained library

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -777,7 +777,7 @@ dependencies = [
  "lightningcss-derive",
  "parcel_selectors",
  "parcel_sourcemap",
- "paste",
+ "pastey",
  "pathdiff",
  "predicates 2.1.5",
  "pretty_assertions",
@@ -1023,10 +1023,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "paste"
-version = "1.0.15"
+name = "pastey"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+checksum = "b3a8cb46bdc156b1c90460339ae6bfd45ba0394e5effbaa640badb4987fdc261"
 
 [[package]]
 name = "pathdiff"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,7 +72,7 @@ lazy_static = "1.4.0"
 const-str = "0.3.1"
 pathdiff = "0.2.1"
 ahash = "0.8.7"
-paste = "1.0.12"
+pastey = "0.1.0"
 indexmap = { version = "2.2.6", features = ["serde"] }
 # CLI deps
 atty = { version = "0.2", optional = true }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -189,7 +189,7 @@ macro_rules! shorthand_property_bitflags {
     crate::macros::shorthand_property_bitflags!($name, [$($all),*] $($rest),* ; $last_index + 1; $($var = $index)* $cur = $last_index + 1);
   };
   ($name:ident, [$($all:ident),*] $cur:ident; $last_index:expr ; $($var:ident = $index:expr)+) => {
-    paste::paste! {
+    pastey::paste! {
       crate::macros::property_bitflags! {
         #[derive(Default, Debug)]
         struct [<$name Property>]: u8 {
@@ -216,7 +216,7 @@ macro_rules! shorthand_handler {
       $(
         pub $key: Option<$type>,
       )*
-      flushed_properties: paste::paste!([<$shorthand Property>]),
+      flushed_properties: pastey::paste!([<$shorthand Property>]),
       has_any: bool
     }
 
@@ -250,7 +250,7 @@ macro_rules! shorthand_handler {
 
             let mut unparsed = val.clone();
             context.add_unparsed_fallbacks(&mut unparsed);
-            paste::paste! {
+            pastey::paste! {
               self.flushed_properties.insert([<$shorthand Property>]::try_from(&unparsed.property_id).unwrap());
             };
             dest.push(Property::Unparsed(unparsed));
@@ -263,7 +263,7 @@ macro_rules! shorthand_handler {
 
       fn finalize(&mut self, dest: &mut DeclarationList<'i>, context: &mut PropertyHandlerContext<'i, '_>) {
         self.flush(dest, context);
-        self.flushed_properties = paste::paste!([<$shorthand Property>]::empty());
+        self.flushed_properties = pastey::paste!([<$shorthand Property>]::empty());
       }
     }
 
@@ -289,7 +289,7 @@ macro_rules! shorthand_handler {
           };
 
           $(
-            if $shorthand_fallback && !self.flushed_properties.intersects(paste::paste!([<$shorthand Property>]::$shorthand)) {
+            if $shorthand_fallback && !self.flushed_properties.intersects(pastey::paste!([<$shorthand Property>]::$shorthand)) {
               let fallbacks = shorthand.get_fallbacks(context.targets);
               for fallback in fallbacks {
                 dest.push(Property::$shorthand(fallback));
@@ -298,7 +298,7 @@ macro_rules! shorthand_handler {
           )?
 
           dest.push(Property::$shorthand(shorthand));
-          paste::paste! {
+          pastey::paste! {
             self.flushed_properties.insert([<$shorthand Property>]::$shorthand);
           };
         } else {
@@ -306,7 +306,7 @@ macro_rules! shorthand_handler {
             #[allow(unused_mut)]
             if let Some(mut val) = $key {
               $(
-                if $fallback && !self.flushed_properties.intersects(paste::paste!([<$shorthand Property>]::$prop)) {
+                if $fallback && !self.flushed_properties.intersects(pastey::paste!([<$shorthand Property>]::$prop)) {
                   let fallbacks = val.get_fallbacks(context.targets);
                   for fallback in fallbacks {
                     dest.push(Property::$prop(fallback));
@@ -315,7 +315,7 @@ macro_rules! shorthand_handler {
               )?
 
               dest.push(Property::$prop(val));
-              paste::paste! {
+              pastey::paste! {
                 self.flushed_properties.insert([<$shorthand Property>]::$prop);
               };
             }
@@ -390,7 +390,7 @@ macro_rules! impl_shorthand {
     impl<'i> Shorthand<'i> for $t {
       #[allow(unused_variables)]
       fn from_longhands(decls: &DeclarationBlock<'i>, vendor_prefix: crate::vendor_prefix::VendorPrefix) -> Option<(Self, bool)> {
-        use paste::paste;
+        use pastey::paste;
 
         $(
           $(

--- a/src/properties/list.rs
+++ b/src/properties/list.rs
@@ -108,7 +108,7 @@ macro_rules! counter_styles {
       fn is_compatible(&self, browsers: Browsers) -> bool {
         match self {
           $(
-            PredefinedCounterStyle::$id => paste::paste! {
+            PredefinedCounterStyle::$id => pastey::paste! {
               crate::compat::Feature::[<$id ListStyleType>].is_compatible(browsers)
             },
           )+

--- a/src/properties/prefix_handler.rs
+++ b/src/properties/prefix_handler.rs
@@ -79,7 +79,7 @@ macro_rules! define_fallbacks {
   (
     $( $name: ident$(($p: ident))?, )+
   ) => {
-    paste::paste! {
+    pastey::paste! {
       #[derive(Default)]
       pub(crate) struct FallbackHandler {
         $(
@@ -97,7 +97,7 @@ macro_rules! define_fallbacks {
               $(
                 $p = context.targets.prefixes($p, Feature::$name);
               )?
-              if paste::paste! { self.[<$name:snake>] }.is_none() {
+              if pastey::paste! { self.[<$name:snake>] }.is_none() {
                 let fallbacks = val.get_fallbacks(context.targets);
                 #[allow(unused_variables)]
                 let has_fallbacks = !fallbacks.is_empty();
@@ -112,10 +112,10 @@ macro_rules! define_fallbacks {
                 )?
               }
 
-              if paste::paste! { self.[<$name:snake>] }.is_none() || matches!(context.targets.browsers, Some(targets) if !val.is_compatible(targets)) {
-                paste::paste! { self.[<$name:snake>] = Some(dest.len()) };
+              if pastey::paste! { self.[<$name:snake>] }.is_none() || matches!(context.targets.browsers, Some(targets) if !val.is_compatible(targets)) {
+                pastey::paste! { self.[<$name:snake>] = Some(dest.len()) };
                 dest.push(Property::$name(val $(, $p)?));
-              } else if let Some(index) = paste::paste! { self.[<$name:snake>] } {
+              } else if let Some(index) = pastey::paste! { self.[<$name:snake>] } {
                 dest[index] = Property::$name(val $(, $p)?);
               }
             }
@@ -138,7 +138,7 @@ macro_rules! define_fallbacks {
                   }
 
                   let val = get_prefixed!($($p)?);
-                  (val, paste::paste! { &mut self.[<$name:snake>] })
+                  (val, pastey::paste! { &mut self.[<$name:snake>] })
                 }
               )+
               _ => return false
@@ -161,7 +161,7 @@ macro_rules! define_fallbacks {
 
       fn finalize(&mut self, _: &mut DeclarationList, _: &mut PropertyHandlerContext) {
         $(
-          paste::paste! { self.[<$name:snake>] = None };
+          pastey::paste! { self.[<$name:snake>] = None };
         )+
       }
     }


### PR DESCRIPTION
I ran cargo-deny and got this output:

```rust
cargo deny check advisories
error[unmaintained]: paste - no longer maintained
205 │ paste 1.0.15 registry+https://github.com/rust-lang/crates.io-index
    │ ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ unmaintained advisory detected
    │
    ├ ID: RUSTSEC-2024-0436
    ├ Advisory: https://rustsec.org/advisories/RUSTSEC-2024-0436
    ├ The creator of the crate `paste` has stated in the [`README.md`](https://github.com/dtolnay/paste/blob/master/README.md) 
      that this project is not longer maintained as well as archived the repository
      
      ## Possible Alternative(s)
      
      - [pastey](https://crates.io/crates/pastey), a fork of paste and is aimed to be a drop-in replacement with additional features for paste crate
    ├ Announcement: https://github.com/dtolnay/paste
    ├ Solution: No safe upgrade is available!
    ├ paste v1.0.15
      └── lightningcss v1.0.0-alpha.67
```

So I changed the dependencie from paste to pastey.