### PR TITLE
Nested declarations: add semicolon at the end

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24800,10 +24800,15 @@ mod tests {
     let mut stylesheet = StyleSheet::parse(
       r#"
       .foo {
+        color: orange;
+        .baz {
+          color: green;
+        }
         color: blue;
         .bar {
           color: red;
         }
+        color: pink;
       }
       "#,
       ParserOptions::default(),
@@ -24816,7 +24821,7 @@ mod tests {
         ..PrinterOptions::default()
       })
       .unwrap();
-    assert_eq!(res.code, ".foo{color:#00f;& .bar{color:red}}");
+    assert_eq!(res.code, ".foo{color:orange;& .baz{color:green}color:#00f;& .bar{color:red}color:pink;}");
 
     nesting_test_with_targets(
       r#"
@@ -27395,7 +27400,7 @@ mod tests {
         }
       }
       "#,
-      ".foo{@scope(.bar){color:#ff0}}",
+      ".foo{@scope(.bar){color:#ff0;}}",
     );
     nesting_test(
       r#"

--- a/src/rules/nesting.rs
+++ b/src/rules/nesting.rs
@@ -118,6 +118,6 @@ impl<'i> ToCss for NestedDeclarationsRule<'i> {
 
     self
       .declarations
-      .to_css_declarations(dest, false, &parcel_selectors::SelectorList(SmallVec::new()), 0)
+      .to_css_declarations(dest, true, &parcel_selectors::SelectorList(SmallVec::new()), 0)
   }
 }


### PR DESCRIPTION
This PR fixes a bug where minification of nested rules produces invalid CSS output because of a missing semicolon. Consider this CSS:
```css
.foo {
  color: red;
  .bar {
    color: green;
  }
  color: blue;
  .baz {
    color: pink;
  }
}
```
When minified, there is a missing semicolon after `color: blue` which makes the stylesheet invalid:
```css
.foo{color:red;& .bar{color:green}color:blue& .baz{color:pink}}
```
The `color: blue` declaration is inside an invisible "[nested declarations rule](https://drafts.csswg.org/css-nesting/#nested-declarations)". When printed, there is no surrounding `{}` block, so the trailing semicolon is often necessary.

My patch is very simple, but suboptimal. Ideally we would detect if there is another nested rule printed after the current one and print the semicolon only in that case. But that would require adding a new param to the `to_css` function, or adding a new field to `StyleContext`.

The problem is visible in the test snapshots. There is a trailing semicolon after `color: pink`, but it's not needed. Similarly in the `@scope(.bar)` at-rule test, there is an extra semicolon now. That's because for at-rules, the declarations are nested in an additional invisible `NestedDeclarationsRule`.