### PR TITLE
Fix source location of list-style-image url location

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28740,8 +28740,7 @@ mod tests {
     dep_test(
       ".foo { list-style-image: url(foo.png) }",
       ".foo{list-style-image:url(\"Vwkwkq\")}",
-      // TODO off-by-one
-      vec![("foo.png", "Vwkwkq", 30 - 1)],
+      vec![("foo.png", "Vwkwkq", 30)],
     );
 
     dep_test(

--- a/src/values/url.rs
+++ b/src/values/url.rs
@@ -32,6 +32,7 @@ impl<'i> PartialEq for Url<'i> {
 
 impl<'i> Parse<'i> for Url<'i> {
   fn parse<'t>(input: &mut Parser<'i, 't>) -> Result<Self, ParseError<'i, ParserError<'i>>> {
+    input.skip_whitespace();
     let loc = input.current_source_location();
     let url = input.expect_url()?.into();
     Ok(Url { url, loc: loc.into() })


### PR DESCRIPTION
Closes https://github.com/parcel-bundler/lightningcss/issues/1149

This is probably the wrong fix, most `Parse` impls don't consume whitespace at the start...
Who is responsible for consuming whitespace? The URL or whatever the URL is contained in?

`background-image` was working fine, but `list-style-image` was off