### PR TITLE
chore: bump dependencies (cssparser, const-str)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -355,9 +355,9 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "cssparser"
-version = "0.37.0"
+version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c9cdaae01d5ed7882b04d795e7f752f46ff52d2fa3b50a20d28c464510bba98"
+checksum = "dae61cf9c0abb83bd659dab65b7e4e38d8236824c85f0f804f173567bda257d2"
 dependencies = [
  "cssparser-macros",
  "dtoa-short",
@@ -369,18 +369,18 @@ dependencies = [
 
 [[package]]
 name = "cssparser-color"
-version = "0.5.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbaa233e1dcd9c13a5d3e3a8a2c0f5a727bac380398345dbcb31db4597edc86b"
+checksum = "114504b9a8d627e73f72d1c80583c8194eb8e0007da29b57782b729c7a7166bd"
 dependencies = [
  "cssparser",
 ]
 
 [[package]]
 name = "cssparser-macros"
-version = "0.7.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10a2a99df6e410a8ff4245aa2006499ea662245f967cc7c0a38c83ef8eb44dbf"
+checksum = "13b588ba4ac1a99f7f2964d24b3d896ddc6bf847ee3855dbd4366f058cfcd331"
 dependencies = [
  "quote",
  "syn 2.0.90",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -369,32 +369,32 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "cssparser"
-version = "0.33.0"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9be934d936a0fbed5bcdc01042b770de1398bf79d0e192f49fa7faea0e99281e"
+checksum = "8c9cdaae01d5ed7882b04d795e7f752f46ff52d2fa3b50a20d28c464510bba98"
 dependencies = [
  "cssparser-macros",
  "dtoa-short",
  "itoa",
- "phf",
+ "phf 0.13.1",
  "serde",
  "smallvec",
 ]
 
 [[package]]
 name = "cssparser-color"
-version = "0.1.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "556c099a61d85989d7af52b692e35a8d68a57e7df8c6d07563dc0778b3960c9f"
+checksum = "bbaa233e1dcd9c13a5d3e3a8a2c0f5a727bac380398345dbcb31db4597edc86b"
 dependencies = [
  "cssparser",
 ]
 
 [[package]]
 name = "cssparser-macros"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13b588ba4ac1a99f7f2964d24b3d896ddc6bf847ee3855dbd4366f058cfcd331"
+checksum = "10a2a99df6e410a8ff4245aa2006499ea662245f967cc7c0a38c83ef8eb44dbf"
 dependencies = [
  "quote",
  "syn 2.0.90",
@@ -987,7 +987,7 @@ dependencies = [
  "bitflags 2.6.0",
  "cssparser",
  "log",
- "phf",
+ "phf 0.11.2",
  "phf_codegen",
  "precomputed-hash",
  "rustc-hash",
@@ -1042,8 +1042,18 @@ version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ade2d8b8f33c7333b51bcf0428d37e217e9f32192ae4772156f65063b8ce03dc"
 dependencies = [
+ "phf_shared 0.11.2",
+]
+
+[[package]]
+name = "phf"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
+dependencies = [
  "phf_macros",
- "phf_shared",
+ "phf_shared 0.13.1",
+ "serde",
 ]
 
 [[package]]
@@ -1052,8 +1062,8 @@ version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8d39688d359e6b34654d328e262234662d16cc0f60ec8dcbe5e718709342a5a"
 dependencies = [
- "phf_generator",
- "phf_shared",
+ "phf_generator 0.11.2",
+ "phf_shared 0.11.2",
 ]
 
 [[package]]
@@ -1062,18 +1072,28 @@ version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48e4cc64c2ad9ebe670cb8fd69dd50ae301650392e81c05f9bfcb2d5bdbc24b0"
 dependencies = [
- "phf_shared",
+ "phf_shared 0.11.2",
  "rand",
 ]
 
 [[package]]
-name = "phf_macros"
-version = "0.11.2"
+name = "phf_generator"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3444646e286606587e49f3bcf1679b8cef1dc2c5ecc29ddacaffc305180d464b"
+checksum = "135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737"
 dependencies = [
- "phf_generator",
- "phf_shared",
+ "fastrand",
+ "phf_shared 0.13.1",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "812f032b54b1e759ccd5f8b6677695d5268c588701effba24601f6932f8269ef"
+dependencies = [
+ "phf_generator 0.13.1",
+ "phf_shared 0.13.1",
  "proc-macro2",
  "quote",
  "syn 2.0.90",
@@ -1085,7 +1105,16 @@ version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90fcb95eef784c2ac79119d1dd819e162b5da872ce6f3c3abe1e8ca1c082f72b"
 dependencies = [
- "siphasher",
+ "siphasher 0.3.11",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
+dependencies = [
+ "siphasher 1.0.2",
 ]
 
 [[package]]
@@ -1171,9 +1200,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.92"
+version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37d3544b3f2748c54e147655edb5025752e2303145b5aefb3c3ea2c78b973bb0"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
@@ -1515,6 +1544,12 @@ name = "siphasher"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
+
+[[package]]
+name = "siphasher"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
 
 [[package]]
 name = "smallvec"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -355,9 +355,9 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "cssparser"
-version = "0.36.0"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dae61cf9c0abb83bd659dab65b7e4e38d8236824c85f0f804f173567bda257d2"
+checksum = "8c9cdaae01d5ed7882b04d795e7f752f46ff52d2fa3b50a20d28c464510bba98"
 dependencies = [
  "cssparser-macros",
  "dtoa-short",
@@ -369,18 +369,18 @@ dependencies = [
 
 [[package]]
 name = "cssparser-color"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "114504b9a8d627e73f72d1c80583c8194eb8e0007da29b57782b729c7a7166bd"
+checksum = "bbaa233e1dcd9c13a5d3e3a8a2c0f5a727bac380398345dbcb31db4597edc86b"
 dependencies = [
  "cssparser",
 ]
 
 [[package]]
 name = "cssparser-macros"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13b588ba4ac1a99f7f2964d24b3d896ddc6bf847ee3855dbd4366f058cfcd331"
+checksum = "10a2a99df6e410a8ff4245aa2006499ea662245f967cc7c0a38c83ef8eb44dbf"
 dependencies = [
  "quote",
  "syn 2.0.90",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -300,23 +300,9 @@ dependencies = [
 
 [[package]]
 name = "const-str"
-version = "0.3.2"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21077772762a1002bb421c3af42ac1725fa56066bfc53d9a55bb79905df2aaf3"
-dependencies = [
- "const-str-proc-macro",
-]
-
-[[package]]
-name = "const-str-proc-macro"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e1e0fdd2e5d3041e530e1b21158aeeef8b5d0e306bc5c1e3d6cf0930d10e25a"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
+checksum = "18f12cc9948ed9604230cdddc7c86e270f9401ccbe3c2e98a4378c5e7632212f"
 
 [[package]]
 name = "convert_case"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,8 +62,8 @@ substitute_variables = ["visitor", "into_owned"]
 [dependencies]
 serde = { version = "1.0.228", features = ["derive"], optional = true }
 serde-content = { version = "0.1.2", features = ["serde"], optional = true }
-cssparser = "0.36.0"
-cssparser-color = "0.4.0"
+cssparser = "0.37.0"
+cssparser-color = "0.5.0"
 parcel_selectors = { version = "0.28.2", path = "./selectors" }
 itertools = "0.10.1"
 smallvec = { version = "1.7.0", features = ["union"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,7 +71,7 @@ bitflags = "2.2.1"
 parcel_sourcemap = { version = "2.1.1", features = ["json"], optional = true }
 data-encoding = "2.3.2"
 lazy_static = "1.4.0"
-const-str = "0.3.1"
+const-str = "1.1.0"
 pathdiff = "0.2.1"
 ahash = "0.8.7"
 pastey = "0.1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,8 +62,8 @@ substitute_variables = ["visitor", "into_owned"]
 [dependencies]
 serde = { version = "1.0.228", features = ["derive"], optional = true }
 serde-content = { version = "0.1.2", features = ["serde"], optional = true }
-cssparser = "0.37.0"
-cssparser-color = "0.5.0"
+cssparser = "0.36.0"
+cssparser-color = "0.4.0"
 parcel_selectors = { version = "0.28.2", path = "./selectors" }
 itertools = "0.10.1"
 smallvec = { version = "1.7.0", features = ["union"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,8 +62,8 @@ substitute_variables = ["visitor", "into_owned"]
 [dependencies]
 serde = { version = "1.0.228", features = ["derive"], optional = true }
 serde-content = { version = "0.1.2", features = ["serde"], optional = true }
-cssparser = "0.33.0"
-cssparser-color = "0.1.0"
+cssparser = "0.37.0"
+cssparser-color = "0.5.0"
 parcel_selectors = { version = "0.28.2", path = "./selectors" }
 itertools = "0.10.1"
 smallvec = { version = "1.7.0", features = ["union"] }
@@ -84,7 +84,10 @@ rayon = { version = "1.5.1", optional = true }
 dashmap = { version = "5.0.0", optional = true }
 serde_json = { version = "1.0.78", optional = true }
 lightningcss-derive = { version = "=1.0.0-alpha.43", path = "./derive" }
-schemars = { version = "0.8.19", features = ["smallvec", "indexmap2"], optional = true }
+schemars = { version = "0.8.19", features = [
+  "smallvec",
+  "indexmap2",
+], optional = true }
 static-self = { version = "0.1.2", path = "static-self", optional = true }
 
 [target.'cfg(target_os = "macos")'.dependencies]

--- a/napi/Cargo.toml
+++ b/napi/Cargo.toml
@@ -16,7 +16,7 @@ bundler = ["dep:crossbeam-channel", "dep:rayon"]
 serde = { version = "1.0.201", features = ["derive"] }
 serde-content = { version = "0.1.2", features = ["serde"] }
 serde_bytes = "0.11.5"
-cssparser = "0.33.0"
+cssparser = "0.37.0"
 lightningcss = { version = "1.0.0-alpha.71", path = "../", features = [
   "nodejs",
   "serde",

--- a/napi/Cargo.toml
+++ b/napi/Cargo.toml
@@ -16,7 +16,7 @@ bundler = ["dep:crossbeam-channel", "dep:rayon"]
 serde = { version = "1.0.201", features = ["derive"] }
 serde-content = { version = "0.1.2", features = ["serde"] }
 serde_bytes = "0.11.5"
-cssparser = "0.37.0"
+cssparser = "0.36.0"
 lightningcss = { version = "1.0.0-alpha.71", path = "../", features = [
   "nodejs",
   "serde",

--- a/napi/Cargo.toml
+++ b/napi/Cargo.toml
@@ -16,7 +16,7 @@ bundler = ["dep:crossbeam-channel", "dep:rayon"]
 serde = { version = "1.0.201", features = ["derive"] }
 serde-content = { version = "0.1.2", features = ["serde"] }
 serde_bytes = "0.11.5"
-cssparser = "0.36.0"
+cssparser = "0.37.0"
 lightningcss = { version = "1.0.0-alpha.71", path = "../", features = [
   "nodejs",
   "serde",

--- a/selectors/Cargo.toml
+++ b/selectors/Cargo.toml
@@ -24,7 +24,7 @@ serde = ["dep:serde", "smallvec/serde"]
 
 [dependencies]
 bitflags = "2.2.1"
-cssparser = "0.33.0"
+cssparser = "0.37.0"
 rustc-hash = "2"
 log = "0.4"
 phf = "0.11.2"

--- a/selectors/Cargo.toml
+++ b/selectors/Cargo.toml
@@ -24,7 +24,7 @@ serde = ["dep:serde", "smallvec/serde"]
 
 [dependencies]
 bitflags = "2.2.1"
-cssparser = "0.36.0"
+cssparser = "0.37.0"
 rustc-hash = "2"
 log = "0.4"
 phf = "0.11.2"

--- a/selectors/Cargo.toml
+++ b/selectors/Cargo.toml
@@ -24,7 +24,7 @@ serde = ["dep:serde", "smallvec/serde"]
 
 [dependencies]
 bitflags = "2.2.1"
-cssparser = "0.37.0"
+cssparser = "0.36.0"
 rustc-hash = "2"
 log = "0.4"
 phf = "0.11.2"

--- a/src/declaration.rs
+++ b/src/declaration.rs
@@ -471,6 +471,7 @@ impl<'a, 'o, 'i> cssparser::DeclarationParser<'i> for PropertyDeclarationParser<
     &mut self,
     name: CowRcStr<'i>,
     input: &mut cssparser::Parser<'i, 't>,
+    _declaration_start: &ParserState,
   ) -> Result<Self::Declaration, cssparser::ParseError<'i, Self::Error>> {
     parse_declaration(
       name,

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1008,6 +1008,7 @@ impl<'a, 'o, 'i, T: crate::traits::AtRuleParser<'i>> cssparser::DeclarationParse
     &mut self,
     name: CowRcStr<'i>,
     input: &mut cssparser::Parser<'i, 't>,
+    _declaration_start: &ParserState,
   ) -> Result<Self::Declaration, cssparser::ParseError<'i, Self::Error>> {
     if self.rules.0.is_empty() {
       parse_declaration(

--- a/src/rules/font_face.rs
+++ b/src/rules/font_face.rs
@@ -450,6 +450,7 @@ impl<'i> cssparser::DeclarationParser<'i> for FontFaceDeclarationParser {
     &mut self,
     name: CowRcStr<'i>,
     input: &mut cssparser::Parser<'i, 't>,
+    _declaration_start: &ParserState,
   ) -> Result<Self::Declaration, cssparser::ParseError<'i, Self::Error>> {
     macro_rules! property {
       ($property: ident, $type: ty) => {

--- a/src/rules/font_feature_values.rs
+++ b/src/rules/font_feature_values.rs
@@ -288,6 +288,7 @@ impl<'a, 'i> cssparser::DeclarationParser<'i> for FontFeatureDeclarationParser<'
     &mut self,
     name: CowRcStr<'i>,
     input: &mut cssparser::Parser<'i, 't>,
+    _declaration_start: &ParserState,
   ) -> Result<Self::Declaration, cssparser::ParseError<'i, Self::Error>> {
     let mut indices = SmallVec::new();
     loop {

--- a/src/rules/font_palette_values.rs
+++ b/src/rules/font_palette_values.rs
@@ -101,6 +101,7 @@ impl<'i> cssparser::DeclarationParser<'i> for FontPaletteValuesDeclarationParser
     &mut self,
     name: CowRcStr<'i>,
     input: &mut cssparser::Parser<'i, 't>,
+    _declaration_start: &ParserState,
   ) -> Result<Self::Declaration, cssparser::ParseError<'i, Self::Error>> {
     let state = input.state();
     match_ignore_ascii_case! { &name,

--- a/src/rules/page.rs
+++ b/src/rules/page.rs
@@ -313,6 +313,7 @@ impl<'a, 'o, 'i> cssparser::DeclarationParser<'i> for PageRuleParser<'a, 'o, 'i>
     &mut self,
     name: CowRcStr<'i>,
     input: &mut cssparser::Parser<'i, 't>,
+    _declaration_start: &ParserState,
   ) -> Result<Self::Declaration, cssparser::ParseError<'i, Self::Error>> {
     parse_declaration(
       name,

--- a/src/rules/property.rs
+++ b/src/rules/property.rs
@@ -169,6 +169,7 @@ impl<'i> cssparser::DeclarationParser<'i> for PropertyRuleDeclarationParser<'i> 
     &mut self,
     name: CowRcStr<'i>,
     input: &mut cssparser::Parser<'i, 't>,
+    _declaration_start: &ParserState,
   ) -> Result<Self::Declaration, cssparser::ParseError<'i, Self::Error>> {
     match_ignore_ascii_case! { &name,
       "syntax" => {

--- a/src/rules/view_transition.rs
+++ b/src/rules/view_transition.rs
@@ -76,8 +76,9 @@ impl<'i> cssparser::DeclarationParser<'i> for ViewTransitionDeclarationParser {
   fn parse_value<'t>(
     &mut self,
     name: CowRcStr<'i>,
-    input: &mut cssparser::Parser<'i, 't>,
-  ) -> Result<Self::Declaration, cssparser::ParseError<'i, Self::Error>> {
+    input: &mut Parser<'i, 't>,
+    _declaration_start: &ParserState,
+  ) -> Result<Self::Declaration, ParseError<'i, Self::Error>> {
     let state = input.state();
     match_ignore_ascii_case! { &name,
       "navigation" => {

--- a/src/values/percentage.rs
+++ b/src/values/percentage.rs
@@ -42,11 +42,8 @@ impl ToCss for Percentage {
     W: std::fmt::Write,
   {
     use cssparser::ToCss;
-    let int_value = if (self.0 * 100.0).fract() == 0.0 {
-      Some(self.0 as i32)
-    } else {
-      None
-    };
+    let v = self.0 * 100.0;
+    let int_value = if (v).fract() == 0.0 { Some(v as i32) } else { None };
     let percent = Token::Percentage {
       has_sign: self.0 < 0.0,
       unit_value: self.0,


### PR DESCRIPTION
This PR updates dependencies, mainly to help prevent duplicate dependencies used by consumers ([e.g.](https://github.com/noahbald/oxvg/issues/227))

Notes
- cssparser 0.37.0 (latest) has a slight change in how it uses `int_value` for `Percentage` (https://github.com/servo/rust-cssparser/issues/429)
- const-str updated to 1.1.0 so that it uses syn@2 instead of syn@1.

Breaking changes: potentially affects MSRV Rust 1.51.0 -> 1.77.0, based on [const-str docs](https://docs.rs/const-str/latest/const_str/)