### PR TITLE
Allow `@property` to be nested inside at-rules

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28742,6 +28742,44 @@ mod tests {
     "#,
       "@property --property-name{syntax:\"<color>\";inherits:true;initial-value:#00f}.foo{color:var(--property-name)}",
     );
+
+    test(
+      r#"
+      @media (width < 800px) {
+        @property --property-name {
+          syntax: '*';
+          inherits: false;
+        }
+      }
+    "#,
+      indoc! {r#"
+        @media (width < 800px) {
+          @property --property-name {
+            syntax: "*";
+            inherits: false
+          }
+        }
+    "#},
+    );
+
+    test(
+      r#"
+      @layer foo {
+        @property --property-name {
+          syntax: '*';
+          inherits: false;
+        }
+      }
+    "#,
+      indoc! {r#"
+        @layer foo {
+          @property --property-name {
+            syntax: "*";
+            inherits: false
+          }
+        }
+    "#},
+    );
   }
 
   #[test]

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -320,10 +320,6 @@ impl<'a, 'o, 'i, T: crate::traits::AtRuleParser<'i>> AtRuleParser<'i> for TopLev
         let media = MediaList::parse(input, &self.options)?;
         return Ok(AtRulePrelude::CustomMedia(name, media))
       },
-      "property" => {
-        let name = DashedIdent::parse(input)?;
-        return Ok(AtRulePrelude::Property(name))
-      },
       _ => {}
     }
 
@@ -695,6 +691,10 @@ impl<'a, 'o, 'b, 'i, T: crate::traits::AtRuleParser<'i>> AtRuleParser<'i> for Ne
         return Err(input.new_custom_error(ParserError::DeprecatedCssModulesValueRule));
       },
 
+      "property" => {
+        let name = DashedIdent::parse(input)?;
+        return Ok(AtRulePrelude::Property(name))
+      },
 
       _ => parse_custom_at_rule_prelude(&name, input, self.options, self.at_rule_parser)?
     };


### PR DESCRIPTION
This updates things such that `@property` no longer errors when nested inside an at-rule.

Note: `@property` is *not* allowed inside style rules (i.e. it silently acts as if it does nothing in the browser) so I left the `allowed_in_style_rule` condition the way it was.

Question: `test_with_options` doesn't appear to emit warnings inside style rules — I would've expected it to. Assuming this is incorrect any chance you could provide an idea of where to look? (Since `allowed_in_style_rule` is already set up to return false I don't think it's that).

Happy to tweak things / add tests if need be.

Closes #968