### PR TITLE
Move away from private serde APIs

### DIFF
--- a/src/rules/container.rs
+++ b/src/rules/container.rs
@@ -32,6 +32,10 @@ pub struct ContainerRule<'i, R = DefaultAtRule> {
   pub name: Option<ContainerName<'i>>,
   /// The container condition.
   pub condition: ContainerCondition<'i>,
+  #[cfg_attr(
+    feature = "serde",
+    serde(borrow, bound(deserialize = "R: serde::Deserialize<'de> + 'i"))
+  )]
   /// The rules within the `@container` rule.
   pub rules: CssRuleList<'i, R>,
   /// The location of the rule in the source file.

--- a/src/rules/document.rs
+++ b/src/rules/document.rs
@@ -20,7 +20,10 @@ use crate::visitor::Visit;
 #[cfg_attr(feature = "into_owned", derive(static_self::IntoOwned))]
 pub struct MozDocumentRule<'i, R = DefaultAtRule> {
   /// Nested rules within the `@-moz-document` rule.
-  #[cfg_attr(feature = "serde", serde(borrow))]
+  #[cfg_attr(
+    feature = "serde",
+    serde(borrow, bound(deserialize = "R: serde::Deserialize<'de> + 'i"))
+  )]
   pub rules: CssRuleList<'i, R>,
   /// The location of the rule in the source file.
   #[cfg_attr(feature = "visitor", skip_visit)]

--- a/src/rules/layer.rs
+++ b/src/rules/layer.rs
@@ -119,7 +119,10 @@ impl<'i> ToCss for LayerStatementRule<'i> {
 #[cfg_attr(feature = "into_owned", derive(static_self::IntoOwned))]
 pub struct LayerBlockRule<'i, R = DefaultAtRule> {
   /// The name of the layer to declare, or `None` to declare an anonymous layer.
-  #[cfg_attr(feature = "serde", serde(borrow))]
+  #[cfg_attr(
+    feature = "serde",
+    serde(borrow, bound(deserialize = "R: serde::Deserialize<'de> + 'i"))
+  )]
   #[cfg_attr(feature = "visitor", skip_visit)]
   pub name: Option<LayerName<'i>>,
   /// The rules within the `@layer` rule.

--- a/src/rules/media.rs
+++ b/src/rules/media.rs
@@ -21,6 +21,10 @@ pub struct MediaRule<'i, R = DefaultAtRule> {
   #[cfg_attr(feature = "serde", serde(borrow))]
   pub query: MediaList<'i>,
   /// The rules within the `@media` rule.
+  #[cfg_attr(
+    feature = "serde",
+    serde(borrow, bound(deserialize = "R: serde::Deserialize<'de> + 'i"))
+  )]
   pub rules: CssRuleList<'i, R>,
   /// The location of the rule in the source file.
   #[cfg_attr(feature = "visitor", skip_visit)]

--- a/src/rules/mod.rs
+++ b/src/rules/mod.rs
@@ -195,7 +195,7 @@ pub enum CssRule<'i, R = DefaultAtRule> {
 // Manually implemented deserialize to reduce binary size.
 #[cfg(feature = "serde")]
 #[cfg_attr(docsrs, doc(cfg(feature = "serde")))]
-impl<'de: 'i, 'i, R: serde::Deserialize<'de> + 'i> serde::Deserialize<'de> for CssRule<'i, R> {
+impl<'i, 'de: 'i, R: serde::Deserialize<'de> + 'i> serde::Deserialize<'de> for CssRule<'i, R> {
   fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
   where
     D: serde::Deserializer<'de>,
@@ -437,7 +437,11 @@ impl<'i, T> CssRule<'i, T> {
 #[cfg_attr(feature = "jsonschema", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "into_owned", derive(static_self::IntoOwned))]
 pub struct CssRuleList<'i, R = DefaultAtRule>(
-  #[cfg_attr(feature = "serde", serde(borrow))] pub Vec<CssRule<'i, R>>,
+  #[cfg_attr(
+    feature = "serde",
+    serde(borrow, bound(deserialize = "R: serde::Deserialize<'de> + 'i"))
+  )]
+  pub Vec<CssRule<'i, R>>,
 );
 
 impl<'i> CssRuleList<'i, DefaultAtRule> {

--- a/src/rules/nesting.rs
+++ b/src/rules/nesting.rs
@@ -23,7 +23,10 @@ use crate::visitor::Visit;
 #[cfg_attr(feature = "into_owned", derive(static_self::IntoOwned))]
 pub struct NestingRule<'i, R = DefaultAtRule> {
   /// The style rule that defines the selector and declarations for the `@nest` rule.
-  #[cfg_attr(feature = "serde", serde(borrow))]
+  #[cfg_attr(
+    feature = "serde",
+    serde(borrow, bound(deserialize = "R: serde::Deserialize<'de> + 'i"))
+  )]
   pub style: StyleRule<'i, R>,
   /// The location of the rule in the source file.
   #[cfg_attr(feature = "visitor", skip_visit)]

