### PR TITLE
Fix incorrect attr() type output with unminified code

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22633,6 +22633,26 @@ mod tests {
     minify_test(".foo { --theme-sizes-1\\/12: 2 }", ".foo{--theme-sizes-1\\/12:2}");
     minify_test(".foo { --test: 0px; }", ".foo{--test:0px}");
 
+    // Test attr() function with type() syntax - minified
+    minify_test(
+      ".foo { background-color: attr(data-color type(<color>)); }",
+      ".foo{background-color:attr(data-color type(<color>))}"
+    );
+    minify_test(
+      ".foo { width: attr(data-width type(<length>), 100px); }",
+      ".foo{width:attr(data-width type(<length>),100px)}"
+    );
+    
+    // Test attr() function with type() syntax - non-minified (issue with extra spaces)
+    test(
+      ".foo { background-color: attr(data-color type(<color>)); }",
+      ".foo {\n  background-color: attr(data-color type(<color>));\n}\n"
+    );
+    test(
+      ".foo { width: attr(data-width type(<length>), 100px); }",
+      ".foo {\n  width: attr(data-width type(<length>), 100px);\n}\n"
+    );
+
     prefix_test(
       r#"
       .foo {

--- a/src/properties/custom.rs
+++ b/src/properties/custom.rs
@@ -603,11 +603,16 @@ impl<'i> TokenList<'i> {
               dest.write_char(' ')?;
               dest.write_char(*d)?;
               dest.write_char(' ')?;
+              true
+            } else if *d == '<' || *d == '>' {
+              // Angle brackets should not have whitespace added after them (e.g., in type(<color>))
+              dest.write_char(*d)?;
+              false
             } else {
               let ws_before = !has_whitespace && (*d == '/' || *d == '*');
               dest.delim(*d, ws_before)?;
+              true
             }
-            true
           }
           Token::Comma => {
             dest.delim(',', false)?;


### PR DESCRIPTION
When using the [CSS attr() function](https://developer.mozilla.org/en-US/docs/Web/CSS/attr) with an attribute type, lightning-css will output incorrect syntax with the unminified build.

[Playground reproducing the issue](https://lightningcss.dev/playground/index.html#%7B%22minify%22%3Afalse%2C%22customMedia%22%3Atrue%2C%22cssModules%22%3Afalse%2C%22analyzeDependencies%22%3Afalse%2C%22targets%22%3A%7B%22chrome%22%3A8716288%7D%2C%22include%22%3A0%2C%22exclude%22%3A0%2C%22source%22%3A%22div%20%7B%5Cn%20%20background-color%3A%20attr(data-color%20type(%3Ccolor%3E))%3B%5Cn%7D%22%2C%22visitorEnabled%22%3Afalse%2C%22visitor%22%3A%22%7B%5Cn%20%20Color(color)%20%7B%5Cn%20%20%20%20if%20(color.type%20%3D%3D%3D%20'rgb')%20%7B%5Cn%20%20%20%20%20%20color.g%20%3D%200%3B%5Cn%20%20%20%20%20%20return%20color%3B%5Cn%20%20%20%20%7D%5Cn%20%20%7D%5Cn%7D%22%2C%22unusedSymbols%22%3A%5B%5D%2C%22version%22%3A%221.30.2%22%7D)

I'm not sure of other scenarios so added a check for angled brackets only to prevent adding whitespace. 