### PR TITLE
fix(minify): preserve 3d transform semantics during minification

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12687,19 +12687,23 @@ mod tests {
     );
     minify_test(
       ".foo { transform: translate3d(2px, 0px, 0px)",
-      ".foo{transform:translate(2px)}",
+      ".foo{transform:translate3d(2px,0,0)}",
     );
     minify_test(
       ".foo { transform: translate3d(0px, 2px, 0px)",
-      ".foo{transform:translateY(2px)}",
+      ".foo{transform:translate3d(0,2px,0)}",
     );
     minify_test(
       ".foo { transform: translate3d(0px, 0px, 2px)",
       ".foo{transform:translateZ(2px)}",
     );
     minify_test(
+      ".foo { transform: translate3d(0px, 0px, 0px)",
+      ".foo{transform:translateZ(0)}",
+    );
+    minify_test(
       ".foo { transform: translate3d(2px, 3px, 0px)",
-      ".foo{transform:translate(2px,3px)}",
+      ".foo{transform:translate3d(2px,3px,0)}",
     );
     minify_test(".foo { transform: scale(2, 3)", ".foo{transform:scale(2,3)}");
     minify_test(".foo { transform: scale(10%, 20%)", ".foo{transform:scale(.1,.2)}");
@@ -12710,14 +12714,15 @@ mod tests {
     minify_test(".foo { transform: scaleY(2)", ".foo{transform:scaleY(2)}");
     minify_test(".foo { transform: scaleZ(2)", ".foo{transform:scaleZ(2)}");
     minify_test(".foo { transform: scale3d(2, 3, 4)", ".foo{transform:scale3d(2,3,4)}");
-    minify_test(".foo { transform: scale3d(2, 1, 1)", ".foo{transform:scaleX(2)}");
-    minify_test(".foo { transform: scale3d(1, 2, 1)", ".foo{transform:scaleY(2)}");
+    minify_test(".foo { transform: scale3d(2, 1, 1)", ".foo{transform:scale3d(2,1,1)}");
+    minify_test(".foo { transform: scale3d(1, 2, 1)", ".foo{transform:scale3d(1,2,1)}");
     minify_test(".foo { transform: scale3d(1, 1, 2)", ".foo{transform:scaleZ(2)}");
-    minify_test(".foo { transform: scale3d(2, 2, 1)", ".foo{transform:scale(2)}");
+    minify_test(".foo { transform: scale3d(2, 2, 1)", ".foo{transform:scale3d(2,2,1)}");
+    minify_test(".foo { transform: scale3d(1, 1, 1)", ".foo{transform:scale3d(1,1,1)}");
     minify_test(".foo { transform: rotate(20deg)", ".foo{transform:rotate(20deg)}");
     minify_test(".foo { transform: rotateX(20deg)", ".foo{transform:rotateX(20deg)}");
     minify_test(".foo { transform: rotateY(20deg)", ".foo{transform:rotateY(20deg)}");
-    minify_test(".foo { transform: rotateZ(20deg)", ".foo{transform:rotate(20deg)}");
+    minify_test(".foo { transform: rotateZ(20deg)", ".foo{transform:rotateZ(20deg)}");
     minify_test(".foo { transform: rotate(360deg)", ".foo{transform:rotate(360deg)}");
     minify_test(
       ".foo { transform: rotate3d(2, 3, 4, 20deg)",
@@ -12733,7 +12738,7 @@ mod tests {
     );
     minify_test(
       ".foo { transform: rotate3d(0, 0, 1, 20deg)",
-      ".foo{transform:rotate(20deg)}",
+      ".foo{transform:rotateZ(20deg)}",
     );
     minify_test(".foo { transform: rotate(405deg)}", ".foo{transform:rotate(405deg)}");
     minify_test(".foo { transform: rotateX(405deg)}", ".foo{transform:rotateX(405deg)}");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12718,7 +12718,7 @@ mod tests {
     minify_test(".foo { transform: scale3d(1, 2, 1)", ".foo{transform:scale3d(1,2,1)}");
     minify_test(".foo { transform: scale3d(1, 1, 2)", ".foo{transform:scaleZ(2)}");
     minify_test(".foo { transform: scale3d(2, 2, 1)", ".foo{transform:scale3d(2,2,1)}");
-    minify_test(".foo { transform: scale3d(1, 1, 1)", ".foo{transform:scale3d(1,1,1)}");
+    minify_test(".foo { transform: scale3d(1, 1, 1)", ".foo{transform:scaleZ(1)}");
     minify_test(".foo { transform: rotate(20deg)", ".foo{transform:rotate(20deg)}");
     minify_test(".foo { transform: rotateX(20deg)", ".foo{transform:rotateX(20deg)}");
     minify_test(".foo { transform: rotateY(20deg)", ".foo{transform:rotateY(20deg)}");

--- a/src/properties/transform.rs
+++ b/src/properties/transform.rs
@@ -1058,20 +1058,9 @@ impl ToCss for Transform {
         dest.write_char(')')
       }
       Translate3d(x, y, z) => {
-        if dest.minify && !x.is_zero() && y.is_zero() && z.is_zero() {
-          dest.write_str("translate(")?;
-          x.to_css(dest)?;
-        } else if dest.minify && x.is_zero() && !y.is_zero() && z.is_zero() {
-          dest.write_str("translateY(")?;
-          y.to_css(dest)?;
-        } else if dest.minify && x.is_zero() && y.is_zero() && !z.is_zero() {
+        if dest.minify && x.is_zero() && y.is_zero() {
           dest.write_str("translateZ(")?;
           z.to_css(dest)?;
-        } else if dest.minify && z.is_zero() {
-          dest.write_str("translate(")?;
-          x.to_css(dest)?;
-          dest.delim(',', false)?;
-          y.to_css(dest)?;
         } else {
           dest.write_str("translate3d(")?;
           x.to_css(dest)?;
@@ -1120,28 +1109,10 @@ impl ToCss for Transform {
         let x: f32 = x.into();
         let y: f32 = y.into();
         let z: f32 = z.into();
-        if dest.minify && z == 1.0 && x == y {
-          // scale3d(x, x, 1) => scale(x)
-          dest.write_str("scale(")?;
-          x.to_css(dest)?;
-        } else if dest.minify && x != 1.0 && y == 1.0 && z == 1.0 {
-          // scale3d(x, 1, 1) => scaleX(x)
-          dest.write_str("scaleX(")?;
-          x.to_css(dest)?;
-        } else if dest.minify && x == 1.0 && y != 1.0 && z == 1.0 {
-          // scale3d(1, y, 1) => scaleY(y)
-          dest.write_str("scaleY(")?;
-          y.to_css(dest)?;
-        } else if dest.minify && x == 1.0 && y == 1.0 && z != 1.0 {
+        if dest.minify && x == 1.0 && y == 1.0 && z != 1.0 {
           // scale3d(1, 1, z) => scaleZ(z)
           dest.write_str("scaleZ(")?;
           z.to_css(dest)?;
-        } else if dest.minify && z == 1.0 {
-          // scale3d(x, y, 1) => scale(x, y)
-          dest.write_str("scale(")?;
-          x.to_css(dest)?;
-          dest.delim(',', false)?;
-          y.to_css(dest)?;
         } else {
           dest.write_str("scale3d(")?;
           x.to_css(dest)?;
@@ -1168,7 +1139,7 @@ impl ToCss for Transform {
         dest.write_char(')')
       }
       RotateZ(angle) => {
-        dest.write_str(if dest.minify { "rotate(" } else { "rotateZ(" })?;
+        dest.write_str("rotateZ(")?;
         angle.to_css_with_unitless_zero(dest)?;
         dest.write_char(')')
       }
@@ -1182,8 +1153,8 @@ impl ToCss for Transform {
           dest.write_str("rotateY(")?;
           angle.to_css_with_unitless_zero(dest)?;
         } else if dest.minify && *x == 0.0 && *y == 0.0 && *z == 1.0 {
-          // rotate3d(0, 0, 1, a) => rotate(a)
-          dest.write_str("rotate(")?;
+          // rotate3d(0, 0, 1, a) => rotateZ(a)
+          dest.write_str("rotateZ(")?;
           angle.to_css_with_unitless_zero(dest)?;
         } else {
           dest.write_str("rotate3d(")?;

--- a/src/properties/transform.rs
+++ b/src/properties/transform.rs
@@ -1109,7 +1109,7 @@ impl ToCss for Transform {
         let x: f32 = x.into();
         let y: f32 = y.into();
         let z: f32 = z.into();
-        if dest.minify && x == 1.0 && y == 1.0 && z != 1.0 {
+        if dest.minify && x == 1.0 && y == 1.0 {
           // scale3d(1, 1, z) => scaleZ(z)
           dest.write_str("scaleZ(")?;
           z.to_css(dest)?;

--- a/website/pages/minification.md
+++ b/website/pages/minification.md
@@ -216,6 +216,8 @@ minifies to:
 .foo{transform:translateY(50px)}
 ```
 
+To avoid changing transform dimensionality, Lightning CSS preserves 3D transform functions rather than lowering them to 2D equivalents. For example, `translate3d(..., ..., 0)` and `scale3d(..., ..., 1)` remain 3D, and `rotate3d(0, 0, 1, a)` is normalized to `rotateZ(a)`.
+
 In addition, the `matrix()` and `matrix3d()` functions are converted to their equivalent transforms when shorter:
 
 ```css


### PR DESCRIPTION
Adjust transform minification so we keep 3D transforms as 3D instead of rewriting them into 2D forms.

The motivation is practical: some of these rewrites are mathematically equivalent, but they are not always behavior-equivalent in browsers (especially around compositing/layer promotion in Safari).

## Output Changes

- `translate3d(..., ..., 0)` is no longer lowered to `translate(...)` / `translateY(...)`.
- `scale3d(..., ..., 1)` is no longer lowered to `scale(...)` / `scaleX(...)` / `scaleY(...)`.
- `scale3d(1,1,z)` now canonicalizes to `scaleZ(z)` (including `scale3d(1,1,1) -> scaleZ(1)`), which keeps transforms in the 3D family.
- `rotateZ(...)` stays `rotateZ(...)` (not `rotate(...)`).
- `rotate3d(0,0,1,a)` now normalizes to `rotateZ(a)` (still 3D).
- `translate3d(0,0,0)` now normalizes to `translateZ(0)` (same family as `translate3d(0,0,z) -> translateZ(z)`).
- Updated docs to reflect the new transform minification behavior.

## Example

```css
/* before -> after */
transform: translate3d(2px,0,0);    /* translate3d(2px,0,0) */
transform: translate3d(0,2px,0);    /* translate3d(0,2px,0) */
transform: translate3d(2px,3px,0);  /* translate3d(2px,3px,0) */
transform: translate3d(0,0,0);      /* translateZ(0) */
transform: translate3d(0,0,2px);    /* translateZ(2px) */

transform: scale3d(2,1,1);          /* scale3d(2,1,1) */
transform: scale3d(1,2,1);          /* scale3d(1,2,1) */
transform: scale3d(2,2,1);          /* scale3d(2,2,1) */
transform: scale3d(1,1,2);          /* scaleZ(2) */
transform: scale3d(1,1,1);          /* scaleZ(1) */

transform: rotateZ(20deg);          /* rotateZ(20deg) */
transform: rotate3d(0,0,1,20deg);   /* rotateZ(20deg) */
```

## Related Issues

- https://github.com/parcel-bundler/lightningcss/issues/1080
- https://github.com/parcel-bundler/lightningcss/issues/239
