### PR TITLE
fix: force webkit prefix for text-size-adjust

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15995,6 +15995,7 @@ mod tests {
     "#,
       indoc! {r#"
       .foo {
+        -webkit-text-size-adjust: none;
         text-size-adjust: none;
       }
     "#},

--- a/src/prefixes.rs
+++ b/src/prefixes.rs
@@ -1414,6 +1414,7 @@ impl Feature {
         }
       }
       Feature::TextSizeAdjust => {
+        prefixes |= VendorPrefix::WebKit;
         if browsers.firefox.is_some() {
           prefixes |= VendorPrefix::Moz;
         }
@@ -1425,11 +1426,6 @@ impl Feature {
         if let Some(version) = browsers.ie {
           if version >= 655360 {
             prefixes |= VendorPrefix::Ms;
-          }
-        }
-        if let Some(version) = browsers.ios_saf {
-          if version >= 327680 {
-            prefixes |= VendorPrefix::WebKit;
           }
         }
       }


### PR DESCRIPTION
This PR fixes #934 

Safari iOS supports this property but must be prefixed by -webkit, no matter the version of iOS. Confirmed by Apple on a bug report I did: https://bugs.webkit.org/show_bug.cgi?id=309551#c3

Thanks!