### PR TITLE
Fix #rrggbbaa support on older versions of android

### DIFF
--- a/node/test/transform.test.mjs
+++ b/node/test/transform.test.mjs
@@ -68,4 +68,20 @@ test('can disable prefixing', () => {
   assert.equal(res.code.toString(), '.foo{user-select:none}');
 });
 
+test('minification works as expected on older yet modern android versions', () => {
+  let res = transform({
+    filename: 'test.css',
+    code: Buffer.from('.foo { color: transparent; }'),
+    minify: true,
+    targets: {
+      // According to MDN (https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Values/hex-color#browser_compatibility)
+      // the Android WebView gained RGBA support alongside Chrome, on version
+      // 62. Thus version 90 should minify 'transparent' to '#0000'.
+      android: 95 << 16
+    }
+  });
+
+  assert.equal(res.code.toString(), '.foo{color:#0000}');
+})
+
 test.run();

--- a/scripts/build-prefixes.js
+++ b/scripts/build-prefixes.js
@@ -189,7 +189,6 @@ let cssFeatures = [
   'css-autofill',
   'css-namespaces',
   'shadowdomv1',
-  'css-rrggbbaa',
   'css-nesting',
   'css-not-sel-list',
   'css-has',
@@ -200,7 +199,6 @@ let cssFeatures = [
 
 let cssFeatureMappings = {
   'css-dir-pseudo': 'DirSelector',
-  'css-rrggbbaa': 'HexAlphaColors',
   'css-not-sel-list': 'NotSelectorList',
   'css-has': 'HasSelector',
   'css-matches-pseudo': 'IsSelector',
@@ -288,6 +286,7 @@ let mdnFeatures = {
   logicalInset: mdn.css.properties['inset-inline-start'].__compat.support,
   logicalSize: mdn.css.properties['inline-size'].__compat.support,
   logicalTextAlign: mdn.css.properties['text-align'].start.__compat.support,
+  hexAlphaColors: mdn.css.types.color.rgb_hexadecimal_notation.alpha_hexadecimal_notation.__compat.support,
   labColors: mdn.css.types.color.lab.__compat.support,
   oklabColors: mdn.css.types.color.oklab.__compat.support,
   colorFunction: mdn.css.types.color.color.__compat.support,

--- a/src/compat.rs
+++ b/src/compat.rs
@@ -1347,51 +1347,6 @@ impl Feature {
           return false;
         }
       }
-      Feature::HexAlphaColors => {
-        if let Some(version) = browsers.edge {
-          if version < 5177344 {
-            return false;
-          }
-        }
-        if let Some(version) = browsers.firefox {
-          if version < 3211264 {
-            return false;
-          }
-        }
-        if let Some(version) = browsers.chrome {
-          if version < 4063232 {
-            return false;
-          }
-        }
-        if let Some(version) = browsers.safari {
-          if version < 655360 {
-            return false;
-          }
-        }
-        if let Some(version) = browsers.opera {
-          if version < 3407872 {
-            return false;
-          }
-        }
-        if let Some(version) = browsers.ios_saf {
-          if version < 655360 {
-            return false;
-          }
-        }
-        if let Some(version) = browsers.android {
-          if version < 9502720 {
-            return false;
-          }
-        }
-        if let Some(version) = browsers.samsung {
-          if version < 524800 {
-            return false;
-          }
-        }
-        if browsers.ie.is_some() {
-          return false;
-        }
-      }
       Feature::Nesting => {
         if let Some(version) = browsers.edge {
           if version < 7864320 {
@@ -2263,6 +2218,51 @@ impl Feature {
         }
         if let Some(version) = browsers.android {
           if version < 2424832 {
+            return false;
+          }
+        }
+        if browsers.ie.is_some() {
+          return false;
+        }
+      }
+      Feature::HexAlphaColors => {
+        if let Some(version) = browsers.chrome {
+          if version < 4063232 {
+            return false;
+          }
+        }
+        if let Some(version) = browsers.edge {
+          if version < 5177344 {
+            return false;
+          }
+        }
+        if let Some(version) = browsers.firefox {
+          if version < 3211264 {
+            return false;
+          }
+        }
+        if let Some(version) = browsers.opera {
+          if version < 3080192 {
+            return false;
+          }
+        }
+        if let Some(version) = browsers.safari {
+          if version < 655360 {
+            return false;
+          }
+        }
+        if let Some(version) = browsers.ios_saf {
+          if version < 590592 {
+            return false;
+          }
+        }
+        if let Some(version) = browsers.samsung {
+          if version < 524288 {
+            return false;
+          }
+        }
+        if let Some(version) = browsers.android {
+          if version < 4063232 {
             return false;
           }
         }


### PR DESCRIPTION
This change replaces the `build-prefixes.js` script's source of data for alpha-hexadecimal support from `caniuse` to MDN, allowing for more precise data regarding Android feature support.

However, issues on other features still persist due to `browserlist`'s odd behavior when it comes to `android` and `ChromeAndroid`

Fixes #1180 