### PR TITLE
fix: keep a single space between functions when formatting `transform` values

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12630,6 +12630,35 @@ mod tests {
 
   #[test]
   fn test_transform() {
+    test(
+      ".foo { transform: perspective(500px)translate3d(10px, 0, 20px)rotateY(30deg) }",
+      indoc! {r#"
+      .foo {
+        transform: perspective(500px) translate3d(10px, 0, 20px) rotateY(30deg);
+      }
+      "#},
+    );
+    test(
+      ".foo { transform: translate3d(12px,50%,3em)scale(2,.5) }",
+      indoc! {r#"
+      .foo {
+        transform: translate3d(12px, 50%, 3em) scale(2, .5);
+      }
+      "#},
+    );
+    test(
+      ".foo { transform:matrix(1,2,-1,1,80,80) }",
+      indoc! {r#"
+      .foo {
+        transform: matrix(1, 2, -1, 1, 80, 80);
+      }
+      "#},
+    );
+
+    minify_test(
+      ".foo { transform: scale(  0.5 )translateX(10px ) }",
+      ".foo{transform:scale(.5)translate(10px)}",
+    );
     minify_test(
       ".foo { transform: translate(2px, 3px)",
       ".foo{transform:translate(2px,3px)}",

--- a/src/properties/transform.rs
+++ b/src/properties/transform.rs
@@ -7,7 +7,6 @@ use crate::error::{ParserError, PrinterError};
 use crate::macros::enum_property;
 use crate::prefixes::Feature;
 use crate::printer::Printer;
-use crate::stylesheet::PrinterOptions;
 use crate::traits::{Parse, PropertyHandler, ToCss, Zero};
 use crate::values::{
   angle::Angle,
@@ -59,20 +58,6 @@ impl ToCss for TransformList {
 
     // TODO: Re-enable with a better solution
     //       See: https://github.com/parcel-bundler/lightningcss/issues/288
-    if dest.minify {
-      let mut base = String::new();
-      self.to_css_base(&mut Printer::new(
-        &mut base,
-        PrinterOptions {
-          minify: true,
-          ..PrinterOptions::default()
-        },
-      ))?;
-
-      dest.write_str(&base)?;
-
-      return Ok(());
-    }
     // if dest.minify {
     //   // Combine transforms into a single matrix.
     //   if let Some(matrix) = self.to_matrix() {
@@ -141,7 +126,13 @@ impl TransformList {
   where
     W: std::fmt::Write,
   {
+    let mut first = true;
     for item in &self.0 {
+      if first {
+        first = false;
+      } else {
+        dest.whitespace()?;
+      }
       item.to_css(dest)?;
     }
     Ok(())


### PR DESCRIPTION
This PR ensures that the serialization of transform and filter property values ​​remains consistent, with a space always separating functions.

- Insert exactly one space between adjacent transform functions in non-minified output
-  Remove the minify intermediate String/Printer path and write directly to the destination printer
- Keep minified output unchanged