### PR TITLE
Replace `atty` with `std::io::IsTerminal`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -759,7 +759,6 @@ dependencies = [
  "ahash 0.8.12",
  "assert_cmd",
  "assert_fs",
- "atty",
  "bitflags 2.6.0",
  "browserslist-rs",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ crate-type = ["rlib"]
 default = ["bundler", "nodejs", "sourcemap"]
 browserslist = ["browserslist-rs"]
 bundler = ["dashmap", "sourcemap", "rayon"]
-cli = ["atty", "clap", "serde_json", "browserslist", "jemallocator"]
+cli = ["clap", "serde_json", "browserslist", "jemallocator"]
 jsonschema = ["schemars", "serde", "parcel_selectors/jsonschema"]
 nodejs = ["dep:serde", "dep:serde-content"]
 serde = [
@@ -77,7 +77,6 @@ ahash = "0.8.7"
 pastey = "0.1.0"
 indexmap = { version = "2.2.6", features = ["serde"] }
 # CLI deps
-atty = { version = "0.2", optional = true }
 clap = { version = "3.0.6", features = ["derive"], optional = true }
 browserslist-rs = { version = "0.19.0", optional = true }
 rayon = { version = "1.5.1", optional = true }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,3 @@
-use atty::Stream;
 use clap::{ArgGroup, Parser};
 use lightningcss::bundler::{Bundler, FileProvider};
 use lightningcss::stylesheet::{MinifyOptions, ParserFlags, ParserOptions, PrinterOptions, StyleSheet};
@@ -6,6 +5,7 @@ use lightningcss::targets::Browsers;
 use parcel_sourcemap::SourceMap;
 use serde::Serialize;
 use std::borrow::Cow;
+use std::io::IsTerminal;
 use std::sync::{Arc, RwLock};
 use std::{ffi, fs, io, path::Path};
 
@@ -105,14 +105,15 @@ pub fn main() -> Result<(), std::io::Error> {
       .collect::<Result<_, _>>()?
   } else {
     // Don't silently wait for input if stdin was not redirected.
-    if atty::is(Stream::Stdin) {
+    let stdin = io::stdin();
+    if stdin.is_terminal() {
       return Err(io::Error::new(
         io::ErrorKind::Other,
         "Not reading from stdin as it was not redirected",
       ));
     }
     let filename = format!("stdin-{}", std::process::id());
-    let contents = io::read_to_string(io::stdin())?;
+    let contents = io::read_to_string(stdin)?;
     vec![(filename, contents)]
   };
 


### PR DESCRIPTION
The [_atty_ repository](https://github.com/softprops/atty) warns that it is no longer maintained and should be replaced with the [equivalent native method](https://doc.rust-lang.org/std/io/trait.IsTerminal.html). This change removes it as a direct dependency (however it stays a transitive dependency through `clap@3`).

`yarn test` and `cargo test` both ran successfully after the change, but the `Not reading from stdin as it was not redirected` error is not checked in any of the test cases, so I also built the CLI with 
```sh
cargo build --bin=lightningcss --features=cli --release
```
and ran `./target/release/lightningcss` on a terminal emulator without any input files nor piping, which generated the expected 
```sh
Error: Custom { kind: Other, error: "Not reading from stdin as it was not redirected" }
```