### PR TITLE
Add lightningcss-wasm as a fallback

### DIFF
--- a/node/index.js
+++ b/node/index.js
@@ -19,7 +19,11 @@ if (process.env.CSS_TRANSFORMER_WASM) {
   try {
     module.exports = require(`lightningcss-${parts.join('-')}`);
   } catch (err) {
-    module.exports = require(`../lightningcss.${parts.join('-')}.node`);
+    try {
+      module.exports = require(`../lightningcss.${parts.join('-')}.node`);
+    } catch (err) {
+      module.exports = require(`lightningcss-wasm`);
+    }
   }
 }
 


### PR DESCRIPTION
For example this allows using `@tailwindcss/cli`, which requires `lightningcss`, on OpenBSD, for which `lightningcss` doesn't provide a binary.