### PR TITLE
Preserve ordering of `font-*` properties that follow a `font` shorthand

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6653,7 +6653,7 @@ mod tests {
     );
     minify_test(
       ".foo { font-variant-numeric: oldstyle-nums; font: 10px serif; }",
-      ".foo{font:10px serif}",
+      ".foo{font-variant-numeric:oldstyle-nums;font:10px serif}",
     );
     minify_test(
       ".foo { font: 10px serif; font-variant-numeric: oldstyle-nums; font-variant-alternates: stylistic(my-style); }",
@@ -6665,7 +6665,7 @@ mod tests {
     );
     minify_test(
       ".foo { font-kerning: none; font: 10px serif; }",
-      ".foo{font:10px serif}",
+      ".foo{font-kerning:none;font:10px serif}",
     );
     minify_test(
       ".foo { font: 10px serif; font-kerning: none; }",
@@ -6673,7 +6673,7 @@ mod tests {
     );
     minify_test(
       ".foo { font-optical-sizing: none; font: 10px serif; }",
-      ".foo{font:10px serif}",
+      ".foo{font-optical-sizing:none;font:10px serif}",
     );
     minify_test(
       ".foo { font: 10px serif; font-optical-sizing: none; }",
@@ -6681,19 +6681,11 @@ mod tests {
     );
     minify_test(
       ".foo { font-synthesis-style: oblique-only; font: 10px serif; }",
-      ".foo{font:10px serif}",
+      ".foo{font-synthesis-style:oblique-only;font:10px serif}",
     );
     minify_test(
       ".foo { font: 10px serif; font-synthesis-style: oblique-only; }",
       ".foo{font:10px serif;font-synthesis-style:oblique-only}",
-    );
-    minify_test(
-      ".foo { font-kerning: none; }",
-      ".foo{font-kerning:none}",
-    );
-    minify_test(
-      ".foo { font-kerning: none; font: 10px serif; font-optical-sizing: none; }",
-      ".foo{font:10px serif;font-optical-sizing:none}",
     );
   }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6663,6 +6663,30 @@ mod tests {
       ".foo { font: 10px serif; font-variant: small-caps; }",
       ".foo{font:10px serif;font-variant:small-caps}",
     );
+    minify_test(
+      ".foo { font-kerning: none; font: 10px serif; }",
+      ".foo{font-kerning:none;font:10px serif}",
+    );
+    minify_test(
+      ".foo { font: 10px serif; font-kerning: none; }",
+      ".foo{font:10px serif;font-kerning:none}",
+    );
+    minify_test(
+      ".foo { font-optical-sizing: none; font: 10px serif; }",
+      ".foo{font-optical-sizing:none;font:10px serif}",
+    );
+    minify_test(
+      ".foo { font: 10px serif; font-optical-sizing: none; }",
+      ".foo{font:10px serif;font-optical-sizing:none}",
+    );
+    minify_test(
+      ".foo { font-synthesis-style: oblique-only; font: 10px serif; }",
+      ".foo{font-synthesis-style:oblique-only;font:10px serif}",
+    );
+    minify_test(
+      ".foo { font: 10px serif; font-synthesis-style: oblique-only; }",
+      ".foo{font:10px serif;font-synthesis-style:oblique-only}",
+    );
   }
 
   #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6646,6 +6646,23 @@ mod tests {
         ..Browsers::default()
       },
     );