--- a/src/rules/scope.rs
+++ b/src/rules/scope.rs
@@ -30,7 +30,10 @@ pub struct ScopeRule<'i, R = DefaultAtRule> {
   /// A selector list used to identify any scoping limits.
   pub scope_end: Option<SelectorList<'i>>,
   /// Nested rules within the `@scope` rule.
-  #[cfg_attr(feature = "serde", serde(borrow))]
+  #[cfg_attr(
+    feature = "serde",
+    serde(borrow, bound(deserialize = "R: serde::Deserialize<'de> + 'i"))
+  )]
   pub rules: CssRuleList<'i, R>,
   /// The location of the rule in the source file.
   #[cfg_attr(feature = "visitor", skip_visit)]

--- a/src/rules/starting_style.rs
+++ b/src/rules/starting_style.rs
@@ -17,7 +17,10 @@ use crate::visitor::Visit;
 #[cfg_attr(feature = "into_owned", derive(static_self::IntoOwned))]
 pub struct StartingStyleRule<'i, R = DefaultAtRule> {
   /// Nested rules within the `@starting-style` rule.
-  #[cfg_attr(feature = "serde", serde(borrow))]
+  #[cfg_attr(
+    feature = "serde",
+    serde(borrow, bound(deserialize = "R: serde::Deserialize<'de> + 'i"))
+  )]
   pub rules: CssRuleList<'i, R>,
   /// The location of the rule in the source file.
   #[cfg_attr(feature = "visitor", skip_visit)]

--- a/src/rules/style.rs
+++ b/src/rules/style.rs
@@ -41,6 +41,10 @@ pub struct StyleRule<'i, R = DefaultAtRule> {
   pub declarations: DeclarationBlock<'i>,
   /// Nested rules within the style rule.
   #[cfg_attr(feature = "serde", serde(default = "default_rule_list::<R>"))]
+  #[cfg_attr(
+    feature = "serde",
+    serde(borrow, bound(deserialize = "R: serde::Deserialize<'de> + 'i"))
+  )]
   pub rules: CssRuleList<'i, R>,
   /// The location of the rule in the source file.
   #[cfg_attr(feature = "visitor", skip_visit)]

--- a/src/rules/supports.rs
+++ b/src/rules/supports.rs
@@ -31,6 +31,10 @@ pub struct SupportsRule<'i, R = DefaultAtRule> {
   #[cfg_attr(feature = "serde", serde(borrow))]
   pub condition: SupportsCondition<'i>,
   /// The rules within the `@supports` rule.
+  #[cfg_attr(
+    feature = "serde",
+    serde(borrow, bound(deserialize = "R: serde::Deserialize<'de> + 'i"))
+  )]
   pub rules: CssRuleList<'i, R>,
   /// The location of the rule in the source file.
   #[cfg_attr(feature = "visitor", skip_visit)]

--- a/src/stylesheet.rs
+++ b/src/stylesheet.rs
@@ -72,7 +72,10 @@ pub use crate::printer::PseudoClasses;
 )]
 pub struct StyleSheet<'i, 'o, T = DefaultAtRule> {
   /// A list of top-level rules within the style sheet.
-  #[cfg_attr(feature = "serde", serde(borrow))]
+  #[cfg_attr(
+    feature = "serde",
+    serde(borrow, bound(deserialize = "T: serde::Deserialize<'de> + 'i"))
+  )]
   pub rules: CssRuleList<'i, T>,
   /// A list of file names for all source files included within the style sheet.
   /// Sources are referenced by index in the `loc` property of each rule.


### PR DESCRIPTION
Part of #1056

<details>
<summary> Lifetime problem that I figured out already </summary>

```
error[E0309]: the parameter type `R` may not live long enough
   --> src/rules/mod.rs:436:56
    |
436 | #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize), serde(transparent))]
    |                                                        ^^^^^^^^^^^^^^^^^^ ...so that the type `R` will meet its required lifetime bounds
...
439 | pub struct CssRuleList<'i, R = DefaultAtRule>(
    |                        -- the parameter type `R` must be valid for the lifetime `'i` as defined here...
    |
    = note: this error originates in the derive macro `serde::Deserialize` (in Nightly builds, run with -Z macro-backtrace for more info)
help: consider adding an explicit lifetime bound
    |
439 | pub struct CssRuleList<'i, R: 'i = DefaultAtRule>(
    |                             ++++

For more information about this error, try `rustc --explain E0309`.
error: could not compile `lightningcss` (lib) due to 1 previous error
```

</details>
