### PR TITLE
fix: avoid wrapping pseudo-element selectors in :is() during nesting compilation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25260,6 +25260,21 @@ mod tests {
       "#},
     );
 
+    nesting_test(
+      r#"
+      .element::after {
+        .parent & {
+          color: red;
+        }
+      }
+      "#,
+      indoc! {r#"
+      .parent .element:after {
+        color: red;
+      }
+      "#},
+    );
+
     nesting_test_no_targets(
       r#"
         .foo {

--- a/src/selector.rs
+++ b/src/selector.rs
@@ -1717,8 +1717,11 @@ where
     // Otherwise, use an :is() pseudo class.
     // Type selectors are only allowed at the start of a compound selector,
     // so use :is() if that is not the case.
+    // Also, :is() cannot contain pseudo-elements, so we must serialize directly in that case.
     if ctx.selectors.0.len() == 1
-      && (first || (!has_type_selector(&ctx.selectors.0[0]) && is_simple(&ctx.selectors.0[0])))
+      && (first
+        || (!has_type_selector(&ctx.selectors.0[0]) && is_simple(&ctx.selectors.0[0]))
+        || ctx.selectors.0[0].has_pseudo_element())
     {
       serialize_selector(ctx.selectors.0.first().unwrap(), dest, ctx.parent, false)
     } else {


### PR DESCRIPTION
## Summary

When compiling nested selectors like `.parent &` where the parent selector contains a pseudo-element (e.g., `.element::after`), the code was incorrectly wrapping the parent in `:is()`, producing invalid CSS.

**Input:**
```css
.element::after {
  .parent & {
    color: red;
  }
}
```

**Before (incorrect):**
```css
.parent :is(.element:after) {
  color: red;
}
```

**After (correct):**
```css
.parent .element:after {
  color: red;
}
```

## Root Cause

The `is_simple()` function returns `false` for selectors with pseudo-elements because they internally contain a `Combinator::PseudoElement` component. This caused the nesting serialization to fall back to using `:is()`, which cannot contain pseudo-elements per CSS specification.

## Fix

Added a check in `serialize_nesting` to detect when the parent selector contains a pseudo-element. In that case, we serialize the selector directly instead of wrapping it in `:is()`.

## Related Issues

- Fixes #352 (original report from 2022)
- Extends the fix from #975 to handle the `.parent &` case (where `&` is not at the start)

## Test Plan

- Added test case for the specific scenario
- All existing tests pass (`cargo test`)