+
+    minify_test(
+      ".foo { font: 10px serif; font-variant-numeric: oldstyle-nums; }",
+      ".foo{font:10px serif;font-variant-numeric:oldstyle-nums}",
+    );
+    minify_test(
+      ".foo { font-variant-numeric: oldstyle-nums; font: 10px serif; }",
+      ".foo{font-variant-numeric:oldstyle-nums;font:10px serif}",
+    );
+    minify_test(
+      ".foo { font: 10px serif; font-variant-numeric: oldstyle-nums; font-variant-alternates: stylistic(my-style); }",
+      ".foo{font:10px serif;font-variant-numeric:oldstyle-nums;font-variant-alternates:stylistic(my-style)}",
+    );
+    minify_test(
+      ".foo { font: 10px serif; font-variant: small-caps; }",
+      ".foo{font:10px serif;font-variant:small-caps}",
+    );
   }
 
   #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6653,7 +6653,7 @@ mod tests {
     );
     minify_test(
       ".foo { font-variant-numeric: oldstyle-nums; font: 10px serif; }",
-      ".foo{font-variant-numeric:oldstyle-nums;font:10px serif}",
+      ".foo{font:10px serif}",
     );
     minify_test(
       ".foo { font: 10px serif; font-variant-numeric: oldstyle-nums; font-variant-alternates: stylistic(my-style); }",
@@ -6665,7 +6665,7 @@ mod tests {
     );
     minify_test(
       ".foo { font-kerning: none; font: 10px serif; }",
-      ".foo{font-kerning:none;font:10px serif}",
+      ".foo{font:10px serif}",
     );
     minify_test(
       ".foo { font: 10px serif; font-kerning: none; }",
@@ -6673,7 +6673,7 @@ mod tests {
     );
     minify_test(
       ".foo { font-optical-sizing: none; font: 10px serif; }",
-      ".foo{font-optical-sizing:none;font:10px serif}",
+      ".foo{font:10px serif}",
     );
     minify_test(
       ".foo { font: 10px serif; font-optical-sizing: none; }",
@@ -6681,11 +6681,19 @@ mod tests {
     );
     minify_test(
       ".foo { font-synthesis-style: oblique-only; font: 10px serif; }",
-      ".foo{font-synthesis-style:oblique-only;font:10px serif}",
+      ".foo{font:10px serif}",
     );
     minify_test(
       ".foo { font: 10px serif; font-synthesis-style: oblique-only; }",
       ".foo{font:10px serif;font-synthesis-style:oblique-only}",
+    );
+    minify_test(
+      ".foo { font-kerning: none; }",
+      ".foo{font-kerning:none}",
+    );
+    minify_test(
+      ".foo { font-kerning: none; font: 10px serif; font-optical-sizing: none; }",
+      ".foo{font:10px serif;font-optical-sizing:none}",
     );
   }
 

--- a/src/properties/font.rs
+++ b/src/properties/font.rs
@@ -2,8 +2,7 @@
 
 use std::collections::HashSet;
 
-use super::{Property, PropertyId};
-use crate::properties::custom::CustomPropertyName;
+use super::{Property, PropertyId, CustomPropertyName};
 use crate::compat::Feature;
 use crate::context::PropertyHandlerContext;
 use crate::declaration::{DeclarationBlock, DeclarationList};

--- a/src/properties/font.rs
+++ b/src/properties/font.rs
@@ -825,6 +825,7 @@ pub(crate) struct FontHandler<'i> {
   line_height: Option<LineHeight>,
   variant_caps: Option<FontVariantCaps>,
   flushed_properties: FontProperty,
+  longhand_properties: Vec<Property<'i>>,
   has_any: bool,
 }
 
@@ -876,6 +877,7 @@ impl<'i> PropertyHandler<'i> for FontHandler<'i> {
         self.stretch = Some(val.stretch.clone());
         self.line_height = Some(val.line_height.clone());
         self.variant_caps = Some(val.variant_caps.clone());
+        self.longhand_properties.clear();
         self.has_any = true;
         // TODO: reset other properties
       }
@@ -887,11 +889,9 @@ impl<'i> PropertyHandler<'i> for FontHandler<'i> {
         dest.push(property.clone());
       }
       Custom(val) if is_longhand_font_property(&val.name) => {
-        // ensure font-variant, font-kerning, etc. aren't reordered in front of the font shorthand
-        if self.has_any {
-          self.flush(dest, context);
-        }
-        dest.push(property.clone());
+        // Store font-variant, font-kerning, font-optical-sizing, font-size-adjust, etc. to ensure they're
+        // omitted if they precede a `font` shorthand property, and won't be reordered if they follow one
+        self.longhand_properties.push(property.clone());
       }
       _ => return false,
     }
