### PR TITLE
Use serde-content instead of private serde types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -784,6 +784,7 @@ dependencies = [
  "rayon",
  "schemars",
  "serde",
+ "serde-content",
  "serde_json",
  "smallvec",
  "static-self",
@@ -810,6 +811,7 @@ dependencies = [
  "parcel_sourcemap",
  "rayon",
  "serde",
+ "serde-content",
  "serde-detach",
  "serde_bytes",
  "smallvec",
@@ -1408,11 +1410,21 @@ checksum = "3cb6eb87a131f756572d7fb904f6e7b68633f09cca868c5df1c4b8d1a694bbba"
 
 [[package]]
 name = "serde"
-version = "1.0.216"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b9781016e935a97e8beecf0c933758c97a5520d32930e460142b4cd80c6338e"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
+ "serde_core",
  "serde_derive",
+]
+
+[[package]]
+name = "serde-content"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3753ca04f350fa92d00b6146a3555e63c55388c9ef2e11e09bce2ff1c0b509c6"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -1435,10 +1447,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_derive"
-version = "1.0.216"
+name = "serde_core"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46f859dbbf73865c6627ed570e78961cd3ac92407a2d117204c49232485da55e"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,9 +39,10 @@ browserslist = ["browserslist-rs"]
 bundler = ["dashmap", "sourcemap", "rayon"]
 cli = ["atty", "clap", "serde_json", "browserslist", "jemallocator"]
 jsonschema = ["schemars", "serde", "parcel_selectors/jsonschema"]
-nodejs = ["dep:serde"]
+nodejs = ["dep:serde", "dep:serde-content"]
 serde = [
   "dep:serde",
+  "dep:serde-content",
   "bitflags/serde",
   "smallvec/serde",
   "cssparser/serde",
@@ -59,7 +60,8 @@ into_owned = [
 substitute_variables = ["visitor", "into_owned"]
 
 [dependencies]
-serde = { version = "1.0.201", features = ["derive"], optional = true }
+serde = { version = "1.0.228", features = ["derive"], optional = true }
+serde-content = { version = "0.1.2", features = ["serde"], optional = true }
 cssparser = "0.33.0"
 cssparser-color = "0.1.0"
 parcel_selectors = { version = "0.28.2", path = "./selectors" }

--- a/napi/Cargo.toml
+++ b/napi/Cargo.toml
@@ -14,6 +14,7 @@ bundler = ["dep:crossbeam-channel", "dep:rayon"]
 
 [dependencies]
 serde = { version = "1.0.201", features = ["derive"] }
+serde-content = { version = "0.1.2", features = ["serde"] }
 serde_bytes = "0.11.5"
 cssparser = "0.33.0"
 lightningcss = { version = "1.0.0-alpha.66", path = "../", features = [

--- a/src/properties/mod.rs
+++ b/src/properties/mod.rs
@@ -989,7 +989,7 @@ macro_rules! define_properties {
         D: serde::Deserializer<'de>,
       {
         enum ContentOrRaw<'de> {
-          Content(serde::__private::de::Content<'de>),
+          Content(serde_content::Value<'de>),
           Raw(CowArcStr<'de>)
         }
 
@@ -1062,26 +1062,26 @@ macro_rules! define_properties {
           ContentOrRaw::Content(content) => content
         };
 
-        let deserializer = serde::__private::de::ContentDeserializer::new(content);
+        let deserializer = serde_content::Deserializer::new(content).coerce_numbers();
         match partial.property_id {
           $(
             $(#[$meta])*
             PropertyId::$property$((vp_name!($vp, prefix)))? => {
-              let value = <$type>::deserialize(deserializer)?;
+              let value = <$type>::deserialize(deserializer).map_err(|e| serde::de::Error::custom(e.to_string()))?;
               Ok(Property::$property(value $(, vp_name!($vp, prefix))?))
             },
           )+
           PropertyId::Custom(name) => {
             if name.as_ref() == "unparsed" {
-              let value = UnparsedProperty::deserialize(deserializer)?;
+              let value = UnparsedProperty::deserialize(deserializer).map_err(|e| serde::de::Error::custom(e.to_string()))?;
               Ok(Property::Unparsed(value))
             } else {
-              let value = CustomProperty::deserialize(deserializer)?;
+              let value = CustomProperty::deserialize(deserializer).map_err(|e| serde::de::Error::custom(e.to_string()))?;
               Ok(Property::Custom(value))
             }
           }
           PropertyId::All => {
-            let value = CSSWideKeyword::deserialize(deserializer)?;
+            let value = CSSWideKeyword::deserialize(deserializer).map_err(|e| serde::de::Error::custom(e.to_string()))?;
             Ok(Property::All(value))
           }
         }

--- a/src/rules/mod.rs
+++ b/src/rules/mod.rs
@@ -209,7 +209,7 @@ impl<'i, 'de: 'i, R: serde::Deserialize<'de>> serde::Deserialize<'de> for CssRul
 
     struct PartialRule<'de> {
       rule_type: CowArcStr<'de>,
-      content: serde::__private::de::Content<'de>,
+      content: serde_content::Value<'de>,
     }
 
     struct CssRuleVisitor;
@@ -226,7 +226,7 @@ impl<'i, 'de: 'i, R: serde::Deserialize<'de>> serde::Deserialize<'de> for CssRul
         A: serde::de::MapAccess<'de>,
       {
         let mut rule_type: Option<CowArcStr<'de>> = None;
-        let mut value: Option<serde::__private::de::Content> = None;
+        let mut value: Option<serde_content::Value> = None;
         while let Some(key) = map.next_key()? {
           match key {
             Field::Type => {
@@ -245,108 +245,122 @@ impl<'i, 'de: 'i, R: serde::Deserialize<'de>> serde::Deserialize<'de> for CssRul
     }
 
     let partial = deserializer.deserialize_map(CssRuleVisitor)?;
-    let deserializer = serde::__private::de::ContentDeserializer::new(partial.content);
+    let deserializer = serde_content::Deserializer::new(partial.content).coerce_numbers();
 
     match partial.rule_type.as_ref() {
       "media" => {
-        let rule = MediaRule::deserialize(deserializer)?;
+        let rule = MediaRule::deserialize(deserializer).map_err(|e| serde::de::Error::custom(e.to_string()))?;
         Ok(CssRule::Media(rule))
       }
       "import" => {
-        let rule = ImportRule::deserialize(deserializer)?;
+        let rule = ImportRule::deserialize(deserializer).map_err(|e| serde::de::Error::custom(e.to_string()))?;
         Ok(CssRule::Import(rule))
       }
       "style" => {
-        let rule = StyleRule::deserialize(deserializer)?;
+        let rule = StyleRule::deserialize(deserializer).map_err(|e| serde::de::Error::custom(e.to_string()))?;
         Ok(CssRule::Style(rule))
       }
       "keyframes" => {
-        let rule = KeyframesRule::deserialize(deserializer)?;
+        let rule =
+          KeyframesRule::deserialize(deserializer).map_err(|e| serde::de::Error::custom(e.to_string()))?;
         Ok(CssRule::Keyframes(rule))
       }
       "font-face" => {
-        let rule = FontFaceRule::deserialize(deserializer)?;
+        let rule = FontFaceRule::deserialize(deserializer).map_err(|e| serde::de::Error::custom(e.to_string()))?;
         Ok(CssRule::FontFace(rule))
       }
       "font-palette-values" => {
-        let rule = FontPaletteValuesRule::deserialize(deserializer)?;
+        let rule =
+          FontPaletteValuesRule::deserialize(deserializer).map_err(|e| serde::de::Error::custom(e.to_string()))?;
         Ok(CssRule::FontPaletteValues(rule))
       }
       "font-feature-values" => {
-        let rule = FontFeatureValuesRule::deserialize(deserializer)?;
+        let rule =
+          FontFeatureValuesRule::deserialize(deserializer).map_err(|e| serde::de::Error::custom(e.to_string()))?;
         Ok(CssRule::FontFeatureValues(rule))
       }
       "page" => {
-        let rule = PageRule::deserialize(deserializer)?;
+        let rule = PageRule::deserialize(deserializer).map_err(|e| serde::de::Error::custom(e.to_string()))?;
         Ok(CssRule::Page(rule))
       }
       "supports" => {
-        let rule = SupportsRule::deserialize(deserializer)?;
+        let rule = SupportsRule::deserialize(deserializer).map_err(|e| serde::de::Error::custom(e.to_string()))?;
         Ok(CssRule::Supports(rule))
       }
       "counter-style" => {
-        let rule = CounterStyleRule::deserialize(deserializer)?;
+        let rule =
+          CounterStyleRule::deserialize(deserializer).map_err(|e| serde::de::Error::custom(e.to_string()))?;
         Ok(CssRule::CounterStyle(rule))
       }
       "namespace" => {
-        let rule = NamespaceRule::deserialize(deserializer)?;
+        let rule =
+          NamespaceRule::deserialize(deserializer).map_err(|e| serde::de::Error::custom(e.to_string()))?;
         Ok(CssRule::Namespace(rule))
       }
       "moz-document" => {
-        let rule = MozDocumentRule::deserialize(deserializer)?;
+        let rule =
+          MozDocumentRule::deserialize(deserializer).map_err(|e| serde::de::Error::custom(e.to_string()))?;
         Ok(CssRule::MozDocument(rule))
       }
       "nesting" => {
-        let rule = NestingRule::deserialize(deserializer)?;
+        let rule = NestingRule::deserialize(deserializer).map_err(|e| serde::de::Error::custom(e.to_string()))?;
         Ok(CssRule::Nesting(rule))
       }
       "nested-declarations" => {
-        let rule = NestedDeclarationsRule::deserialize(deserializer)?;
+        let rule = NestedDeclarationsRule::deserialize(deserializer)
+          .map_err(|e| serde::de::Error::custom(e.to_string()))?;
         Ok(CssRule::NestedDeclarations(rule))
       }
       "viewport" => {
-        let rule = ViewportRule::deserialize(deserializer)?;
+        let rule = ViewportRule::deserialize(deserializer).map_err(|e| serde::de::Error::custom(e.to_string()))?;
         Ok(CssRule::Viewport(rule))
       }
       "custom-media" => {
-        let rule = CustomMediaRule::deserialize(deserializer)?;
+        let rule =
+          CustomMediaRule::deserialize(deserializer).map_err(|e| serde::de::Error::custom(e.to_string()))?;
         Ok(CssRule::CustomMedia(rule))
       }
       "layer-statement" => {
-        let rule = LayerStatementRule::deserialize(deserializer)?;
+        let rule =
+          LayerStatementRule::deserialize(deserializer).map_err(|e| serde::de::Error::custom(e.to_string()))?;
         Ok(CssRule::LayerStatement(rule))
       }
       "layer-block" => {
-        let rule = LayerBlockRule::deserialize(deserializer)?;
+        let rule =
+          LayerBlockRule::deserialize(deserializer).map_err(|e| serde::de::Error::custom(e.to_string()))?;
         Ok(CssRule::LayerBlock(rule))
       }
       "property" => {
-        let rule = PropertyRule::deserialize(deserializer)?;
+        let rule = PropertyRule::deserialize(deserializer).map_err(|e| serde::de::Error::custom(e.to_string()))?;
         Ok(CssRule::Property(rule))
       }
       "container" => {
-        let rule = ContainerRule::deserialize(deserializer)?;
+        let rule =
+          ContainerRule::deserialize(deserializer).map_err(|e| serde::de::Error::custom(e.to_string()))?;
         Ok(CssRule::Container(rule))
       }
       "scope" => {
-        let rule = ScopeRule::deserialize(deserializer)?;
+        let rule = ScopeRule::deserialize(deserializer).map_err(|e| serde::de::Error::custom(e.to_string()))?;
         Ok(CssRule::Scope(rule))
       }
       "starting-style" => {
-        let rule = StartingStyleRule::deserialize(deserializer)?;
+        let rule =
+          StartingStyleRule::deserialize(deserializer).map_err(|e| serde::de::Error::custom(e.to_string()))?;
         Ok(CssRule::StartingStyle(rule))
       }
       "view-transition" => {
-        let rule = ViewTransitionRule::deserialize(deserializer)?;
+        let rule =
+          ViewTransitionRule::deserialize(deserializer).map_err(|e| serde::de::Error::custom(e.to_string()))?;
         Ok(CssRule::ViewTransition(rule))
       }
       "ignored" => Ok(CssRule::Ignored),
       "unknown" => {
-        let rule = UnknownAtRule::deserialize(deserializer)?;
+        let rule =
+          UnknownAtRule::deserialize(deserializer).map_err(|e| serde::de::Error::custom(e.to_string()))?;
         Ok(CssRule::Unknown(rule))
       }
       "custom" => {
-        let rule = R::deserialize(deserializer)?;
+        let rule = R::deserialize(deserializer).map_err(|e| serde::de::Error::custom(e.to_string()))?;
         Ok(CssRule::Custom(rule))
       }
       t => Err(serde::de::Error::unknown_variant(t, &[])),


### PR DESCRIPTION
Fixes #1056

Uses the [serde-content](https://crates.io/crates/serde-content) crate to buffer during deserialization instead of internal private serde types, which have now moved.