### PR TITLE
fix: error on `composes:` references to undefined classes

### DIFF
--- a/src/bundler.rs
+++ b/src/bundler.rs
@@ -881,6 +881,7 @@ mod tests {
   use super::*;
   use crate::{
     css_modules::{self, CssModuleExports, CssModuleReference},
+    error::PrinterErrorKind,
     parser::ParserFlags,
     stylesheet::{MinifyOptions, PrinterOptions},
     targets::{Browsers, Targets},
@@ -1989,38 +1990,89 @@ mod tests {
       }
     );
 
-    let (code, exports) = bundle_css_module(
-      TestProvider {
-        map: fs! {
-          "/a.css": r#"
-          .a { composes: x from './b.css'; background: red; }
-        "#,
-          "/b.css": r#"
-          .a { background: red }
-        "#
-        },
+    // `composes: x from './b.css'` where `.x` is not defined in `./b.css` must error,
+    // not silently drop the reference. (Previously this emitted code as if the
+    // composes declaration had no effect — a silent correctness failure.)
+    let fs = TestProvider {
+      map: fs! {
+        "/a.css": r#"
+        .a { composes: x from './b.css'; background: red; }
+      "#,
+        "/b.css": r#"
+        .a { background: red }
+      "#
       },
-      "/a.css",
+    };
+    let mut bundler = Bundler::new(
+      &fs,
       None,
+      ParserOptions {
+        css_modules: Some(css_modules::Config {
+          dashed_idents: true,
+          pattern: css_modules::Pattern::parse("[hash]_[local]").unwrap(),
+          ..Default::default()
+        }),
+        ..ParserOptions::default()
+      },
     );
-    assert_eq!(
-      code,
-      indoc! { r#"
-      ._8Cs9ZG_a {
-        background: red;
-      }
+    let mut stylesheet = bundler.bundle(Path::new("/a.css")).unwrap();
+    stylesheet.minify(MinifyOptions::default()).unwrap();
+    match stylesheet.to_css(PrinterOptions::default()) {
+      Err(err) => match err.kind {
+        PrinterErrorKind::MissingComposesName { name, specifier } => {
+          assert_eq!(name, "x");
+          assert!(
+            specifier.as_deref().map_or(false, |s| s.ends_with("b.css")),
+            "expected specifier to reference b.css, got {:?}",
+            specifier
+          );
+        }
+        kind => panic!("expected MissingComposesName, got {:?}", kind),
+      },
+      Ok(_) => panic!("expected MissingComposesName error"),
+    }
 
-      ._6lixEq_a {
-        background: red;
-      }
-    "#}
+    // Same check, reachable without a pre-existing `.a` in `/b.css` to guard
+    // against regressions where the validator only fires when other rules
+    // happen to be printed.
+    let fs = TestProvider {
+      map: fs! {
+        "/a.css": r#"
+        .a { composes: x from './b.css'; color: red; }
+      "#,
+        "/b.css": r#"
+        .y { background: green }
+      "#
+      },
+    };
+    let mut bundler = Bundler::new(
+      &fs,
+      None,
+      ParserOptions {
+        css_modules: Some(css_modules::Config {
+          dashed_idents: true,
+          pattern: css_modules::Pattern::parse("[hash]_[local]").unwrap(),
+          ..Default::default()
+        }),
+        ..ParserOptions::default()
+      },
     );
-    assert_eq!(
-      flatten_exports(exports),
-      map! {
-        "a" => "_6lixEq_a"
-      }
-    );
+    let mut stylesheet = bundler.bundle(Path::new("/a.css")).unwrap();
+    stylesheet.minify(MinifyOptions::default()).unwrap();
+    match stylesheet.to_css(PrinterOptions::default()) {
+      Err(err) => match err.kind {
+        PrinterErrorKind::MissingComposesName { name, specifier } => {
+          assert_eq!(name, "x");
+          assert!(
+            specifier.as_deref().map_or(false, |s| s.ends_with("b.css")),
+            "expected specifier to reference b.css, got {:?}",
+            specifier
+          );
+        }
+        kind => panic!("expected MissingComposesName, got {:?}", kind),
+      },
+      Ok(_) => panic!("expected MissingComposesName error"),
+    }
 
     let (code, exports) = bundle_css_module(
       TestProvider {

--- a/src/css_modules.rs
+++ b/src/css_modules.rs
@@ -8,7 +8,8 @@
 //! style sheet is printed, hashes will be added to any declared names, and references to those names
 //! will be updated accordingly. A map of the original names to compiled (hashed) names will be returned.
 
-use crate::error::PrinterErrorKind;
+use crate::dependencies::Location;
+use crate::error::{Error, ErrorLocation, PrinterError, PrinterErrorKind};
 use crate::properties::css_modules::{Composes, Specifier};
 use crate::selector::SelectorList;
 use data_encoding::{Encoding, Specification};
@@ -274,6 +275,28 @@ pub(crate) struct CssModule<'a, 'b, 'c> {
   pub content_hashes: &'a Option<Vec<String>>,
   pub exports_by_source_index: Vec<CssModuleExports>,
   pub references: &'a mut HashMap<String, CssModuleReference>,
+  /// Deferred `composes` references to verify once all rules have been printed.
+  /// `composes` is resolved during printing, but same-file references can be
+  /// forward references to classes that have not been emitted yet — so we
+  /// record them here and validate after the full stylesheet has been processed.
+  pub pending_composes: Vec<PendingCompose>,
+}
+
+/// A pending `composes` reference that must be validated against `exports_by_source_index`
+/// after the full stylesheet has been printed.
+pub(crate) struct PendingCompose {
+  /// The referenced class name (as written in the source).
+  pub name: String,
+  /// The source index of the file containing the `composes` declaration.
+  pub source_index: u32,
+  /// The source index to look up the reference in. For same-file references, this equals
+  /// `source_index`. For cross-file `SourceIndex` references (resolved by the bundler),
+  /// this is the dependency's source index.
+  pub target_source_index: u32,
+  /// Dependency specifier for error reporting, when available. `None` for same-file references.
+  pub specifier: Option<String>,
+  /// The source location of the `composes` property, used for error reporting.
+  pub loc: Location,
 }
 
 impl<'a, 'b, 'c> CssModule<'a, 'b, 'c> {
@@ -309,6 +332,7 @@ impl<'a, 'b, 'c> CssModule<'a, 'b, 'c> {
       hashes,
       content_hashes,
       references,
+      pending_composes: Vec::new(),
     }
   }
 
@@ -472,24 +496,49 @@ impl<'a, 'b, 'c> CssModule<'a, 'b, 'c> {
           parcel_selectors::parser::Component::Class(ref id) => {
             for name in &composes.names {
               let reference = match &composes.from {
-                None => CssModuleReference::Local {
-                  name: self
-                    .config
-                    .pattern
-                    .write_to_string(
-                      String::new(),
-                      &self.hashes[source_index as usize],
-                      &self.sources[source_index as usize],
-                      name.0.as_ref(),
-                      if let Some(content_hashes) = &self.content_hashes {
-                        &content_hashes[source_index as usize]
-                      } else {
-                        ""
-                      },
-                    )
-                    .unwrap(),
-                },
+                None => {
+                  // Same-file reference. Record for deferred validation so forward
+                  // references (where the target class is declared later in the file)
+                  // still work, but typo'd or missing references are reported once
+                  // the full stylesheet has been processed.
+                  self.pending_composes.push(PendingCompose {
+                    name: name.0.as_ref().to_owned(),
+                    source_index,
+                    target_source_index: source_index,
+                    specifier: None,
+                    loc: composes.loc,
+                  });
+
+                  CssModuleReference::Local {
+                    name: self
+                      .config
+                      .pattern
+                      .write_to_string(
+                        String::new(),
+                        &self.hashes[source_index as usize],
+                        &self.sources[source_index as usize],
+                        name.0.as_ref(),
+                        if let Some(content_hashes) = &self.content_hashes {
+                          &content_hashes[source_index as usize]
+                        } else {
+                          ""
+                        },
+                      )
+                      .unwrap(),
+                  }
+                }
                 Some(Specifier::SourceIndex(dep_source_index)) => {
+                  // Cross-file reference resolved by the bundler. Like the same-file
+                  // branch, the target file may not have been processed yet, so we
+                  // defer validation until after printing.
+                  self.pending_composes.push(PendingCompose {
+                    name: name.0.as_ref().to_owned(),
+                    source_index,
+                    target_source_index: *dep_source_index,
+                    specifier: Some(self.sources[*dep_source_index as usize].to_string_lossy().into_owned()),
+                    loc: composes.loc,
+                  });
+
                   if let Some(entry) =
                     self.exports_by_source_index[*dep_source_index as usize].get(&name.0.as_ref().to_owned())
                   {
@@ -530,6 +579,32 @@ impl<'a, 'b, 'c> CssModule<'a, 'b, 'c> {
       return Err(PrinterErrorKind::InvalidComposesSelector);
     }
 
+    Ok(())
+  }
+
+  /// Validate that all pending `composes` references resolve to classes that exist
+  /// in the corresponding CSS modules exports. Called after the full stylesheet has
+  /// been printed.
+  pub fn validate_composes(&self) -> Result<(), PrinterError> {
+    for pending in &self.pending_composes {
+      if !self.exports_by_source_index[pending.target_source_index as usize].contains_key(&pending.name) {
+        let filename = self.sources[pending.source_index as usize]
+          .to_string_lossy()
+          .into_owned();
+        return Err(Error {
+          kind: PrinterErrorKind::MissingComposesName {
+            name: pending.name.clone(),
+            specifier: pending.specifier.clone(),
+          },
+          loc: Some(ErrorLocation {
+            filename,
+            // Match Printer::error's line adjustment (`loc.line - 1`).
+            line: pending.loc.line.saturating_sub(1),
+            column: pending.loc.column,
+          }),
+        });
+      }
+    }
     Ok(())
   }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -417,6 +417,13 @@ pub enum PrinterErrorKind {
   InvalidComposesSelector,
   /// The CSS modules pattern must end with `[local]` for use in CSS grid.
   InvalidCssModulesPatternInGrid,
+  /// A CSS modules `composes` property references a class name that is not defined.
+  MissingComposesName {
+    /// The referenced class name.
+    name: String,
+    /// The referenced specifier (file path), or `None` for same-file references.
+    specifier: Option<String>,
+  },
 }
 
 impl From<fmt::Error> for PrinterError {
@@ -437,6 +444,16 @@ impl fmt::Display for PrinterErrorKind {
       InvalidComposesNesting => write!(f, "The `composes` property cannot be used within nested rules"),
       InvalidComposesSelector => write!(f, "The `composes` property cannot be used with a simple class selector"),
       InvalidCssModulesPatternInGrid => write!(f, "The CSS modules `pattern` config must end with `[local]` for use in CSS grid line names."),
+      MissingComposesName { name, specifier: Some(specifier) } => write!(
+        f,
+        "The `composes` property references a class name \"{}\" that is not defined in \"{}\"",
+        name, specifier
+      ),
+      MissingComposesName { name, specifier: None } => write!(
+        f,
+        "The `composes` property references a class name \"{}\" that is not defined",
+        name
+      ),
     }
   }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26320,6 +26320,63 @@ mod tests {
       unreachable!()
     }
 
+    // `composes:` referencing a same-file class that does not exist must error,
+    // not silently emit a dangling reference. Regression test for a silent
+    // correctness failure where typos in `composes:` produced hashed class
+    // names that had no corresponding CSS rule.
+    let stylesheet = StyleSheet::parse(
+      r#"
+        .historyChevron {
+          color: blue;
+        }
+
+        .historyChevronOpen {
+          composes: historychevron;
+          transform: rotate(180deg);
+        }
+      "#,
+      ParserOptions {
+        css_modules: Some(Default::default()),
+        ..ParserOptions::default()
+      },
+    )
+    .unwrap();
+    match stylesheet.to_css(PrinterOptions::default()) {
+      Err(err) => assert_eq!(
+        err.kind,
+        PrinterErrorKind::MissingComposesName {
+          name: "historychevron".into(),
+          specifier: None,
+        }
+      ),
+      Ok(_) => unreachable!("expected MissingComposesName error"),
+    }
+
+    // Fully missing same-file class (no case mismatch, just a typo).
+    let stylesheet = StyleSheet::parse(
+      r#"
+        .foo {
+          composes: bar;
+          color: red;
+        }
+      "#,
+      ParserOptions {
+        css_modules: Some(Default::default()),
+        ..ParserOptions::default()
+      },
+    )
+    .unwrap();
+    match stylesheet.to_css(PrinterOptions::default()) {
+      Err(err) => assert_eq!(
+        err.kind,
+        PrinterErrorKind::MissingComposesName {
+          name: "bar".into(),
+          specifier: None,
+        }
+      ),
+      Ok(_) => unreachable!("expected MissingComposesName error"),
+    }
+
     css_modules_test(
       r#"
       @property --foo {

--- a/src/stylesheet.rs
+++ b/src/stylesheet.rs
@@ -304,6 +304,10 @@ where
       self.rules.to_css(&mut printer)?;
       printer.newline()?;
 
+      if let Some(css_module) = &printer.css_module {
+        css_module.validate_composes()?;
+      }
+
       Ok(ToCssResult {
         dependencies: printer.dependencies,
         exports: Some(std::mem::take(


### PR DESCRIPTION
Fixes https://github.com/parcel-bundler/lightningcss/issues/1215.

`composes:` used to silently accept references to classes that don't exist. The exports pointed to a hashed name
with no matching CSS rule, so styles broke at runtime with no build signal. Now it errors, matching
postcss-modules-scope.

New `PrinterErrorKind::MissingComposesName { name, specifier }`. Validation is deferred until after all rules are
printed so forward references (`.a { composes: b }` before `.b`) still work. Covers both same-file and bundler
resolved cross-file (`Specifier::SourceIndex`) references. Unresolved `from "./file.css"` stays out of scope since
lightningcss doesn't read the other file itself.

Tests cover the same-file case mismatch repro, same-file missing class, and cross-file missing via the bundler.

Breaking: projects relying on the old silent drop will now fail to build.
