### PR TITLE
Supports `:target-before/after/current` pseudo-class

### DIFF
--- a/c/lightningcss.h
+++ b/c/lightningcss.h
@@ -23,6 +23,7 @@ typedef struct ParseOptions {
   const char *filename;
   bool nesting;
   bool custom_media;
+  bool scroll_navigation_controls;
   bool css_modules;
   const char *css_modules_pattern;
   bool css_modules_dashed_idents;

--- a/c/src/lib.rs
+++ b/c/src/lib.rs
@@ -77,6 +77,7 @@ pub struct ParseOptions {
   filename: *const c_char,
   nesting: bool,
   custom_media: bool,
+  scroll_navigation_controls: bool,
   css_modules: bool,
   css_modules_pattern: *const c_char,
   css_modules_dashed_idents: bool,
@@ -259,6 +260,10 @@ pub extern "C" fn lightningcss_stylesheet_parse(
   let warnings = Arc::new(RwLock::new(Vec::new()));
   let mut flags = ParserFlags::empty();
   flags.set(ParserFlags::CUSTOM_MEDIA, options.custom_media);
+  flags.set(
+    ParserFlags::SCROLL_NAVIGATION_CONTROLS,
+    options.scroll_navigation_controls,
+  );
   let opts = ParserOptions {
     filename: if options.filename.is_null() {
       String::new()

--- a/napi/src/lib.rs
+++ b/napi/src/lib.rs
@@ -667,6 +667,8 @@ impl<'a> Into<PseudoClasses<'a>> for &'a OwnedPseudoClasses {
 struct Drafts {
   #[serde(default)]
   custom_media: bool,
+  #[serde(default)]
+  scroll_navigation_controls: bool,
 }
 
 #[derive(Serialize, Debug, Deserialize, Default)]
@@ -699,6 +701,10 @@ fn compile<'i>(
   let res = {
     let mut flags = ParserFlags::empty();
     flags.set(ParserFlags::CUSTOM_MEDIA, matches!(drafts, Some(d) if d.custom_media));
+    flags.set(
+      ParserFlags::SCROLL_NAVIGATION_CONTROLS,
+      matches!(drafts, Some(d) if d.scroll_navigation_controls),
+    );
     flags.set(
       ParserFlags::DEEP_SELECTOR_COMBINATOR,
       matches!(non_standard, Some(v) if v.deep_selector_combinator),
@@ -834,6 +840,10 @@ fn compile_bundle<
     let non_standard = config.non_standard.as_ref();
     let mut flags = ParserFlags::empty();
     flags.set(ParserFlags::CUSTOM_MEDIA, matches!(drafts, Some(d) if d.custom_media));
+    flags.set(
+      ParserFlags::SCROLL_NAVIGATION_CONTROLS,
+      matches!(drafts, Some(d) if d.scroll_navigation_controls),
+    );
     flags.set(
       ParserFlags::DEEP_SELECTOR_COMBINATOR,
       matches!(non_standard, Some(v) if v.deep_selector_combinator),

--- a/node/ast.d.ts
+++ b/node/ast.d.ts
@@ -6728,6 +6728,15 @@ export type PseudoClass =
       kind: "target";
     }
   | {
+      kind: "target-current";
+    }
+  | {
+      kind: "target-before";
+    }
+  | {
+      kind: "target-after";
+    }
+  | {
       kind: "target-within";
     }
   | {

--- a/node/index.d.ts
+++ b/node/index.d.ts
@@ -270,6 +270,11 @@ export interface Resolver {
 export interface Drafts {
   /** Whether to enable @custom-media rules. */
   customMedia?: boolean
+  /** 
+   * Whether to enable the scroll navigation controls.
+   * https://drafts.csswg.org/css-overflow-5/#scroll-navigation
+   */
+  scrollNavigationControls?: boolean
 }
 
 export interface NonStandard {

--- a/node/test/transform.test.mjs
+++ b/node/test/transform.test.mjs
@@ -29,6 +29,20 @@ test('can enable non-standard syntax', () => {
   assert.equal(res.code.toString(), '.foo>>>.bar{color:red}');
 });
 
+test('can enable scroll navigation controls draft syntax', () => {
+  let res = transform({
+    filename: 'test.css',
+    code: Buffer.from('a:target-current { color: red }'),
+    drafts: {
+      scrollNavigationControls: true
+    },
+    minify: true
+  });
+
+  assert.equal(res.code.toString(), 'a:target-current{color:red}');
+  assert.equal(res.warnings, []);
+});
+
 test('can enable features without targets', () => {
   let res = transform({
     filename: 'test.css',

--- a/scripts/build-prefixes.js
+++ b/scripts/build-prefixes.js
@@ -464,6 +464,18 @@ addValue(compat, {
   ios_saf: parseVersion('10.3')
 }, 'LangSelectorList');
 
+addValue(compat, {
+  chrome: parseVersion('135'),
+  edge: parseVersion('135'),
+  android: parseVersion('135')
+}, 'TargetCurrent');
+
+addValue(compat, {
+  chrome: parseVersion('142'),
+  edge: parseVersion('142'),
+  android: parseVersion('142')
+}, 'TargetBeforeAfter');
+
 let prefixMapping = {
   webkit: 'WebKit',
   moz: 'Moz',

--- a/src/compat.rs
+++ b/src/compat.rs
@@ -197,6 +197,8 @@ pub enum Feature {
   StringListStyleType,
   SymbolsListStyleType,
   TamilListStyleType,
+  TargetBeforeAfter,
+  TargetCurrent,
   TargetText,
   TeluguListStyleType,
   TextDecorationThicknessPercent,
@@ -3628,6 +3630,58 @@ impl Feature {
           }
         }
         if browsers.ie.is_some() {
+          return false;
+        }
+      }
+      Feature::TargetCurrent => {
+        if let Some(version) = browsers.chrome {
+          if version < 8847360 {
+            return false;
+          }
+        }
+        if let Some(version) = browsers.edge {
+          if version < 8847360 {
+            return false;
+          }
+        }
+        if let Some(version) = browsers.android {
+          if version < 8847360 {
+            return false;
+          }
+        }
+        if browsers.firefox.is_some()
+          || browsers.ie.is_some()
+          || browsers.ios_saf.is_some()
+          || browsers.opera.is_some()
+          || browsers.safari.is_some()
+          || browsers.samsung.is_some()
+        {
+          return false;
+        }
+      }
+      Feature::TargetBeforeAfter => {
+        if let Some(version) = browsers.chrome {
+          if version < 9306112 {
+            return false;
+          }
+        }
+        if let Some(version) = browsers.edge {
+          if version < 9306112 {
+            return false;
+          }
+        }
+        if let Some(version) = browsers.android {
+          if version < 9306112 {
+            return false;
+          }
+        }
+        if browsers.firefox.is_some()
+          || browsers.ie.is_some()
+          || browsers.ios_saf.is_some()
+          || browsers.opera.is_some()
+          || browsers.safari.is_some()
+          || browsers.samsung.is_some()
+        {
           return false;
         }
       }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6720,6 +6720,22 @@ mod tests {
       ".test:where(.foo, .bar) {color:red}",
       ".test:where(.foo,.bar){color:red}",
     );
+    minify_test("a:target-current { color: green }", "a:target-current{color:green}");
+    minify_test("a:target-before { color: green }", "a:target-before{color:green}");
+    minify_test("a:target-after { color: green }", "a:target-after{color:green}");
+    minify_test(
+      ":is(a:target-before, a:target-after) { color: green }",
+      ":is(a:target-before,a:target-after){color:green}",
+    );
+    minify_test(
+      "a:where(:target-before, :target-after) { color: green }",
+      "a:where(:target-before,:target-after){color:green}",
+    );
+    error_test(
+      "a::before:target-current { color: green }",
+      ParserError::SelectorError(SelectorError::InvalidPseudoClassAfterPseudoElement),
+    );
+
     minify_test(":host {color:red}", ":host{color:red}");
     minify_test(":host(.foo) {color:red}", ":host(.foo){color:red}");
     minify_test("::slotted(span) {color:red", "::slotted(span){color:red}");
@@ -8660,6 +8676,63 @@ mod tests {
         ..Browsers::default()
       },
     );
+  }
+
+  #[test]
+  fn test_selector_compatibility() {
+    fn selectors(source: &str) -> crate::selector::SelectorList<'_> {
+      let stylesheet = StyleSheet::parse(source, ParserOptions::default()).unwrap();
+      match &stylesheet.rules.0[0] {
+        CssRule::Style(rule) => rule.selectors.clone(),
+        _ => unreachable!(),
+      }
+    }
+
+    let target_current = selectors("a:target-current { color: green }");
+    assert!(!crate::selector::is_compatible(
+      &target_current.0,
+      Browsers {
+        chrome: Some(134 << 16),
+        ..Browsers::default()
+      }
+      .into()
+    ));
+    assert!(crate::selector::is_compatible(
+      &target_current.0,
+      Browsers {
+        chrome: Some(135 << 16),
+        ..Browsers::default()
+      }
+      .into()
+    ));
+
+    let target_before = selectors("a:target-before { color: green }");
+    assert!(!crate::selector::is_compatible(
+      &target_before.0,
+      Browsers {
+        chrome: Some(141 << 16),
+        ..Browsers::default()
+      }
+      .into()
+    ));
+    assert!(crate::selector::is_compatible(
+      &target_before.0,
+      Browsers {
+        chrome: Some(142 << 16),
+        ..Browsers::default()
+      }
+      .into()
+    ));
+
+    let target_after = selectors("a:target-after { color: green }");
+    assert!(crate::selector::is_compatible(
+      &target_after.0,
+      Browsers {
+        chrome: Some(142 << 16),
+        ..Browsers::default()
+      }
+      .into()
+    ));
   }
 
   #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -335,7 +335,7 @@ mod tests {
     }
   }
 
-  fn error_test_with_options<'i>(source: &'i str, error: ParserError<'i>, options: ParserOptions<'_, 'i>) {
+  fn error_test_with_options<'i>(source: &'i str, error: ParserError<'i>, options: ParserOptions<'i>) {
     let res = StyleSheet::parse(&source, options);
     match res {
       Ok(_) => unreachable!(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -115,16 +115,35 @@ mod tests {
   }
 
   #[track_caller]
-  fn minify_test_with_options<'i, 'o>(source: &'i str, expected: &'i str, options: ParserOptions<'o, 'i>) {
+  fn minify_test_with_options<'i, 'o>(
+    source: &'i str,
+    expected: &'i str,
+    options: ParserOptions<'o, 'i>,
+  ) {
+    minify_test_with_options_and_browsers(source, expected, options, None)
+  }
+
+  #[track_caller]
+  fn minify_test_with_options_and_browsers<'i, 'o>(
+    source: &'i str,
+    expected: &'i str,
+    options: ParserOptions<'o, 'i>,
+    browsers: Option<Browsers>,
+  ) {
+    let targets = browsers.into();
     let mut stylesheet = match StyleSheet::parse(&source, options) {
       Ok(stylesheet) => stylesheet,
       Err(e) => panic_with_test_error("minify_test_with_options", "parse", source, e),
     };
-    if let Err(e) = stylesheet.minify(MinifyOptions::default()) {
+    if let Err(e) = stylesheet.minify(MinifyOptions {
+      targets,
+      ..MinifyOptions::default()
+    }) {
       panic_with_test_error("minify_test_with_options", "minify", source, e);
     }
     let res = match stylesheet.to_css(PrinterOptions {
       minify: true,
+      targets,
       ..PrinterOptions::default()
     }) {
       Ok(res) => res,
@@ -318,6 +337,14 @@ mod tests {
 
   fn error_test(source: &str, error: ParserError) {
     let res = StyleSheet::parse(&source, ParserOptions::default());
+    match res {
+      Ok(_) => unreachable!(),
+      Err(e) => assert_eq!(e.kind, error),
+    }
+  }
+
+  fn error_test_with_options<'i>(source: &'i str, error: ParserError<'i>, options: ParserOptions<'_, 'i>) {
+    let res = StyleSheet::parse(&source, options);
     match res {
       Ok(_) => unreachable!(),
       Err(e) => assert_eq!(e.kind, error),
@@ -6720,20 +6747,80 @@ mod tests {
       ".test:where(.foo, .bar) {color:red}",
       ".test:where(.foo,.bar){color:red}",
     );
-    minify_test("a:target-current { color: green }", "a:target-current{color:green}");
-    minify_test("a:target-before { color: green }", "a:target-before{color:green}");
-    minify_test("a:target-after { color: green }", "a:target-after{color:green}");
-    minify_test(
+
+    // Test scroll navigation controls pseudo-classes
+    let scroll_navigation_controls_options = ParserOptions {
+      flags: ParserFlags::SCROLL_NAVIGATION_CONTROLS,
+      ..ParserOptions::default()
+    };
+    minify_test_with_options(
+      "a:target-current { color: green }",
+      "a:target-current{color:green}",
+      scroll_navigation_controls_options.clone(),
+    );
+    minify_test_with_options(
+      "a:target-before { color: green }",
+      "a:target-before{color:green}",
+      scroll_navigation_controls_options.clone(),
+    );
+    minify_test_with_options(
+      "a:target-after { color: green }",
+      "a:target-after{color:green}",
+      scroll_navigation_controls_options.clone(),
+    );
+    minify_test_with_options(
       ":is(a:target-before, a:target-after) { color: green }",
       ":is(a:target-before,a:target-after){color:green}",
+      scroll_navigation_controls_options.clone(),
     );
-    minify_test(
+    minify_test_with_options(
       "a:where(:target-before, :target-after) { color: green }",
       "a:where(:target-before,:target-after){color:green}",
+      scroll_navigation_controls_options.clone(),
     );
-    error_test(
+    // If the browser does not support it, it will output the `:is()` selector.
+    minify_test_with_options_and_browsers(
+      "a:target-before, a:target-after { color: green }",
+      ":is(a:target-before,a:target-after){color:green}",
+      scroll_navigation_controls_options.clone(),
+      Some(Browsers {
+        chrome: Some(130 << 16),
+        ..Browsers::default()
+      }),
+    );
+    minify_test_with_options_and_browsers(
+      "a:target-before, a:target-after { color: green }",
+      "a:target-before,a:target-after{color:green}",
+      scroll_navigation_controls_options.clone(),
+      Some(Browsers {
+        chrome: Some(150 << 16),
+        ..Browsers::default()
+      }),
+    );
+
+    error_test_with_options(
       "a::before:target-current { color: green }",
       ParserError::SelectorError(SelectorError::InvalidPseudoClassAfterPseudoElement),
+      ParserOptions {
+        flags: ParserFlags::SCROLL_NAVIGATION_CONTROLS,
+        ..ParserOptions::default()
+      },
+    );
+
+    let warnings = Some(Arc::new(RwLock::new(Vec::new())));
+    let _ = StyleSheet::parse(
+      "a:target-current { color: green }",
+      ParserOptions {
+        warnings: warnings.clone(),
+        ..ParserOptions::default()
+      },
+    )
+    .unwrap();
+    let warnings = Arc::try_unwrap(warnings.unwrap()).unwrap().into_inner().unwrap();
+    assert_eq!(warnings.len(), 1);
+    assert_eq!(
+      warnings[0].kind,
+      ParserError::SelectorError(SelectorError::UnsupportedPseudoClass("target-current".into()))
     );
 
     minify_test(":host {color:red}", ":host{color:red}");
@@ -8681,7 +8768,14 @@ mod tests {
   #[test]
   fn test_selector_compatibility() {
     fn selectors(source: &str) -> crate::selector::SelectorList<'_> {
-      let stylesheet = StyleSheet::parse(source, ParserOptions::default()).unwrap();
+      let stylesheet = StyleSheet::parse(
+        source,
+        ParserOptions {
+          flags: ParserFlags::SCROLL_NAVIGATION_CONTROLS,
+          ..ParserOptions::default()
+        },
+      )
+      .unwrap();
       match &stylesheet.rules.0[0] {
         CssRule::Style(rule) => rule.selectors.clone(),
         _ => unreachable!(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -39,6 +39,10 @@ struct CliArgs {
   /// Enable parsing custom media queries
   #[clap(long, value_parser)]
   custom_media: bool,
+  /// Enable parsing scroll navigation controls.
+  /// https://drafts.csswg.org/css-overflow-5/#scroll-navigation
+  #[clap(long, value_parser)]
+  scroll_navigation_controls: bool,
   /// Enable CSS modules in output.
   /// If no filename is provided, <output_file>.json will be used.
   /// If no --output-file is specified, code and exports will be printed to stdout as JSON.
@@ -166,6 +170,10 @@ pub fn main() -> Result<(), std::io::Error> {
     let res = {
       let mut flags = ParserFlags::empty();
       flags.set(ParserFlags::CUSTOM_MEDIA, cli_args.custom_media);
+      flags.set(
+        ParserFlags::SCROLL_NAVIGATION_CONTROLS,
+        cli_args.scroll_navigation_controls,
+      );
 
       let mut options = ParserOptions {
         flags,

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -54,6 +54,8 @@ bitflags! {
     const CUSTOM_MEDIA = 1 << 1;
     /// Whether to enable the non-standard >>> and /deep/ selector combinators used by Vue and Angular.
     const DEEP_SELECTOR_COMBINATOR = 1 << 2;
+    /// Whether to enable the [scroll navigation controls](https://drafts.csswg.org/css-overflow-5/#scroll-navigation-controls) draft syntax.
+    const SCROLL_NAVIGATION_CONTROLS = 1 << 3;
   }
 }
 

--- a/src/selector.rs
+++ b/src/selector.rs
@@ -148,6 +148,12 @@ impl<'a, 'o, 'i> parcel_selectors::parser::Parser<'i> for SelectorParser<'a, 'o,
       "local-link" => LocalLink,
       "target" => Target,
       "target-within" => TargetWithin,
+
+      // https://drafts.csswg.org/css-overflow-5/#active-before-after-scroll-markers
+      "target-current" => TargetCurrent,
+      "target-before" => TargetBefore,
+      "target-after" => TargetAfter,
+
       "visited" => Visited,
 
       // https://drafts.csswg.org/selectors-4/#input-pseudos
@@ -482,7 +488,15 @@ pub enum PseudoClass<'i> {
   LocalLink,
   /// The [:target](https://drafts.csswg.org/selectors-4/#the-target-pseudo) pseudo class.
   Target,
+
+  /// The [:target-current](https://drafts.csswg.org/css-overflow-5/#selectordef-target-current) pseudo class.
+  TargetCurrent,
+  /// The [:target-before](https://drafts.csswg.org/css-overflow-5/#selectordef-target-before) pseudo class.
+  TargetBefore,
+  /// The [:target-after](https://drafts.csswg.org/css-overflow-5/#selectordef-target-after) pseudo class.
+  TargetAfter,
   /// The [:target-within](https://drafts.csswg.org/selectors-4/#the-target-within-pseudo) pseudo class.
+
   TargetWithin,
   /// The [:visited](https://drafts.csswg.org/selectors-4/#visited-pseudo) pseudo class.
   Visited,
@@ -782,6 +796,12 @@ where
     LocalLink => dest.write_str(":local-link"),
     Target => dest.write_str(":target"),
     TargetWithin => dest.write_str(":target-within"),
+
+    // https://drafts.csswg.org/css-overflow-5/#active-before-after-scroll-markers
+    TargetCurrent => dest.write_str(":target-current"),
+    TargetBefore => dest.write_str(":target-before"),
+    TargetAfter => dest.write_str(":target-after"),
+
     Visited => dest.write_str(":visited"),
 
     // https://drafts.csswg.org/selectors-4/#input-pseudos
@@ -1931,6 +1951,9 @@ pub(crate) fn is_compatible(selectors: &[Selector], targets: Targets) -> bool {
             PseudoClass::Dir { direction: _ } => Feature::DirSelector,
             PseudoClass::Optional => Feature::OptionalPseudo,
             PseudoClass::PlaceholderShown(prefix) if *prefix == VendorPrefix::None => Feature::PlaceholderShown,
+
+            PseudoClass::TargetCurrent => Feature::TargetCurrent,
+            PseudoClass::TargetBefore | PseudoClass::TargetAfter => Feature::TargetBeforeAfter,
 
             PseudoClass::ReadOnly(prefix) | PseudoClass::ReadWrite(prefix) if *prefix == VendorPrefix::None => {
               Feature::ReadOnlyWrite

--- a/src/selector.rs
+++ b/src/selector.rs
@@ -100,6 +100,10 @@ impl<'a, 'o, 'i> parcel_selectors::parser::Parser<'i> for SelectorParser<'a, 'o,
     name: CowRcStr<'i>,
   ) -> Result<PseudoClass<'i>, ParseError<'i, Self::Error>> {
     use PseudoClass::*;
+    let scroll_navigation_controls = self
+      .options
+      .flags
+      .contains(ParserFlags::SCROLL_NAVIGATION_CONTROLS);
     let pseudo_class = match_ignore_ascii_case! { &name,
       // https://drafts.csswg.org/selectors-4/#useraction-pseudos
       "hover" => Hover,
@@ -150,9 +154,9 @@ impl<'a, 'o, 'i> parcel_selectors::parser::Parser<'i> for SelectorParser<'a, 'o,
       "target-within" => TargetWithin,
 
       // https://drafts.csswg.org/css-overflow-5/#active-before-after-scroll-markers
-      "target-current" => TargetCurrent,
-      "target-before" => TargetBefore,
-      "target-after" => TargetAfter,
+      "target-current" if scroll_navigation_controls => TargetCurrent,
+      "target-before" if scroll_navigation_controls => TargetBefore,
+      "target-after" if scroll_navigation_controls => TargetAfter,
 
       "visited" => Visited,
 

--- a/website/playground/index.html
+++ b/website/playground/index.html
@@ -171,6 +171,7 @@
         <label><input id="visitorEnabled" type="checkbox"> Visitor</label>
         <h3>Draft syntax</h3>
         <label><input id="customMedia" type="checkbox" checked> Custom media queries</label>
+        <label><input id="scrollNavigationControls" type="checkbox" checked> Scroll navigation controls</label>
         <h3>Targets</h3>
         <div class="targets">
           <label><span>Chrome: </span><input id="chrome" type="number" value="95"></label>

--- a/website/playground/playground.js
+++ b/website/playground/playground.js
@@ -105,6 +105,10 @@ function reflectPlaygroundState(playgroundState) {
     customMedia.checked = playgroundState.customMedia;
   }
 
+  if (typeof playgroundState.scrollNavigationControls !== 'undefined') {
+    scrollNavigationControls.checked = playgroundState.scrollNavigationControls;
+  }
+
   if (typeof playgroundState.visitorEnabled !== 'undefined') {
     visitorEnabled.checked = playgroundState.visitorEnabled;
   }
@@ -140,6 +144,7 @@ function savePlaygroundState() {
   const playgroundState = {
     minify: minify.checked,
     customMedia: customMedia.checked,
+    scrollNavigationControls: scrollNavigationControls.checked,
     cssModules: cssModules.checked,
     analyzeDependencies: analyzeDependencies.checked,
     targets: getTargets(),
@@ -210,7 +215,8 @@ function update() {
       include,
       exclude,
       drafts: {
-        customMedia: customMedia.checked
+        customMedia: customMedia.checked,
+        scrollNavigationControls: scrollNavigationControls.checked
       },
       cssModules: cssModules.checked,
       analyzeDependencies: analyzeDependencies.checked,


### PR DESCRIPTION
Spec: https://drafts.csswg.org/css-overflow-5/#active-before-after-scroll-markers

MDN:

- https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Selectors/:target-current#browser_compatibility
- https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Selectors/:target-after#browser_compatibility
- https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Selectors/:target-before#browser_compatibility

Part of #1184
Fixes: #1181