### PR TITLE
feat: add `minifyWhitespace` override option

### DIFF
--- a/napi/src/lib.rs
+++ b/napi/src/lib.rs
@@ -573,6 +573,7 @@ struct Config {
   #[serde(default)]
   pub exclude: u32,
   pub minify: Option<bool>,
+  pub minify_whitespace: Option<bool>,
   pub source_map: Option<bool>,
   pub input_source_map: Option<String>,
   pub drafts: Option<Drafts>,
@@ -629,6 +630,7 @@ struct BundleConfig {
   #[serde(default)]
   pub exclude: u32,
   pub minify: Option<bool>,
+  pub minify_whitespace: Option<bool>,
   pub source_map: Option<bool>,
   pub drafts: Option<Drafts>,
   pub non_standard: Option<NonStandard>,
@@ -753,13 +755,22 @@ fn compile<'i>(
       exclude: Features::from_bits_truncate(config.exclude),
     };
 
-    stylesheet.minify(MinifyOptions {
-      targets,
-      unused_symbols: config.unused_symbols.clone().unwrap_or_default(),
-    })?;
+    let format_minify = config.minify_whitespace.unwrap_or(config.minify.unwrap_or_default());
+    let should_optimize = if config.minify_whitespace.is_some() {
+      config.minify.unwrap_or_default()
+    } else {
+      true
+    };
+
+    if should_optimize {
+      stylesheet.minify(MinifyOptions {
+        targets,
+        unused_symbols: config.unused_symbols.clone().unwrap_or_default(),
+      })?;
+    }
 
     stylesheet.to_css(PrinterOptions {
-      minify: config.minify.unwrap_or_default(),
+      minify: format_minify,
       source_map: source_map.as_mut(),
       project_root,
       targets,
@@ -889,13 +900,22 @@ fn compile_bundle<
       exclude: Features::from_bits_truncate(config.exclude),
     };
 
-    stylesheet.minify(MinifyOptions {
-      targets,
-      unused_symbols: config.unused_symbols.clone().unwrap_or_default(),
-    })?;
+    let format_minify = config.minify_whitespace.unwrap_or(config.minify.unwrap_or_default());
+    let should_optimize = if config.minify_whitespace.is_some() {
+      config.minify.unwrap_or_default()
+    } else {
+      true
+    };
+
+    if should_optimize {
+      stylesheet.minify(MinifyOptions {
+        targets,
+        unused_symbols: config.unused_symbols.clone().unwrap_or_default(),
+      })?;
+    }
 
     stylesheet.to_css(PrinterOptions {
-      minify: config.minify.unwrap_or_default(),
+      minify: format_minify,
       source_map: source_map.as_mut(),
       project_root,
       targets,
@@ -951,6 +971,7 @@ struct AttrConfig {
   pub exclude: u32,
   #[serde(default)]
   pub minify: bool,
+  pub minify_whitespace: Option<bool>,
   #[serde(default)]
   pub analyze_dependencies: bool,
   #[serde(default)]
@@ -1012,12 +1033,21 @@ fn compile_attr<'i>(
       exclude: Features::from_bits_truncate(config.exclude),
     };
 
-    attr.minify(MinifyOptions {
-      targets,
-      ..MinifyOptions::default()
-    });
+    let format_minify = config.minify_whitespace.unwrap_or(config.minify);
+    let should_optimize = if config.minify_whitespace.is_some() {
+      config.minify
+    } else {
+      true
+    };
+
+    if should_optimize {
+      attr.minify(MinifyOptions {
+        targets,
+        ..MinifyOptions::default()
+      });
+    }
     attr.to_css(PrinterOptions {
-      minify: config.minify,
+      minify: format_minify,
       source_map: None,
       project_root: None,
       targets,

--- a/node/index.d.ts
+++ b/node/index.d.ts
@@ -12,6 +12,11 @@ export interface TransformOptions<C extends CustomAtRules> {
   code: Uint8Array,
   /** Whether to enable minification. */
   minify?: boolean,
+  /**
+   * Controls whitespace/newline minification during serialization only.
+   * When omitted, output formatting follows existing `minify` behavior.
+   */
+  minifyWhitespace?: boolean,
   /** Whether to output a source map. */
   sourceMap?: boolean,
   /** An input source map to extend. */
@@ -417,6 +422,11 @@ export interface TransformAttributeOptions {
   code: Uint8Array,
   /** Whether to enable minification. */
   minify?: boolean,
+  /**
+   * Controls whitespace/newline minification during serialization only.
+   * When omitted, output formatting follows existing `minify` behavior.
+   */
+  minifyWhitespace?: boolean,
   /** The browser targets for the generated code. */
   targets?: Targets,
   /**

--- a/node/test/bundle.test.mjs
+++ b/node/test/bundle.test.mjs
@@ -121,6 +121,11 @@ test('sync bundle supports minifyWhitespace and omitted minify', () => {
     const compact = bundle({
       filename: file,
       minifyWhitespace: true,
+      resolver: {
+        read(filePath) {
+          return fs.readFileSync(filePath, 'utf8');
+        }
+      }
     }).code.toString('utf-8');
 
     assert.equal(compact, '.a{color:red}.a{color:#00f}');
@@ -129,6 +134,11 @@ test('sync bundle supports minifyWhitespace and omitted minify', () => {
       filename: file,
       minify: true,
       minifyWhitespace: false,
+      resolver: {
+        read(filePath) {
+          return fs.readFileSync(filePath, 'utf8');
+        }
+      }
     }).code.toString('utf-8');
 
     assert.ok(pretty.includes('\n'));

--- a/node/test/bundle.test.mjs
+++ b/node/test/bundle.test.mjs
@@ -1,18 +1,20 @@
 import path from 'path';
 import fs from 'fs';
+import os from 'os';
 import { test } from 'uvu';
 import * as assert from 'uvu/assert';
 import {webcrypto as crypto} from 'node:crypto';
 
-let bundleAsync;
+let bundle, bundleAsync;
 if (process.env.TEST_WASM === 'node') {
-  bundleAsync = (await import('../../wasm/wasm-node.mjs')).bundleAsync;
+  ({ bundle, bundleAsync } = await import('../../wasm/wasm-node.mjs'));
 } else if (process.env.TEST_WASM === 'browser') {
   // Define crypto globally for old node.
   // @ts-ignore
   globalThis.crypto ??= crypto;
   let wasm = await import('../../wasm/index.mjs');
   await wasm.default();
+  bundle = wasm.bundle;
   bundleAsync = function (options) {
     if (!options.resolver?.read) {
       options.resolver = {
@@ -24,7 +26,7 @@ if (process.env.TEST_WASM === 'node') {
     return wasm.bundleAsync(options);
   }
 } else {
-  bundleAsync = (await import('../index.mjs')).bundleAsync;
+  ({ bundle, bundleAsync } = await import('../index.mjs'));
 }
 
 test('resolver', async () => {
@@ -76,6 +78,65 @@ test('resolver', async () => {
 }
      `.trim();
   if (code !== expected) throw new Error(`\`testResolver()\` failed. Expected:\n${expected}\n\nGot:\n${code}`);
+});
+
+test('minifyWhitespace can compact bundle output without semantic minification', async () => {
+  const { code: buffer } = await bundleAsync({
+    filename: 'foo.css',
+    minify: false,
+    minifyWhitespace: true,
+    resolver: {
+      read() {
+        return '.a { color: red; } .a { color: blue; }';
+      }
+    }
+  });
+
+  assert.equal(buffer.toString('utf-8'), '.a{color:red}.a{color:#00f}');
+});
+
+test('minifyWhitespace can force pretty bundle output with semantic minification', async () => {
+  const { code: buffer } = await bundleAsync({
+    filename: 'foo.css',
+    minify: true,
+    minifyWhitespace: false,
+    resolver: {
+      read() {
+        return '.a { color: red; } .a { color: blue; }';
+      }
+    }
+  });
+  const code = buffer.toString('utf-8');
+
+  assert.ok(code.includes('\n'));
+  assert.ok(code.includes('color: #00f;'));
+  assert.ok(!code.includes('color: red;'));
+});
+
+test('sync bundle supports minifyWhitespace and omitted minify', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'lightningcss-bundle-test-'));
+  const file = path.join(dir, 'foo.css');
+  fs.writeFileSync(file, '.a { color: red; } .a { color: blue; }');
+  try {
+    const compact = bundle({
+      filename: file,
+      minifyWhitespace: true,
+    }).code.toString('utf-8');
+
+    assert.equal(compact, '.a{color:red}.a{color:#00f}');
+
+    const pretty = bundle({
+      filename: file,
+      minify: true,
+      minifyWhitespace: false,
+    }).code.toString('utf-8');
+
+    assert.ok(pretty.includes('\n'));
+    assert.ok(pretty.includes('color: #00f;'));
+    assert.ok(!pretty.includes('color: red;'));
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
 });
 
 test('only custom read', async () => {

--- a/node/test/transform.test.mjs
+++ b/node/test/transform.test.mjs
@@ -2,18 +2,18 @@ import { test } from 'uvu';
 import * as assert from 'uvu/assert';
 import {webcrypto as crypto} from 'node:crypto';
 
-let transform, Features;
+let transform, transformStyleAttribute, Features;
 if (process.env.TEST_WASM === 'node') {
-  ({transform, Features} = await import('../../wasm/wasm-node.mjs'));
+  ({transform, transformStyleAttribute, Features} = await import('../../wasm/wasm-node.mjs'));
 } else if (process.env.TEST_WASM === 'browser') {
   // Define crypto globally for old node.
   // @ts-ignore
   globalThis.crypto ??= crypto;
   let wasm = await import('../../wasm/index.mjs');
   await wasm.default();
-  ({transform, Features} = wasm);
+  ({transform, transformStyleAttribute, Features} = wasm);
 } else {
-  ({transform, Features} = await import('../index.mjs'));
+  ({transform, transformStyleAttribute, Features} = await import('../index.mjs'));
 }
 
 test('can enable non-standard syntax', () => {
@@ -66,6 +66,75 @@ test('can disable prefixing', () => {
   });
 
   assert.equal(res.code.toString(), '.foo{user-select:none}');
+});
+
+test('minifyWhitespace can compact output without semantic minification', () => {
+  let res = transform({
+    filename: 'test.css',
+    code: Buffer.from('.a { color: red; } .a { color: blue; }'),
+    minify: false,
+    minifyWhitespace: true
+  });
+
+  assert.equal(res.code.toString(), '.a{color:red}.a{color:#00f}');
+});
+
+test('minifyWhitespace can force pretty output with semantic minification', () => {
+  let res = transform({
+    filename: 'test.css',
+    code: Buffer.from('.a { color: red; } .a { color: blue; }'),
+    minify: true,
+    minifyWhitespace: false
+  });
+
+  let code = res.code.toString();
+  assert.ok(code.includes('\n'));
+  assert.ok(code.includes('color: #00f;'));
+  assert.ok(!code.includes('color: red;'));
+});
+
+test('minifyWhitespace decouples formatting when minify is omitted', () => {
+  let compact = transform({
+    filename: 'test.css',
+    code: Buffer.from('.a { color: red; } .a { color: blue; }'),
+    minifyWhitespace: true
+  });
+  assert.equal(compact.code.toString(), '.a{color:red}.a{color:#00f}');
+
+  let pretty = transform({
+    filename: 'test.css',
+    code: Buffer.from('.a { color: red; } .a { color: blue; }'),
+    minifyWhitespace: false
+  });
+  let code = pretty.code.toString();
+  assert.ok(code.includes('\n'));
+  assert.ok(code.includes('color: red;'));
+  assert.ok(code.includes('color: #00f;'));
+});
+
+test('style attributes support minifyWhitespace override', () => {
+  let compact = transformStyleAttribute({
+    filename: 'test.css',
+    code: Buffer.from('color: yellow; flex: 1 1 auto'),
+    minify: false,
+    minifyWhitespace: true
+  });
+  assert.equal(compact.code.toString(), 'color:#ff0;flex:auto');
+
+  let pretty = transformStyleAttribute({
+    filename: 'test.css',
+    code: Buffer.from('color: yellow; flex: 1 1 auto'),
+    minify: true,
+    minifyWhitespace: false
+  });
+  assert.equal(pretty.code.toString(), 'color: #ff0; flex: auto');
+
+  let omittedMinify = transformStyleAttribute({
+    filename: 'test.css',
+    code: Buffer.from('color: yellow; flex: 1 1 auto'),
+    minifyWhitespace: false
+  });
+  assert.equal(omittedMinify.code.toString(), 'color: #ff0; flex: auto');
 });
 
 test.run();

--- a/node/test/transform.test.mjs
+++ b/node/test/transform.test.mjs
@@ -1,10 +1,12 @@
-import { test } from 'uvu';
+import {test} from 'uvu';
 import * as assert from 'uvu/assert';
 import {webcrypto as crypto} from 'node:crypto';
 
 let transform, transformStyleAttribute, Features;
 if (process.env.TEST_WASM === 'node') {
-  ({transform, transformStyleAttribute, Features} = await import('../../wasm/wasm-node.mjs'));
+  ({transform, transformStyleAttribute, Features} = await import(
+    '../../wasm/wasm-node.mjs'
+  ));
 } else if (process.env.TEST_WASM === 'browser') {
   // Define crypto globally for old node.
   // @ts-ignore
@@ -13,7 +15,9 @@ if (process.env.TEST_WASM === 'node') {
   await wasm.default();
   ({transform, transformStyleAttribute, Features} = wasm);
 } else {
-  ({transform, transformStyleAttribute, Features} = await import('../index.mjs'));
+  ({transform, transformStyleAttribute, Features} = await import(
+    '../index.mjs'
+  ));
 }
 
 test('can enable non-standard syntax', () => {
@@ -21,9 +25,9 @@ test('can enable non-standard syntax', () => {
     filename: 'test.css',
     code: Buffer.from('.foo >>> .bar { color: red }'),
     nonStandard: {
-      deepSelectorCombinator: true
+      deepSelectorCombinator: true,
     },
-    minify: true
+    minify: true,
   });
 
   assert.equal(res.code.toString(), '.foo>>>.bar{color:red}');
@@ -34,7 +38,7 @@ test('can enable features without targets', () => {
     filename: 'test.css',
     code: Buffer.from('.foo { .bar { color: red }}'),
     minify: true,
-    include: Features.Nesting
+    include: Features.Nesting,
   });
 
   assert.equal(res.code.toString(), '.foo .bar{color:red}');
@@ -46,9 +50,9 @@ test('can disable features', () => {
     code: Buffer.from('.foo { color: lch(50.998% 135.363 338) }'),
     minify: true,
     targets: {
-      chrome: 80 << 16
+      chrome: 80 << 16,
     },
-    exclude: Features.Colors
+    exclude: Features.Colors,
   });
 
   assert.equal(res.code.toString(), '.foo{color:lch(50.998% 135.363 338)}');
@@ -60,9 +64,9 @@ test('can disable prefixing', () => {
     code: Buffer.from('.foo { user-select: none }'),
     minify: true,
     targets: {
-      safari: 15 << 16
+      safari: 15 << 16,
     },
-    exclude: Features.VendorPrefixes
+    exclude: Features.VendorPrefixes,
   });
 
   assert.equal(res.code.toString(), '.foo{user-select:none}');
@@ -73,7 +77,7 @@ test('minifyWhitespace can compact output without semantic minification', () => 
     filename: 'test.css',
     code: Buffer.from('.a { color: red; } .a { color: blue; }'),
     minify: false,
-    minifyWhitespace: true
+    minifyWhitespace: true,
   });
 
   assert.equal(res.code.toString(), '.a{color:red}.a{color:#00f}');
@@ -84,7 +88,7 @@ test('minifyWhitespace can force pretty output with semantic minification', () =
     filename: 'test.css',
     code: Buffer.from('.a { color: red; } .a { color: blue; }'),
     minify: true,
-    minifyWhitespace: false
+    minifyWhitespace: false,
   });
 
   let code = res.code.toString();
@@ -97,14 +101,14 @@ test('minifyWhitespace decouples formatting when minify is omitted', () => {
   let compact = transform({
     filename: 'test.css',
     code: Buffer.from('.a { color: red; } .a { color: blue; }'),
-    minifyWhitespace: true
+    minifyWhitespace: true,
   });
   assert.equal(compact.code.toString(), '.a{color:red}.a{color:#00f}');
 
   let pretty = transform({
     filename: 'test.css',
     code: Buffer.from('.a { color: red; } .a { color: blue; }'),
-    minifyWhitespace: false
+    minifyWhitespace: false,
   });
   let code = pretty.code.toString();
   assert.ok(code.includes('\n'));
@@ -117,7 +121,7 @@ test('style attributes support minifyWhitespace override', () => {
     filename: 'test.css',
     code: Buffer.from('color: yellow; flex: 1 1 auto'),
     minify: false,
-    minifyWhitespace: true
+    minifyWhitespace: true,
   });
   assert.equal(compact.code.toString(), 'color:#ff0;flex:auto');
 
@@ -125,16 +129,49 @@ test('style attributes support minifyWhitespace override', () => {
     filename: 'test.css',
     code: Buffer.from('color: yellow; flex: 1 1 auto'),
     minify: true,
-    minifyWhitespace: false
+    minifyWhitespace: false,
   });
   assert.equal(pretty.code.toString(), 'color: #ff0; flex: auto');
 
   let omittedMinify = transformStyleAttribute({
     filename: 'test.css',
     code: Buffer.from('color: yellow; flex: 1 1 auto'),
-    minifyWhitespace: false
+    minifyWhitespace: false,
   });
   assert.equal(omittedMinify.code.toString(), 'color: #ff0; flex: auto');
+});
+
+test('minifyWhitespace applies inside at-rules without forcing pretty formatting', () => {
+  let res = transform({
+    filename: 'test.css',
+    code: Buffer.from(
+      '@media screen and (min-width: 1px) { .a { color: red; } }',
+    ),
+    minify: false,
+    minifyWhitespace: true,
+  });
+
+  let code = res.code.toString();
+  assert.ok(code.startsWith('@media '));
+  assert.ok(code.includes('{.a{color:red}}'));
+  assert.ok(!code.includes('\n'));
+});
+
+test('minifyWhitespace compacts function-heavy values', () => {
+  let res = transform({
+    filename: 'test.css',
+    code: Buffer.from(
+      '.a { width: calc(100% - 10px); background: linear-gradient(red, blue); }',
+    ),
+    minify: false,
+    minifyWhitespace: true,
+  });
+
+  let code = res.code.toString();
+  assert.ok(!code.includes('\n'));
+  assert.ok(code.startsWith('.a{'));
+  assert.ok(code.includes('width:calc(100% - 10px)'));
+  assert.ok(code.includes('background:linear-gradient('));
 });
 
 test.run();

--- a/website/pages/docs.md
+++ b/website/pages/docs.md
@@ -29,6 +29,8 @@ let { code, map } = transform({
 });
 ```
 
+If you want compact output formatting without enabling semantic minification optimizations, use `minifyWhitespace: true` and leave `minify` disabled. For example, `minify: false, minifyWhitespace: true` outputs compact CSS without beautifying whitespace/newlines.
+
 See [Transpilation](transpilation.html) for details about syntax lowering and vendor prefixing CSS for your browser targets, and the draft syntax support in Lightning CSS. You can also use the `bundle` API to process `@import` rules and inline them – see [Bundling](bundling.html) for details.
 
 The [TypeScript definitions](https://github.com/parcel-bundler/lightningcss/blob/master/node/index.d.ts) also include documentation for all API options.
@@ -160,6 +162,8 @@ Then, you can run the `lightningcss` command via `npx`, `yarn`, or by setting up
   }
 }
 ```
+
+Use `--minify-whitespace` to force compact output formatting and `--no-minify-whitespace` to force pretty output formatting. These flags are useful when you want to control whitespace/newlines independently from semantic minification (`--minify`).
 
 To see all of the available options, use the `--help` argument:
 

--- a/website/pages/minification.md
+++ b/website/pages/minification.md
@@ -17,6 +17,43 @@ let { code, map } = transform({
 });
 ```
 
+## Output formatting vs semantic minification
+
+Lightning CSS has separate concepts for:
+
+- semantic minification optimizations (e.g. merging adjacent rules, reducing values)
+- output formatting (compact vs pretty whitespace/newlines)
+
+By default, output formatting follows `minify`. In the JavaScript APIs and CLI, you can override formatting with `minifyWhitespace` (or the CLI flags `--minify-whitespace` / `--no-minify-whitespace`).
+
+For example, this produces compact output without semantic minification optimizations:
+
+```js
+let { code } = transform({
+  // ...
+  minify: false,
+  minifyWhitespace: true
+});
+```
+
+And this produces pretty output while still applying semantic minification optimizations:
+
+```js
+let { code } = transform({
+  // ...
+  minify: true,
+  minifyWhitespace: false
+});
+```
+
+When `minifyWhitespace` is omitted, Lightning CSS preserves the existing `minify`-driven formatting behavior.
+
+<div class="warning">
+
+`minifyWhitespace` controls serializer formatting only. Lightning CSS still parses and reserializes your CSS, so output formatting is not preserved byte-for-byte from the input.
+
+</div>
+
 ## Optimizations
 
 The Lightning CSS minifier includes many optimizations to generate the smallest possible output for all rules, properties, and values in your stylesheet. Lightning CSS does not perform any optimizations that change the behavior of your CSS unless it can prove that it is safe to do so. For example, only adjacent style rules are merged to avoid changing the order and potentially breaking the styles.


### PR DESCRIPTION
Added a new `minifyWhitespace` option (JS/NAPI) and matching CLI flags (`--minify-whitespace` / `--no-minify-whitespace`) so users can control output whitespace/newlines separately from semantic minification.

This is mainly to fix the confusing case where `minify: false` would still "beautify" the output (add spaces/newlines) even if the input was already compact.

Behavior:

- If `minifyWhitespace` is omitted, formatting still follows `minify` like before (old behavior preserved).
- If `minifyWhitespace` is provided, behavior is decoupled:
  - `minify` controls semantic optimizations
  - `minifyWhitespace` controls serializer whitespace/newlines

Examples:
- `minify: false, minifyWhitespace: true` -> no semantic optimizations + compact output
- `minify: true, minifyWhitespace: false` -> semantic optimizations + pretty output

This stays non-breaking for existing JS/CLI users.
