### PR TITLE
Fix casing for camel-cased svg values

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26306,6 +26306,8 @@ mod tests {
 
   #[test]
   fn test_svg() {
+    use crate::properties::svg;
+
     minify_test(".foo { fill: yellow; }", ".foo{fill:#ff0}");
     minify_test(".foo { fill: url(#foo); }", ".foo{fill:url(#foo)}");
     minify_test(".foo { fill: url(#foo) none; }", ".foo{fill:url(#foo) none}");
@@ -27134,6 +27136,21 @@ mod tests {
         ..Browsers::default()
       },
     );
+
+    let property =
+      Property::parse_string("text-rendering".into(), "geometricPrecision", ParserOptions::default()).unwrap();
+    assert_eq!(
+      property,
+      Property::TextRendering(svg::TextRendering::GeometricPrecision)
+    );
+    let property =
+      Property::parse_string("shape-rendering".into(), "geometricPrecision", ParserOptions::default()).unwrap();
+    assert_eq!(
+      property,
+      Property::ShapeRendering(svg::ShapeRendering::GeometricPrecision)
+    );
+    let property = Property::parse_string("color-interpolation".into(), "sRGB", ParserOptions::default()).unwrap();
+    assert_eq!(property, Property::ColorInterpolation(svg::ColorInterpolation::SRGB));
   }
 
   #[test]

--- a/src/properties/svg.rs
+++ b/src/properties/svg.rs
@@ -211,6 +211,7 @@ pub enum Marker<'i> {
 
 /// A value for the [color-interpolation](https://www.w3.org/TR/SVG2/painting.html#ColorInterpolation) property.
 #[derive(Debug, Clone, Copy, PartialEq, Parse, ToCss)]
+#[css(case = lower)]
 #[cfg_attr(feature = "visitor", derive(Visit))]
 #[cfg_attr(
   feature = "serde",
@@ -249,6 +250,7 @@ pub enum ColorRendering {
 
 /// A value for the [shape-rendering](https://www.w3.org/TR/SVG2/painting.html#ShapeRendering) property.
 #[derive(Debug, Clone, Copy, PartialEq, Parse, ToCss)]
+#[css(case = lower)]
 #[cfg_attr(feature = "visitor", derive(Visit))]
 #[cfg_attr(
   feature = "serde",
@@ -270,6 +272,7 @@ pub enum ShapeRendering {
 
 /// A value for the [text-rendering](https://www.w3.org/TR/SVG2/painting.html#TextRendering) property.
 #[derive(Debug, Clone, Copy, PartialEq, Parse, ToCss)]
+#[css(case = lower)]
 #[cfg_attr(feature = "visitor", derive(Visit))]
 #[cfg_attr(
   feature = "serde",


### PR DESCRIPTION
Closes #1106 

Turns out these values weren't parsing because they didn't have the casing attribute applied