### PR TITLE
feat: support name-only `@container` queries

### DIFF
--- a/node/ast.d.ts
+++ b/node/ast.d.ts
@@ -2368,6 +2368,10 @@ export type PropertyId =
       property: "color-scheme";
     }
   | {
+      property: "print-color-adjust";
+      vendorPrefix: VendorPrefix;
+    }
+  | {
       property: "all";
     }
   | {
@@ -3854,6 +3858,11 @@ export type Declaration =
   | {
       property: "color-scheme";
       value: ColorScheme;
+    }
+  | {
+      property: "print-color-adjust";
+      value: PrintColorAdjust;
+      vendorPrefix: VendorPrefix;
     }
   | {
       property: "all";
@@ -6451,6 +6460,10 @@ export type NoneOrCustomIdentList =
  */
 export type ViewTransitionGroup =
   "normal" | "contain" | "nearest" | String;
+/**
+ * A value for the [print-color-adjust](https://drafts.csswg.org/css-color-adjust/#propdef-print-color-adjust) property.
+ */
+export type PrintColorAdjust = "economy" | "exact";
 /**
  * A [CSS-wide keyword](https://drafts.csswg.org/css-cascade-5/#defaulting-keywords).
  */
@@ -9775,7 +9788,7 @@ export interface ContainerRule<D = Declaration, M = MediaQuery> {
   /**
    * The container condition.
    */
-  condition: ContainerCondition<D>;
+  condition?: ContainerCondition<D> | null;
   /**
    * The location of the rule in the source file.
    */

--- a/src/error.rs
+++ b/src/error.rs
@@ -84,6 +84,8 @@ pub enum ParserError<'i> {
   InvalidDeclaration,
   /// A media query was invalid.
   InvalidMediaQuery,
+  /// The brackets in a condition cannot be empty.
+  EmptyBracketInCondition,
   /// Invalid CSS nesting.
   InvalidNesting,
   /// The @nest rule is deprecated.
@@ -118,6 +120,7 @@ impl<'i> fmt::Display for ParserError<'i> {
       EndOfInput => write!(f, "Unexpected end of input"),
       InvalidDeclaration => write!(f, "Invalid declaration"),
       InvalidMediaQuery => write!(f, "Invalid media query"),
+      EmptyBracketInCondition => write!(f, "The brackets cannot be empty"),
       InvalidNesting => write!(f, "Invalid nesting"),
       DeprecatedNestRule => write!(f, "The @nest rule is deprecated"),
       DeprecatedCssModulesValueRule => write!(f, "The @value rule is deprecated"),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9167,6 +9167,10 @@ mod tests {
       ParserError::UnexpectedToken(crate::properties::custom::Token::Function("unknown".into())),
     );
 
+    // empty brackets should return a clearer error message
+    error_test("@media () {}", ParserError::EmptyBracketInCondition);
+    error_test("@media screen and () {}", ParserError::EmptyBracketInCondition);
+
     error_recovery_test("@media unknown(foo) {}");
   }
 
@@ -29157,6 +29161,18 @@ mod tests {
 
   #[test]
   fn test_container_queries() {
+    // name only (no condition) - new syntax
+    minify_test(
+      r#"
+      @container foo {
+        .inner {
+          background: green;
+        }
+      }
+    "#,
+      "@container foo{.inner{background:green}}",
+    );
+
     // with name
     minify_test(
       r#"
@@ -29588,6 +29604,19 @@ mod tests {
     error_test(
       "@container unknown(foo) {}",
       ParserError::UnexpectedToken(crate::properties::custom::Token::Function("unknown".into())),
+    );
+
+    // empty container (no name and no condition) should error
+    error_test("@container {}", ParserError::EndOfInput);
+
+    // empty brackets should return a clearer error message
+    error_test("@container () {}", ParserError::EmptyBracketInCondition);
+
+    // invalid condition after a name should error
+    error_test("@container foo () {}", ParserError::EmptyBracketInCondition);
+    error_test(
+      "@container foo bar {}",
+      ParserError::UnexpectedToken(crate::properties::custom::Token::Ident("bar".into())),
     );
 
     error_recovery_test("@container unknown(foo) {}");

--- a/src/media_query.rs
+++ b/src/media_query.rs
@@ -791,6 +791,11 @@ fn parse_paren_block<'t, 'i, P: QueryCondition<'i>>(
   options: &ParserOptions<'_, 'i>,
 ) -> Result<P, ParseError<'i, ParserError<'i>>> {
   input.parse_nested_block(|input| {
+    // Detect empty brackets and provide a clearer error message.
+    if input.is_exhausted() {
+      return Err(input.new_custom_error(ParserError::EmptyBracketInCondition));
+    }
+
     if let Ok(inner) =
       input.try_parse(|i| parse_query_condition(i, flags | QueryConditionFlags::ALLOW_OR, options))
     {


### PR DESCRIPTION
In the CSS specification, `<container-query>` is now optional.

Old: `[ <container-name> ]? <container-query>`
New：`[ <container-name>? <container-query>? ]!`

This means that previously, to determine whether an element had container queries enabled, we had to write it like this:

```css
@container foo (width >= 0) {
  .inner {
    color: green
  }
}
```

It can now be simplified to:

```css
@container foo {
  .inner {
    color: green
  }
}
```

- Spec: https://github.com/w3c/csswg-drafts/pull/11172
- Chrome implemented in: https://chromium-review.googlesource.com/c/chromium/src/+/7378819
- Safari implemented in: https://bugs.webkit.org/show_bug.cgi?id=302433

----

This PR also improves error messages; `@container foo () {}` now provides specific syntax error reasons:

```
The brackets cannot be empty
```