### PR TITLE
Convert the percentage in the `scale` property or `scale()` to a number

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12714,6 +12714,57 @@ mod tests {
     minify_test(".foo { transform: scale3d(1, 2, 1)", ".foo{transform:scaleY(2)}");
     minify_test(".foo { transform: scale3d(1, 1, 2)", ".foo{transform:scaleZ(2)}");
     minify_test(".foo { transform: scale3d(2, 2, 1)", ".foo{transform:scale(2)}");
+
+    // transform: scale(), Convert <percentage> to <number>
+    test(
+      ".foo { transform: scale3d(50%, 1, 200%) }",
+      indoc! {r#"
+      .foo {
+        transform: scale3d(.5, 1, 2);
+      }
+      "#},
+    );
+    minify_test(".foo { transform: scale(1%) }", ".foo{transform:scale(.01)}");
+    minify_test(".foo { transform: scale(0%) }", ".foo{transform:scale(0)}");
+    minify_test(".foo { transform: scale(0.0%) }", ".foo{transform:scale(0)}");
+    minify_test(".foo { transform: scale(-0%) }", ".foo{transform:scale(0)}");
+    minify_test(".foo { transform: scale(-0) }", ".foo{transform:scale(0)}");
+    minify_test(".foo { transform: scale(-0.0) }", ".foo{transform:scale(0)}");
+    minify_test(".foo { transform: scale(100%) }", ".foo{transform:scale(1)}");
+    minify_test(".foo { transform: scale(-100%) }", ".foo{transform:scale(-1)}");
+    minify_test(".foo { transform: scale(68%) }", ".foo{transform:scale(.68)}");
+    minify_test(".foo { transform: scale(5.96%) }", ".foo{transform:scale(.0596)}");
+    // Match WPT coverage for repeated and multi-value percentages.
+    minify_test(".foo { transform: scale(100%, 100%) }", ".foo{transform:scale(1)}");
+    minify_test(".foo { transform: scale3d(100%, 100%, 1) }", ".foo{transform:scale(1)}");
+    minify_test(".foo { transform: scale(-100%, -100%) }", ".foo{transform:scale(-1)}");
+    minify_test(".foo { transform: scale3d(-100%, -100%, 1) }", ".foo{transform:scale(-1)}");
+    minify_test(".foo { transform: scale(100%, 200%) }", ".foo{transform:scaleY(2)}");
+    minify_test(".foo { transform: scale3d(100%, 200%, 1) }", ".foo{transform:scaleY(2)}");
+    minify_test(".foo { transform: scale3d(100%, 100%, 0%) }", ".foo{transform:scaleZ(0)}");
+    minify_test(".foo { transform: scale3d(100%, 100%, 100%) }", ".foo{transform:scale(1)}");
+    minify_test(".foo { transform: scale3d(-0%, -0%, -0%) }", ".foo{transform:scale3d(0,0,0)}");
+    // Additional edge cases: mixed inputs and computed percentages.
+    minify_test(".foo { transform: scale(2, 100%) }", ".foo{transform:scaleX(2)}");
+    minify_test(".foo { transform: scale(2, -50%) }", ".foo{transform:scale(2,-.5)}");
+    minify_test(".foo { transform: scale(-90%, -1) }", ".foo{transform:scale(-.9,-1)}");
+    minify_test(".foo { transform: scale(calc(10% + 20%)) }", ".foo{transform:scale(.3)}");
+    minify_test(".foo { transform: scale(calc(150% - 50%), 200%) }", ".foo{transform:scaleY(2)}");
+    minify_test(".foo { transform: scale(200%, calc(50% - 80%)) }", ".foo{transform:scale(2,-.3)}");
+    // TODO: For infinite decimals, please do not attempt to resolve calc
+    // Expected: calc(1 / 3)
+    // https://github.com/parcel-bundler/lightningcss/issues/12
+    minify_test(".foo { transform: scale(calc(100% / 3)) }", ".foo{transform:scale(.333333)}");
+    // Transform::ScaleX/Y/Z
+    minify_test(".foo { transform: scaleX(10%) }", ".foo{transform:scaleX(.1)}");
+    minify_test(".foo { transform: scaleY(20%) }", ".foo{transform:scaleY(.2)}");
+    minify_test(".foo { transform: scaleZ(30%) }", ".foo{transform:scaleZ(.3)}");
+    minify_test(".foo { transform: scaleX(0%) }", ".foo{transform:scaleX(0)}");
+    minify_test(".foo { transform: scaleX(-0%) }", ".foo{transform:scaleX(0)}");
+    minify_test(".foo { transform: scaleX(calc(10% + 20%)) }", ".foo{transform:scaleX(.3)}");
+    minify_test(".foo { transform: scaleX(calc(180% - 20%)) }", ".foo{transform:scaleX(1.6)}");
+    minify_test(".foo { transform: scaleX(calc(50% - 80%)) }", ".foo{transform:scaleX(-.3)}");
+
     minify_test(".foo { transform: rotate(20deg)", ".foo{transform:rotate(20deg)}");
     minify_test(".foo { transform: rotateX(20deg)", ".foo{transform:rotateX(20deg)}");
     minify_test(".foo { transform: rotateY(20deg)", ".foo{transform:rotateY(20deg)}");
@@ -12851,7 +12902,6 @@ mod tests {
       ".foo{transform:rotate(calc(10deg + var(--test)))}",
       ".foo{transform:rotate(calc(10deg + var(--test)))}",
     );
-    minify_test(".foo { transform: scale(calc(10% + 20%))", ".foo{transform:scale(.3)}");
     minify_test(".foo { transform: scale(calc(.1 + .2))", ".foo{transform:scale(.3)}");
 
     minify_test(
@@ -12896,6 +12946,81 @@ mod tests {
     minify_test(".foo { scale: 1 0 }", ".foo{scale:1 0}");
     minify_test(".foo { scale: 1 0 1 }", ".foo{scale:1 0}");
     minify_test(".foo { scale: 1 0 0 }", ".foo{scale:1 0 0}");
+
+    // scale, Convert <percentage> to <number>
+    test(
+      ".foo { scale: 50% 1 200% }",
+      indoc! {r#"
+      .foo {
+        scale: .5 1 2;
+      }
+      "#},
+    );
+    minify_test(".foo { scale: 1% }", ".foo{scale:.01}");
+    minify_test(".foo { scale: 0% }", ".foo{scale:0}");
+    minify_test(".foo { scale: 0.0% }", ".foo{scale:0}");
+    minify_test(".foo { scale: -0% }", ".foo{scale:0}");
+    minify_test(".foo { scale: -0 }", ".foo{scale:0}");
+    minify_test(".foo { scale: -0.0 }", ".foo{scale:0}");
+    minify_test(".foo { scale: 100% }", ".foo{scale:1}");
+    minify_test(".foo { scale: -100% }", ".foo{scale:-1}");
+    minify_test(".foo { scale: 68% }", ".foo{scale:.68}");
+    minify_test(".foo { scale: 5.96% }", ".foo{scale:.0596}");
+    // Match WPT coverage for repeated and multi-value percentages.
+    minify_test(".foo { scale: 100% 100% }", ".foo{scale:1}");
+    minify_test(".foo { scale: 100% 100% 1 }", ".foo{scale:1}");
+    minify_test(".foo { scale: -100% -100% }", ".foo{scale:-1}");
+    minify_test(".foo { scale: -100% -100% 1 }", ".foo{scale:-1}");
+    minify_test(".foo { scale: 100% 200% }", ".foo{scale:1 2}");
+    minify_test(".foo { scale: 100% 200% 1 }", ".foo{scale:1 2}");
+    minify_test(".foo { scale: 100% 100% 0% }", ".foo{scale:1 1 0}");
+    minify_test(".foo { scale: 100% 100% 100% }", ".foo{scale:1}");
+    minify_test(".foo { scale: -0% -0% -0% }", ".foo{scale:0 0 0}");
+    // Additional edge cases: mixed inputs and computed percentages.
+    minify_test(".foo { scale: 2 100% }", ".foo{scale:2 1}");
+    minify_test(".foo { scale: 2 -50% }", ".foo{scale:2 -.5}");
+    minify_test(".foo { scale: -90% -1 }", ".foo{scale:-.9 -1}");
+    minify_test(".foo { scale: calc(10% + 20%) }", ".foo{scale:.3}");
+    minify_test(".foo { scale: calc(150% - 50%) 200% }", ".foo{scale:1 2}");
+    minify_test(".foo { scale: 200% calc(50% - 80%) }", ".foo{scale:2 -.3}");
+    // TODO: For infinite decimals, please do not attempt to resolve calc
+    // Expected: calc(1 / 3)
+    // https://github.com/parcel-bundler/lightningcss/issues/12
+    minify_test(".foo { scale: calc(100% / 3) }", ".foo{scale:.333333}");
+
+    assert_eq!(
+      Property::Scale(crate::properties::transform::Scale::XYZ {
+        x: crate::values::percentage::NumberOrPercentage::Percentage(crate::values::percentage::Percentage(0.5)),
+        y: crate::values::percentage::NumberOrPercentage::Percentage(crate::values::percentage::Percentage(2.0)),
+        z: crate::values::percentage::NumberOrPercentage::Percentage(crate::values::percentage::Percentage(1.0)),
+      })
+      .to_css_string(
+        false,
+        PrinterOptions {
+          minify: true,
+          ..PrinterOptions::default()
+        },
+      )
+      .unwrap(),
+      "scale:.5 2"
+    );
+    assert_eq!(
+      Property::Transform(
+        crate::properties::transform::TransformList(vec![crate::properties::transform::Transform::ScaleX(
+          crate::values::percentage::NumberOrPercentage::Percentage(crate::values::percentage::Percentage(0.1)),
+        )]),
+        VendorPrefix::None,
+      )
+      .to_css_string(
+        false,
+        PrinterOptions {
+          minify: true,
+          ..PrinterOptions::default()
+        },
+      )
+      .unwrap(),
+      "transform:scaleX(.1)"
+    );
 
     // TODO: Re-enable with a better solution
     //       See: https://github.com/parcel-bundler/lightningcss/issues/288

--- a/src/properties/transform.rs
+++ b/src/properties/transform.rs
@@ -938,32 +938,32 @@ impl<'i> Parse<'i> for Transform {
           Ok(Transform::Translate3d(x, y, z))
         },
         "scale" => {
-          let x = NumberOrPercentage::parse(input)?;
+          let x = convert_percentage_to_number(input)?;
           if input.try_parse(|input| input.expect_comma()).is_ok() {
-            let y = NumberOrPercentage::parse(input)?;
+            let y = convert_percentage_to_number(input)?;
             Ok(Transform::Scale(x, y))
           } else {
             Ok(Transform::Scale(x.clone(), x))
           }
         },
         "scalex" => {
-          let x = NumberOrPercentage::parse(input)?;
+          let x = convert_percentage_to_number(input)?;
           Ok(Transform::ScaleX(x))
         },
         "scaley" => {
-          let y = NumberOrPercentage::parse(input)?;
+          let y = convert_percentage_to_number(input)?;
           Ok(Transform::ScaleY(y))
         },
         "scalez" => {
-          let z = NumberOrPercentage::parse(input)?;
+          let z = convert_percentage_to_number(input)?;
           Ok(Transform::ScaleZ(z))
         },
         "scale3d" => {
-          let x = NumberOrPercentage::parse(input)?;
+          let x = convert_percentage_to_number(input)?;
           input.expect_comma()?;
-          let y = NumberOrPercentage::parse(input)?;
+          let y = convert_percentage_to_number(input)?;
           input.expect_comma()?;
-          let z = NumberOrPercentage::parse(input)?;
+          let z = convert_percentage_to_number(input)?;
           Ok(Transform::Scale3d(x, y, z))
         },
         "rotate" => {
@@ -1102,16 +1102,19 @@ impl ToCss for Transform {
         dest.write_char(')')
       }
       ScaleX(x) => {
+        let x: f32 = x.into();
         dest.write_str("scaleX(")?;
         x.to_css(dest)?;
         dest.write_char(')')
       }
       ScaleY(y) => {
+        let y: f32 = y.into();
         dest.write_str("scaleY(")?;
         y.to_css(dest)?;
         dest.write_char(')')
       }
       ScaleZ(z) => {
+        let z: f32 = z.into();
         dest.write_str("scaleZ(")?;
         z.to_css(dest)?;
         dest.write_char(')')
@@ -1643,16 +1646,25 @@ pub enum Scale {
   },
 }
 
+fn convert_percentage_to_number<'i, 't>(
+  input: &mut Parser<'i, 't>,
+) -> Result<NumberOrPercentage, ParseError<'i, ParserError<'i>>> {
+  Ok(match NumberOrPercentage::parse(input)? {
+    NumberOrPercentage::Number(number) => NumberOrPercentage::Number(number),
+    NumberOrPercentage::Percentage(percent) => NumberOrPercentage::Number(percent.0),
+  })
+}
+
 impl<'i> Parse<'i> for Scale {
   fn parse<'t>(input: &mut Parser<'i, 't>) -> Result<Self, ParseError<'i, ParserError<'i>>> {
     if input.try_parse(|i| i.expect_ident_matching("none")).is_ok() {
       return Ok(Scale::None);
     }
 
-    let x = NumberOrPercentage::parse(input)?;
-    let y = input.try_parse(NumberOrPercentage::parse);
+    let x = convert_percentage_to_number(input)?;
+    let y = input.try_parse(convert_percentage_to_number);
     let z = if y.is_ok() {
-      input.try_parse(NumberOrPercentage::parse).ok()
+      input.try_parse(convert_percentage_to_number).ok()
     } else {
       None
     };
@@ -1675,12 +1687,14 @@ impl ToCss for Scale {
         dest.write_str("none")?;
       }
       Scale::XYZ { x, y, z } => {
+        let x: f32 = x.into();
+        let y: f32 = y.into();
+        let z: f32 = z.into();
         x.to_css(dest)?;
-        let zv: f32 = z.into();
-        if y != x || zv != 1.0 {
+        if y != x || z != 1.0 {
           dest.write_char(' ')?;
           y.to_css(dest)?;
-          if zv != 1.0 {
+          if z != 1.0 {
             dest.write_char(' ')?;
             z.to_css(dest)?;
           }


### PR DESCRIPTION
- Use shared scale component parsing so individual `scale` and transform scale functions normalize percentages into numbers consistently.
- Keep serialization canonical by converting scale values through numeric output paths, including `scaleX/Y/Z`.
- Expand transform tests to mirror the individual `scale` percentage cases one-for-one, and add direct AST serialization coverage for both `scale` and `transform`.