### PR TITLE
Add support for FreeBSD aarch64 (arm64)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -175,6 +175,15 @@ jobs:
             lightningcss
 
   build-freebsd:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: x86_64
+            target: x86_64-unknown-freebsd
+          - arch: arm64
+            target: aarch64-unknown-freebsd
+    name: build-${{ matrix.target }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -188,6 +197,7 @@ jobs:
         with:
           operating_system: freebsd
           version: '14.0'
+          architecture: ${{ matrix.arch }}
           memory: 13G
           cpu_count: 3
           environment_variables: 'DEBUG RUSTUP_IO_THREADS'
@@ -217,7 +227,7 @@ jobs:
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: bindings-x86_64-unknown-freebsd
+          name: bindings-${{ matrix.target }}
           path: |
             *.node
             lightningcss

--- a/scripts/build-npm.js
+++ b/scripts/build-npm.js
@@ -40,6 +40,9 @@ const triples = [
     name: 'x86_64-unknown-freebsd'
   },
   {
+    name: 'aarch64-unknown-freebsd'
+  },
+  {
     name: 'aarch64-linux-android'
   }
 ];


### PR DESCRIPTION
This adds FreeBSD arm64 build targets to both the npm package builder and the release workflow, enabling native binaries for FreeBSD on aarch64 architecture.

Fixes #991