### PR TITLE
Fix division by zero in polar color space unpremultiply when alpha is 0

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22304,6 +22304,26 @@ mod tests {
         &format!(".foo{{color:color({} .3 .4 .5/none)}}", result_color_space),
       );
     }
+
+    // Test: color-mix in polar color spaces with zero alpha should not produce inf/NaN.
+    // This exercises the polar_premultiply unpremultiply path where alpha=0.
+    // When alpha is 0, unpremultiply should not divide by zero.
+    minify_test(
+      ".foo { color: color-mix(in hsl, hsl(0 100% 50% / 0), hsl(200 100% 50% / 0)); }",
+      ".foo{color:#0000}",
+    );
+    minify_test(
+      ".foo { color: color-mix(in oklch, oklch(0.5 0.2 120 / 0), oklch(0.7 0.1 240 / 0)); }",
+      ".foo{color:oklch(0% 0 180/0)}",
+    );
+    minify_test(
+      ".foo { color: color-mix(in lch, lch(50 30 120 / 0), lch(70 10 240 / 0)); }",
+      ".foo{color:lch(0% 0 180/0)}",
+    );
+    minify_test(
+      ".foo { color: color-mix(in hwb, hwb(0 0% 50% / 0), hwb(200 0% 50% / 0)); }",
+      ".foo{color:#a0f0}",
+    );
   }
 
   #[test]

--- a/src/values/color.rs
+++ b/src/values/color.rs
@@ -3512,7 +3512,7 @@ macro_rules! polar_premultiply {
 
     fn unpremultiply(&mut self, alpha_multiplier: f32) {
       self.h %= 360.0;
-      if !self.alpha.is_nan() {
+      if !self.alpha.is_nan() && self.alpha != 0.0 {
         self.$a /= self.alpha;
         self.$b /= self.alpha;
         self.alpha *= alpha_multiplier;


### PR DESCRIPTION
## Summary

- Fix division by zero in `polar_premultiply` macro's `unpremultiply` method when `alpha == 0.0`
- Add `&& self.alpha != 0.0` guard to match the existing `rectangular_premultiply` behavior
- Add tests for `color-mix()` with zero-alpha colors in all four polar color spaces (HSL, HWB, LCH, OKLCH)

## Problem

When using `color-mix()` to interpolate colors with zero alpha in polar color spaces (HSL, HWB, LCH, OKLCH), the `unpremultiply` step divides by `alpha` (which is 0), producing `NaN` values. These `NaN` values then serialize as `none` in the CSS output.

For example:
```css
/* Input */
.foo { color: color-mix(in oklch, oklch(0.5 0.2 120 / 0), oklch(0.7 0.1 240 / 0)); }
/* Before fix: */ .foo{color:oklch(none none 180/0)}
/* After fix:  */ .foo{color:oklch(0% 0 180/0)}
```

The `rectangular_premultiply` macro already guards against this with `self.alpha != 0.0`, but `polar_premultiply` was missing the check.

## Test plan

- [x] Added test cases for `color-mix()` with zero-alpha in HSL, HWB, LCH, and OKLCH
- [x] All existing tests pass (`cargo test` - 117 tests + doc tests)

Fixes #1194

Generated with [Claude Code](https://claude.com/claude-code)