### PR TITLE
feat: implementation of `contrast-color()` from the CSS Color 5

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ An extremely fast CSS parser, transformer, and minifier written in Rust. Use it 
   - Logical properties
   * [Color Level 5](https://drafts.csswg.org/css-color-5/)
     - `color-mix()` function
+    - `light-dark()` function
+    - `contrast-color()` function
     - Relative color syntax, e.g. `lab(from purple calc(l * .8) a b)`
   - [Color Level 4](https://drafts.csswg.org/css-color-4/)
     - `lab()`, `lch()`, `oklab()`, and `oklch()` colors

--- a/src/bundler.rs
+++ b/src/bundler.rs
@@ -864,6 +864,9 @@ fn visit_vars<'a, 'b>(
             stack.push(light.0.iter_mut());
             stack.push(dark.0.iter_mut());
           }
+          UnresolvedColor::ContrastColor { value } => {
+            stack.push(value.0.iter_mut());
+          }
         },
         None => {
           stack.pop();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30758,6 +30758,96 @@ mod tests {
   }
 
   #[test]
+  fn test_contrast_color() {
+    // WPT reference:
+    // https://github.com/web-platform-tests/wpt/blob/e4a69111d7a6e24b80b71e6c6ef4536f84754f22/css/css-color/parsing/color-valid-contrast-color-function.html
+    minify_test(".foo { color: contrast-color(green); }", ".foo{color:contrast-color(green)}");
+    minify_test(
+      ".foo { color: contrast-color(hwb(120deg 0 49.8%)); }",
+      ".foo{color:contrast-color(green)}",
+    );
+    minify_test(
+      ".foo { color: contrast-color(rgb(70 130 180)); }",
+      ".foo{color:contrast-color(#4682b4)}",
+    );
+    minify_test(
+      ".foo { color: contrast-color(hsl(0deg 100% 0%)); }",
+      ".foo{color:contrast-color(#000)}",
+    );
+    // relative colors
+    minify_test(
+      ".foo { color: contrast-color(rgb(from red r g b)); }",
+      ".foo{color:contrast-color(red)}",
+    );
+    minify_test(
+      ".foo { color: rgb(from contrast-color(black) r g b); }",
+      ".foo{color:rgb(from contrast-color(#000) r g b)}",
+    );
+    // color-mix()
+    minify_test(
+      ".foo { color: color-mix(in srgb, contrast-color(blue) 100%, purple); }",
+      ".foo{color:color-mix(in srgb, contrast-color(#00f) 100%, purple)}",
+    );
+    // light-dark()
+    minify_test(
+      ".foo { color: contrast-color(light-dark(red, white)); }",
+      ".foo{color:contrast-color(light-dark(red,#fff))}",
+    );
+    minify_test(
+      ".foo { color: light-dark(contrast-color(red), white); }",
+      ".foo{color:light-dark(contrast-color(red),#fff)}",
+    );
+    minify_test(
+      ".foo { color: contrast-color(currentcolor); }",
+      ".foo{color:contrast-color(currentColor)}",
+    );
+    minify_test(
+      ".foo { color: contrast-color(transparent); }",
+      ".foo{color:contrast-color(#0000)}",
+    );
+
+    // Nested contrast-color() should be flattened.
+    minify_test(
+      ".foo { color: contrast-color(contrast-color(blue)); }",
+      ".foo{color:contrast-color(#00f)}",
+    );
+    minify_test(
+      ".foo { color: contrast-color(contrast-color(contrast-color(blue))); }",
+      ".foo{color:contrast-color(#00f)}",
+    );
+
+    // var() and unresolved token list paths should be preserved and flattened safely.
+    minify_test(
+      ".foo { color: contrast-color(var(--bg)); }",
+      ".foo{color:contrast-color(var(--bg))}",
+    );
+    minify_test(
+      ".foo { color: contrast-color(contrast-color(var(--bg))); }",
+      ".foo{color:contrast-color(var(--bg))}",
+    );
+    minify_test(
+      ".foo { --x: contrast-color(contrast-color(var(--bg))); }",
+      ".foo{--x:contrast-color(var(--bg))}",
+    );
+
+    // Should not panic for unsupported interpolation inputs.
+    minify_test(
+      ".foo { color: color-mix(in srgb, contrast-color(blue), red); }",
+      ".foo{color:color-mix(in srgb, contrast-color(#00f), red)}",
+    );
+
+    minify_test(
+      ".foo { background: linear-gradient( contrast-color(black) ); }",
+      ".foo{background:linear-gradient(contrast-color(#000))}",
+    );
+    minify_test(
+      ".foo { background: contrast-color(color(srgb calc(0.5) calc(-1 + 1 / 1) 1 / .99)); }",
+      ".foo{background:contrast-color(color(srgb .5 0 1/.99))}",
+    );
+
+  }
+
+  #[test]
   fn test_print_color_adjust() {
     prefix_test(
       ".foo { print-color-adjust: exact; }",

--- a/src/properties/custom.rs
+++ b/src/properties/custom.rs
@@ -470,7 +470,7 @@ fn try_parse_color_token<'i, 't>(
   input: &mut Parser<'i, 't>,
 ) -> Option<CssColor> {
   match_ignore_ascii_case! { &*f,
-    "rgb" | "rgba" | "hsl" | "hsla" | "hwb" | "lab" | "lch" | "oklab" | "oklch" | "color" | "color-mix" | "light-dark" => {
+    "rgb" | "rgba" | "hsl" | "hsla" | "hwb" | "lab" | "lch" | "oklab" | "oklch" | "color" | "color-mix" | "light-dark" | "contrast-color" => {
       let s = input.state();
       input.reset(&state);
       if let Ok(color) = CssColor::parse(input) {
@@ -1103,6 +1103,9 @@ impl<'i> TokenList<'i> {
               features |= light.get_features();
               features |= dark.get_features();
             }
+            UnresolvedColor::ContrastColor { value } => {
+              features |= value.get_features();
+            }
             _ => {}
           }
         }
@@ -1490,6 +1493,13 @@ pub enum UnresolvedColor<'i> {
     /// The dark value.
     dark: TokenList<'i>,
   },
+  /// The contrast-color() function.
+  /// https://drafts.csswg.org/css-color-5/#contrast-color
+  #[cfg_attr(feature = "serde", serde(rename = "contrast-color"))]
+  ContrastColor {
+    /// contrast-color( <color> )
+    value: TokenList<'i>,
+  },
 }
 
 impl<'i> LightDarkColor for UnresolvedColor<'i> {
@@ -1544,6 +1554,19 @@ impl<'i> UnresolvedColor<'i> {
           input.expect_comma()?;
           let dark = TokenList::parse(input, options, 0)?;
           Ok(UnresolvedColor::LightDark { light, dark })
+        })
+      },
+      "contrast-color" => {
+        input.parse_nested_block(|input| {
+          let value = TokenList::parse(input, options, 0)?;
+          let value = match value.0.as_slice() {
+            [TokenOrValue::Color(CssColor::ContrastColor(inner))] => {
+              TokenList(vec![TokenOrValue::Color((**inner).clone())])
+            }
+            [TokenOrValue::UnresolvedColor(UnresolvedColor::ContrastColor { value })] => value.clone(),
+            _ => value,
+          };
+          Ok(UnresolvedColor::ContrastColor { value })
         })
       },
       _ => Err(input.new_custom_error(ParserError::InvalidValue))
@@ -1620,6 +1643,11 @@ impl<'i> UnresolvedColor<'i> {
         light.to_css(dest, is_custom_property)?;
         dest.delim(',', false)?;
         dark.to_css(dest, is_custom_property)?;
+        dest.write_char(')')
+      }
+      UnresolvedColor::ContrastColor { value } => {
+        dest.write_str("contrast-color(")?;
+        value.to_css(dest, is_custom_property)?;
         dest.write_char(')')
       }
     }

--- a/src/values/color.rs
+++ b/src/values/color.rs
@@ -64,6 +64,10 @@ pub enum CssColor {
   #[cfg_attr(feature = "visitor", skip_type)]
   #[cfg_attr(feature = "serde", serde(with = "LightDark"))]
   LightDark(Box<CssColor>, Box<CssColor>),
+  /// The [`contrast-color()`](https://drafts.csswg.org/css-color-5/#contrast-color) function.
+  #[cfg_attr(feature = "visitor", skip_type)]
+  #[cfg_attr(feature = "serde", serde(with = "ContrastColor"))]
+  ContrastColor(Box<CssColor>),
   /// A [system color](https://drafts.csswg.org/css-color/#css-system-colors) keyword.
   System(SystemColor),
 }
@@ -153,6 +157,38 @@ impl<'de> LightDark {
     let v: LightDark = serde::Deserialize::deserialize(deserializer)?;
     match v {
       LightDark::LightDark { light, dark } => Ok((Box::new(light), Box::new(dark))),
+    }
+  }
+}
+
+// For AST serialization.
+#[cfg(feature = "serde")]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[serde(tag = "type", rename_all = "kebab-case")]
+#[cfg_attr(feature = "jsonschema", derive(schemars::JsonSchema))]
+enum ContrastColor {
+  ContrastColor { value: CssColor },
+}
+
+#[cfg(feature = "serde")]
+impl<'de> ContrastColor {
+  pub fn serialize<S>(value: &Box<CssColor>, serializer: S) -> Result<S::Ok, S::Error>
+  where
+    S: serde::Serializer,
+  {
+    let wrapper = ContrastColor::ContrastColor {
+      value: (**value).clone(),
+    };
+    serde::Serialize::serialize(&wrapper, serializer)
+  }
+
+  pub fn deserialize<D>(deserializer: D) -> Result<Box<CssColor>, D::Error>
+  where
+    D: serde::Deserializer<'de>,
+  {
+    let v: ContrastColor = serde::Deserialize::deserialize(deserializer)?;
+    match v {
+      ContrastColor::ContrastColor { value } => Ok(Box::new(value)),
     }
   }
 }