@@ -908,6 +908,7 @@ impl<'i> PropertyHandler<'i> for FontHandler<'i> {
 impl<'i> FontHandler<'i> {
   fn flush(&mut self, decls: &mut DeclarationList<'i>, context: &mut PropertyHandlerContext<'i, '_>) {
     if !self.has_any {
+      decls.extend(self.longhand_properties.drain(..));
       return;
     }
 
@@ -999,6 +1000,8 @@ impl<'i> FontHandler<'i> {
         push!(LineHeight, val);
       }
     }
+
+    decls.extend(self.longhand_properties.drain(..));
   }
 }
 

--- a/src/properties/font.rs
+++ b/src/properties/font.rs
@@ -825,7 +825,6 @@ pub(crate) struct FontHandler<'i> {
   line_height: Option<LineHeight>,
   variant_caps: Option<FontVariantCaps>,
   flushed_properties: FontProperty,
-  longhand_properties: Vec<Property<'i>>,
   has_any: bool,
 }
 
@@ -877,7 +876,6 @@ impl<'i> PropertyHandler<'i> for FontHandler<'i> {
         self.stretch = Some(val.stretch.clone());
         self.line_height = Some(val.line_height.clone());
         self.variant_caps = Some(val.variant_caps.clone());
-        self.longhand_properties.clear();
         self.has_any = true;
         // TODO: reset other properties
       }
@@ -889,9 +887,11 @@ impl<'i> PropertyHandler<'i> for FontHandler<'i> {
         dest.push(property.clone());
       }
       Custom(val) if is_longhand_font_property(&val.name) => {
-        // Store font-variant, font-kerning, font-optical-sizing, font-size-adjust, etc. to ensure they're
-        // omitted if they precede a `font` shorthand property, and won't be reordered if they follow one
-        self.longhand_properties.push(property.clone());
+        // ensure font-variant, font-kerning, etc. aren't reordered in front of the font shorthand
+        if self.has_any {
+          self.flush(dest, context);
+        }
+        dest.push(property.clone());
       }
       _ => return false,
     }
@@ -908,7 +908,6 @@ impl<'i> PropertyHandler<'i> for FontHandler<'i> {
 impl<'i> FontHandler<'i> {
   fn flush(&mut self, decls: &mut DeclarationList<'i>, context: &mut PropertyHandlerContext<'i, '_>) {
     if !self.has_any {
-      decls.extend(self.longhand_properties.drain(..));
       return;
     }
 
@@ -1000,8 +999,6 @@ impl<'i> FontHandler<'i> {
         push!(LineHeight, val);
       }
     }
-
-    decls.extend(self.longhand_properties.drain(..));
   }
 }
 

--- a/src/properties/font.rs
+++ b/src/properties/font.rs
@@ -886,8 +886,8 @@ impl<'i> PropertyHandler<'i> for FontHandler<'i> {
           .insert(FontProperty::try_from(&val.property_id).unwrap());
         dest.push(property.clone());
       }
