### PR TITLE
Tolerate trailing whitespace in ViewTransitionPartSelector

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6965,6 +6965,10 @@ mod tests {
         &format!(":root::{}(.foo.bar) {{position: fixed}}", name),
         &format!(":root::{}(.foo.bar){{position:fixed}}", name),
       );
+      minify_test(
+        &format!(":root::{}(  .foo.bar  ) {{position: fixed}}", name),
+        &format!(":root::{}(.foo.bar){{position:fixed}}", name),
+      );
       error_test(
         &format!(":root::{}(foo):first-child {{position: fixed}}", name),
         ParserError::SelectorError(SelectorError::InvalidPseudoClassAfterPseudoElement),

--- a/src/selector.rs
+++ b/src/selector.rs
@@ -1084,13 +1084,19 @@ impl<'i> Parse<'i> for ViewTransitionPartSelector<'i> {
     let name = input.try_parse(ViewTransitionPartName::parse).ok();
     let mut classes = Vec::new();
     while let Ok(token) = input.next_including_whitespace() {
-      if matches!(token, Token::Delim('.')) {
-        match input.next_including_whitespace() {
+      match token {
+        Token::WhiteSpace(_) => {
+          if input.is_exhausted() {
+            break;
+          } else {
+            return Err(input.new_custom_error(ParserError::SelectorError(SelectorError::InvalidState)));
+          }
+        }
+        Token::Delim('.') => match input.next_including_whitespace() {
           Ok(Token::Ident(id)) => classes.push(CustomIdent(id.into())),
           _ => return Err(input.new_custom_error(ParserError::SelectorError(SelectorError::InvalidState))),
-        }
-      } else {
-        return Err(input.new_custom_error(ParserError::SelectorError(SelectorError::InvalidState)));
+        },
+        _ => return Err(input.new_custom_error(ParserError::SelectorError(SelectorError::InvalidState))),
       }
     }
 


### PR DESCRIPTION
When parsing a functional pseudoselector with spaces, `::view-transition-old(root )`, the lightningcss parser throws an "Invalid state" error. This PR adds support for tolerating the trailing whitespace.