@@ -334,6 +370,7 @@ impl CssColor {
       CssColor::LightDark(light, dark) => {
         Ok(CssColor::LightDark(Box::new(light.to_rgb()?), Box::new(dark.to_rgb()?)))
       }
+      CssColor::ContrastColor(value) => Ok(CssColor::ContrastColor(Box::new(value.to_rgb()?))),
       _ => Ok(RGBA::try_from(self)?.into()),
     }
   }
@@ -344,6 +381,7 @@ impl CssColor {
       CssColor::LightDark(light, dark) => {
         Ok(CssColor::LightDark(Box::new(light.to_lab()?), Box::new(dark.to_lab()?)))
       }
+      CssColor::ContrastColor(value) => Ok(CssColor::ContrastColor(Box::new(value.to_lab()?))),
       _ => Ok(LAB::try_from(self)?.into()),
     }
   }
@@ -354,6 +392,7 @@ impl CssColor {
       CssColor::LightDark(light, dark) => {
         Ok(CssColor::LightDark(Box::new(light.to_p3()?), Box::new(dark.to_p3()?)))
       }
+      CssColor::ContrastColor(value) => Ok(CssColor::ContrastColor(Box::new(value.to_p3()?))),
       _ => Ok(P3::try_from(self)?.into()),
     }
   }
