### PR TITLE
Add support for ::search-text and :current::search-text (#1212)

### DIFF
--- a/scripts/build-prefixes.js
+++ b/scripts/build-prefixes.js
@@ -339,6 +339,7 @@ let mdnFeatures = {
   viewTransition: mdn.css.selectors['view-transition'].__compat.support,
   detailsContent: mdn.css.selectors['details-content'].__compat.support,
   targetText: mdn.css.selectors['target-text'].__compat.support,
+  searchText: mdn.css.selectors['search-text'].__compat.support,
   picker: mdn.css.selectors.picker.__compat.support,
   pickerIcon: mdn.css.selectors['picker-icon'].__compat.support,
   checkmark: mdn.css.selectors.checkmark.__compat.support,

--- a/selectors/parser.rs
+++ b/selectors/parser.rs
@@ -3932,6 +3932,8 @@ pub mod tests {
 
     assert!(parse("foo::details-content").is_ok());
     assert!(parse("foo::target-text").is_ok());
+    assert!(parse("foo::search-text").is_ok());
+    assert!(parse(":current::search-text").is_ok());
 
     assert!(parse("::highlight").is_err());
     assert!(parse("::highlight()").is_err());

--- a/src/compat.rs
+++ b/src/compat.rs
@@ -180,6 +180,7 @@ pub enum Feature {
   RicUnit,
   RlhUnit,
   RoundFunction,
+  SearchText,
   Selection,
   Selectors2,
   Selectors3,
@@ -3673,6 +3674,36 @@ impl Feature {
           }
         }
         if browsers.ie.is_some() {
+          return false;
+        }
+      }
+      Feature::SearchText => {
+        if let Some(version) = browsers.chrome {
+          if version < 9437184 {
+            return false;
+          }
+        }
+        if let Some(version) = browsers.edge {
+          if version < 9437184 {
+            return false;
+          }
+        }
+        if let Some(version) = browsers.opera {
+          if version < 6225920 {
+            return false;
+          }
+        }
+        if let Some(version) = browsers.android {
+          if version < 9437184 {
+            return false;
+          }
+        }
+        if browsers.firefox.is_some()
+          || browsers.ie.is_some()
+          || browsers.ios_saf.is_some()
+          || browsers.safari.is_some()
+          || browsers.samsung.is_some()
+        {
           return false;
         }
       }

--- a/src/selector.rs
+++ b/src/selector.rs
@@ -273,6 +273,7 @@ impl<'a, 'o, 'i> parcel_selectors::parser::Parser<'i> for SelectorParser<'a, 'o,
       "first-letter" => FirstLetter,
       "details-content" => DetailsContent,
       "target-text" => TargetText,
+      "search-text" => SearchText,
       "cue" => Cue,
       "cue-region" => CueRegion,
       "selection" => Selection(VendorPrefix::None),
@@ -916,6 +917,8 @@ pub enum PseudoElement<'i> {
   DetailsContent,
   /// The [::target-text](https://drafts.csswg.org/css-pseudo-4/#selectordef-target-text)
   TargetText,
+  /// The [::search-text](https://drafts.csswg.org/css-pseudo-4/#selectordef-search-text) pseudo element.
+  SearchText,
   /// The [::selection](https://drafts.csswg.org/css-pseudo-4/#selectordef-selection) pseudo element.
   #[cfg_attr(feature = "serde", serde(with = "PrefixWrapper"))]
   Selection(VendorPrefix),
@@ -1192,6 +1195,7 @@ where
     FirstLetter => dest.write_str(":first-letter"),
     DetailsContent => dest.write_str("::details-content"),
     TargetText => dest.write_str("::target-text"),
+    SearchText => dest.write_str("::search-text"),
     HighlightFunction { name } => {
       dest.write_str("::highlight(")?;
       name.to_css(dest)?;
@@ -1974,6 +1978,7 @@ pub(crate) fn is_compatible(selectors: &[Selector], targets: Targets) -> bool {
           PseudoElement::FirstLetter => Feature::FirstLetter,
           PseudoElement::DetailsContent => Feature::DetailsContent,
           PseudoElement::TargetText => Feature::TargetText,
+          PseudoElement::SearchText => Feature::SearchText,
           PseudoElement::Selection(prefix) if *prefix == VendorPrefix::None => Feature::Selection,
           PseudoElement::Placeholder(prefix) if *prefix == VendorPrefix::None => Feature::Placeholder,
           PseudoElement::HighlightFunction { name: _ } => Feature::Highlight,


### PR DESCRIPTION
Closes #1212.

This PR adds parser/selector compatibility for `::search-text` (including `:current::search-text`) based on CSS Pseudo-4 highlight pseudos.

Spec references:
- https://drafts.csswg.org/css-pseudo-4/#highlight-pseudos
- https://drafts.csswg.org/css-pseudo-4/#selectordef-search-text

### Why
`::search-text` is spec-defined selector syntax. Tooling should parse and serialize it without emitting unknown pseudo-element warnings.

### What changed
- Add `search-text` parsing in selector pseudo-element parsing.
- Add `PseudoElement::SearchText` enum variant.
- Add serialization to `::search-text`.
- Add compatibility mapping through `Feature::SearchText`.
- Extend MDN compat ingestion with `mdn.css.selectors['search-text']`.
- Regenerate compat table.
- Add parser tests:
  - `foo::search-text`
  - `:current::search-text`

### Files changed
- `scripts/build-prefixes.js`
- `selectors/parser.rs`
- `src/compat.rs`
- `src/selector.rs`

### Related precedent
- `::target-text` support: #888 -> #930
- `::highlight()` support: #861 -> #970
- `::grammar-error` / `::spelling-error`: #1021 -> #1026

### Validation
Ran locally in this branch:

```bash
cargo test
RUSTFLAGS='-D warnings' cargo test --all-features
```

```bash
yarn build
yarn test
yarn tsc
yarn wasm:build-release
```
<img width="602" height="22" alt="lightningcss-pr-highlight" src="https://github.com/user-attachments/assets/90ba3527-4188-4d9b-bdc4-74cb892886c1" />
<img width="699" height="22" alt="lightningcss-pr-highlight2" src="https://github.com/user-attachments/assets/0215c2d5-1da9-41f1-86c6-2e3355abee1d" />



All passed in local environment after standard toolchain setup (Node 18 + Yarn 1 + rustup toolchain + wasm-opt installed).