-      Custom(val) if is_font_variant_property(&val.name) => {
-        // ensure font-variant isn't reordered in front of the font shorthand
+      Custom(val) if is_longhand_font_property(&val.name) => {
+        // ensure font-variant, font-kerning, etc. aren't reordered in front of the font shorthand
         if self.has_any {
           self.flush(dest, context);
         }
@@ -1041,9 +1041,9 @@ fn compatible_font_family(mut family: Option<Vec<FontFamily>>, is_supported: boo
 }
 
 #[inline]
-fn is_font_variant_property(name: &CustomPropertyName) -> bool {
+fn is_longhand_font_property(name: &CustomPropertyName) -> bool {
   if let CustomPropertyName::Unknown(name) = name {
-    name.as_ref().starts_with("font-variant")
+    name.as_ref().starts_with("font-")
   } else {
     false
   }

--- a/src/properties/font.rs
+++ b/src/properties/font.rs
@@ -3,6 +3,7 @@
 use std::collections::HashSet;
 
 use super::{Property, PropertyId};
+use crate::properties::custom::CustomPropertyName;
 use crate::compat::Feature;
 use crate::context::PropertyHandlerContext;
 use crate::declaration::{DeclarationBlock, DeclarationList};
@@ -885,6 +886,13 @@ impl<'i> PropertyHandler<'i> for FontHandler<'i> {
           .insert(FontProperty::try_from(&val.property_id).unwrap());
         dest.push(property.clone());
       }
+      Custom(val) if is_font_variant_property(&val.name) => {
+        // ensure font-variant isn't reordered in front of the font shorthand
+        if self.has_any {
+          self.flush(dest, context);
+        }
+        dest.push(property.clone());
+      }
       _ => return false,
     }
 
@@ -1030,6 +1038,15 @@ fn compatible_font_family(mut family: Option<Vec<FontFamily>>, is_supported: boo
   }
 
   return family;
+}
+
+#[inline]
+fn is_font_variant_property(name: &CustomPropertyName) -> bool {
+  if let CustomPropertyName::Unknown(name) = name {
+    name.as_ref().starts_with("font-variant")
+  } else {
+    false
+  }
 }
 
 #[inline]


### PR DESCRIPTION
This PR prevents non-shorthand `font-*` properties being reordered to precede a shorthand `font` rule. 


## Existing behavior
As described in #1207, the `FontHandler` currently watches for all the properties that could be combined into a shorthand (e.g., `font-family`, `font-weight`, `font-style`, etc.), but will immediately emit any unrecognized font properties such as `font-variant` or `font-kerning` while deferring the `font` shorthand.

For example ([playground](https://lightningcss.dev/playground/index.html#%7B%22minify%22%3Atrue%2C%22customMedia%22%3Atrue%2C%22cssModules%22%3Afalse%2C%22analyzeDependencies%22%3Afalse%2C%22targets%22%3A%7B%22chrome%22%3A6225920%7D%2C%22include%22%3A0%2C%22exclude%22%3A0%2C%22source%22%3A%22.foo%7B%5Cn%20%20font%3A%2012px%20serif%3B%5Cn%20%20font-variant-numeric%3A%20oldstyle-nums%3B%5Cn%20%20font-kerning%3A%20none%3B%5Cn%7D%22%2C%22visitorEnabled%22%3Afalse%2C%22visitor%22%3A%22%7B%5Cn%20%20Color(color)%20%7B%5Cn%20%20%20%20if%20(color.type%20%3D%3D%3D%20'rgb')%20%7B%5Cn%20%20%20%20%20%20color.g%20%3D%200%3B%5Cn%20%20%20%20%20%20return%20color%3B%5Cn%20%20%20%20%7D%5Cn%20%20%7D%5Cn%7D%22%2C%22unusedSymbols%22%3A%5B%5D%2C%22version%22%3A%22local%22%7D)):
```css
.foo{
  font: 12px serif;
  font-variant-numeric: oldstyle-nums;
  font-kerning: none;
}
```
will be minified to:
```css
.foo{font-variant-numeric:oldstyle-nums;font-kerning:none;font:12px serif}
```
This is a problem because placing the `font` shorthand at the end has the side-effect of resetting all prior `font-*` properties to their defaults, which is clearly not the intent of the original css.

## Changes

I added a new `match` branch to `FontHandler`’s `handle_property` method to catch any `Property::Custom` that begins with `"font-"` (but has not already been caught as a property that could be merged into the shorthand) and trigger a flush of the pending shorthand *before* emitting the newly encountered longhand.

Initially I applied this to just the `font-variant-*` properties (cd12e58587edc44aa6680de6dc42b9f8e2920b02), but I believe this behavior is actually desirable for *all* non-shorthand font properties so I extended it to the whole `font-*` prefix.

Fixes #1207

## Questions

I'm not quite clear on the distinction between `Property::Custom` and `Property::Unparsed`; maybe this needs to check `Unparsed` properties to see if they match the `font-*` prefix as well?

~I added an optimization that [discards](https://github.com/parcel-bundler/lightningcss/pull/1209/changes#diff-6da1aeda09d0ffb9c25b08c5ede95a89e5367b64490f7374c432fd78886d4182R880) the cached longhand properties when a shorthand `font` declaration is encountered (since they'll all be reset to their defaults anyway). Are there any negative consequences to doing this?~ [*reverted: see discussion below*]