@@ -382,6 +421,9 @@ impl CssColor {
       },
       CssColor::LightDark(light, dark) => {
         return light.get_possible_fallbacks(targets) | dark.get_possible_fallbacks(targets);
+      }
+      CssColor::ContrastColor(value) => {
+        return value.get_possible_fallbacks(targets);
       }
     };
 
@@ -473,6 +515,9 @@ impl CssColor {
         features |= light.get_features();
         features |= dark.get_features();
       }
+      CssColor::ContrastColor(value) => {
+        features |= value.get_features();
+      }
       _ => {}
     }
 
@@ -495,6 +540,7 @@ impl IsCompatible for CssColor {
       CssColor::LightDark(light, dark) => {
         Feature::LightDark.is_compatible(browsers) && light.is_compatible(browsers) && dark.is_compatible(browsers)
       }
+      CssColor::ContrastColor(value) => value.is_compatible(browsers),
       CssColor::System(system) => system.is_compatible(browsers),
     }
   }
@@ -645,6 +691,11 @@ impl ToCss for CssColor {
         light.to_css(dest)?;
         dest.delim(',', false)?;
         dark.to_css(dest)?;
+        dest.write_char(')')
+      }
+      CssColor::ContrastColor(value) => {
+        dest.write_str("contrast-color(")?;
+        value.to_css(dest)?;
         dest.write_char(')')
       }
       CssColor::System(system) => system.to_css(dest),
@@ -1089,6 +1140,15 @@ fn parse_color_function<'i, 't>(
           dark => Box::new(dark)
         };
         Ok(CssColor::LightDark(light, dark))
+      })
+    },
+    "contrast-color" => {
+      input.parse_nested_block(|input| {
+        let value = match CssColor::parse(input)? {
+          CssColor::ContrastColor(value) => value,
+          value => Box::new(value),
+        };
+        Ok(CssColor::ContrastColor(value))
       })
     },
     _ => Err(location.new_unexpected_token_error(
@@ -2971,6 +3031,7 @@ macro_rules! color_space {
           CssColor::Float(float) => (**float).into(),
           CssColor::CurrentColor => return Err(()),
           CssColor::LightDark(..) => return Err(()),
+          CssColor::ContrastColor(..) => return Err(()),
           CssColor::System(..) => return Err(()),
         })
       }
@@ -2986,6 +3047,7 @@ macro_rules! color_space {
           CssColor::Float(float) => (*float).into(),
           CssColor::CurrentColor => return Err(()),
           CssColor::LightDark(..) => return Err(()),
+          CssColor::ContrastColor(..) => return Err(()),
           CssColor::System(..) => return Err(()),
         })
       }
@@ -3363,8 +3425,8 @@ impl CssColor {
       + From<OKLCH>
       + Copy,
   {
-    if matches!(self, CssColor::CurrentColor | CssColor::System(..))
-      || matches!(other, CssColor::CurrentColor | CssColor::System(..))
+    if matches!(self, CssColor::CurrentColor | CssColor::System(..) | CssColor::ContrastColor(..))
+      || matches!(other, CssColor::CurrentColor | CssColor::System(..) | CssColor::ContrastColor(..))
     {
       return Err(());
     }


### PR DESCRIPTION
The former name of `contrast-color()` was `color-contrast()`. In CSS Color 5, its syntax has been simplified to:
`contrast-color() = contrast-color( <color> )`

Spec: https://drafts.csswg.org/css-color-5/#contrast-color

This function is part of interop-2026 and is already supported in [Firefox 146](https://bugzilla.mozilla.org/show_bug.cgi?id=1682439)、[Safari 26](https://developer.apple.com/documentation/safari-release-notes/safari-26-release-notes#:~:text=Added%20support%20for%20contrast%2Dcolor) and [Chrome 147.0.7707.0](https://chromiumdash.appspot.com/commit/24d3ad2604a0090584257661cd643df47a5b4a98)(experimental)

This implementation solely parses functions, enabling color values within `contrast-color()` to be compressed or simplified.

Part of #99