### PR TITLE
fix: normalize paths in js test cases for consistent handling on Windows

### DIFF
--- a/node/test/bundle.test.mjs
+++ b/node/test/bundle.test.mjs
@@ -44,7 +44,7 @@ test('resolver', async () => {
     'hello/world.css': `
  .baz { color: blue; }
          `.trim(),
-  }));
+  }).map(([key, value]) => [path.normalize(key), value]));
 
   const { code: buffer } = await bundleAsync({
     filename: 'foo.css',
@@ -95,7 +95,7 @@ test('only custom read', async () => {
     'bar.css': `
  .baz { color: blue; }
          `.trim(),
-  }));
+  }).map(([key, value]) => [path.normalize(key), value]));
 
   const { code: buffer } = await bundleAsync({
     filename: 'foo.css',


### PR DESCRIPTION
part of fix: #541 
follows up: #544 