### PR TITLE
feat(minify): avoid removing the default value of the `filter` function

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27257,9 +27257,23 @@ mod tests {
       ".foo{filter:url(filters.svg#filter-id)}",
     );
     minify_test(".foo { filter: blur(5px); }", ".foo{filter:blur(5px)}");
-    minify_test(".foo { filter: blur(0px); }", ".foo{filter:blur()}");
+    minify_test(".foo { filter: blur(0px); }", ".foo{filter:blur(0)}");
+    minify_test(".foo { filter: brightness(0.520); }", ".foo{filter:brightness(.52)}");
     minify_test(".foo { filter: brightness(10%); }", ".foo{filter:brightness(10%)}");
-    minify_test(".foo { filter: brightness(100%); }", ".foo{filter:brightness()}");
+    minify_test(".foo { filter: brightness(100%); }", ".foo{filter:brightness(100%)}");
+    minify_test(".foo { filter: brightness(1); }", ".foo{filter:brightness(1)}");
+    minify_test(".foo { filter: contrast(100%); }", ".foo{filter:contrast(100%)}");
+    minify_test(".foo { filter: contrast(1); }", ".foo{filter:contrast(1)}");
+    minify_test(".foo { filter: grayscale(100%); }", ".foo{filter:grayscale(100%)}");
+    minify_test(".foo { filter: grayscale(1); }", ".foo{filter:grayscale(1)}");
+    minify_test(".foo { filter: invert(100%); }", ".foo{filter:invert(100%)}");
+    minify_test(".foo { filter: invert(1); }", ".foo{filter:invert(1)}");
+    minify_test(".foo { filter: opacity(100%); }", ".foo{filter:opacity(100%)}");
+    minify_test(".foo { filter: opacity(1); }", ".foo{filter:opacity(1)}");
+    minify_test(".foo { filter: saturate(100%); }", ".foo{filter:saturate(100%)}");
+    minify_test(".foo { filter: saturate(1); }", ".foo{filter:saturate(1)}");
+    minify_test(".foo { filter: sepia(100%); }", ".foo{filter:sepia(100%)}");
+    minify_test(".foo { filter: sepia(1); }", ".foo{filter:sepia(1)}");
     minify_test(
       ".foo { filter: drop-shadow(16px 16px 20px yellow); }",
       ".foo{filter:drop-shadow(16px 16px 20px #ff0)}",
@@ -27268,7 +27282,21 @@ mod tests {
       ".foo { filter: contrast(175%) brightness(3%); }",
       ".foo{filter:contrast(175%)brightness(3%)}",
     );
-    minify_test(".foo { filter: hue-rotate(0) }", ".foo{filter:hue-rotate()}");
+    minify_test(".foo { filter: hue-rotate(0) }", ".foo{filter:hue-rotate(0)}");
+
+    prefix_test(
+      ".foo { filter: brightness(1) }",
+      indoc! { r#"
+        .foo {
+          -webkit-filter: brightness(1);
+          filter: brightness(1);
+        }
+      "#},
+      Browsers {
+        chrome: Some(20 << 16),
+        ..Browsers::default()
+      },
+    );
 
     prefix_test(
       ".foo { filter: blur(5px) }",

--- a/src/properties/effects.rs
+++ b/src/properties/effects.rs
@@ -122,72 +122,47 @@ impl<'i> ToCss for Filter<'i> {
     match self {
       Filter::Blur(val) => {
         dest.write_str("blur(")?;
-        if *val != Length::zero() {
-          val.to_css(dest)?;
-        }
+        val.to_css(dest)?;
         dest.write_char(')')
       }
       Filter::Brightness(val) => {
         dest.write_str("brightness(")?;
-        let v: f32 = val.into();
-        if v != 1.0 {
-          val.to_css(dest)?;
-        }
+        val.to_css(dest)?;
         dest.write_char(')')
       }
       Filter::Contrast(val) => {
         dest.write_str("contrast(")?;
-        let v: f32 = val.into();
-        if v != 1.0 {
-          val.to_css(dest)?;
-        }
+        val.to_css(dest)?;
         dest.write_char(')')
       }
       Filter::Grayscale(val) => {
         dest.write_str("grayscale(")?;
-        let v: f32 = val.into();
-        if v != 1.0 {
-          val.to_css(dest)?;
-        }
+        val.to_css(dest)?;
         dest.write_char(')')
       }
       Filter::HueRotate(val) => {
         dest.write_str("hue-rotate(")?;
-        if !val.is_zero() {
-          val.to_css(dest)?;
-        }
+        val.to_css_with_unitless_zero(dest)?;
         dest.write_char(')')
       }
       Filter::Invert(val) => {
         dest.write_str("invert(")?;
-        let v: f32 = val.into();
-        if v != 1.0 {
-          val.to_css(dest)?;
-        }
+        val.to_css(dest)?;
         dest.write_char(')')
       }
       Filter::Opacity(val) => {
         dest.write_str("opacity(")?;
-        let v: f32 = val.into();
-        if v != 1.0 {
-          val.to_css(dest)?;
-        }
+        val.to_css(dest)?;
         dest.write_char(')')
       }
       Filter::Saturate(val) => {
         dest.write_str("saturate(")?;
-        let v: f32 = val.into();
-        if v != 1.0 {
-          val.to_css(dest)?;
-        }
+        val.to_css(dest)?;
         dest.write_char(')')
       }
       Filter::Sepia(val) => {
         dest.write_str("sepia(")?;
-        let v: f32 = val.into();
-        if v != 1.0 {
-          val.to_css(dest)?;
-        }
+        val.to_css(dest)?;
         dest.write_char(')')
       }
       Filter::DropShadow(val) => {


### PR DESCRIPTION
There are several inconsistencies in Chrome's implementation of defaults in older versions, which can cause filters to behave in opposite ways in older browsers. Perhaps other browsers have similar bugs with inconsistent defaults between old and new versions, I didn't continue searching.

In older versions of Chrome(49), `-webkit-filter: brightness()` also caused crashes.

## Input

```css
.foo {
  filter: brightness(1);
}
```

## Output
```css
.foo {
  -webkit-filter: brightness(); /* I'm also concerned that `-webkit-filter` does not support omitting the default values. */
  filter: brightness(); /* In older versions of Chrome, the calculated value is 0 */
}
```

- https://bugs.chromium.org/p/chromium/issues/detail?id=964696#c13
- https://bugs.chromium.org/p/chromium/issues/detail?id=798683#c6

I would recommend turning off arguments omitting of the functions in the `filter` by default, it's not worth sacrificing correctness for those few bytes.

Fixed: https://github.com/parcel-bundler/lightningcss/issues/251