### PR TITLE
Add prebuilt binaries for ppc64le and s390x

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -174,6 +174,61 @@ jobs:
             *.node
             lightningcss
 
+  build-cross-ppc64le-s390x:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: powerpc64le-unknown-linux-gnu
+            strip: powerpc64le-linux-gnu-strip
+            setup: |
+              sudo apt update
+              sudo apt install -y gcc-powerpc64le-linux-gnu libc6-dev-ppc64el-cross
+          - target: s390x-unknown-linux-gnu
+            strip: s390x-linux-gnu-strip
+            setup: |
+              sudo apt update
+              sudo apt install -y gcc-s390x-linux-gnu libc6-dev-s390x-cross
+
+    name: build-${{ matrix.target }}
+    runs-on: ubuntu-latest
+    env:
+      CARGO_TARGET_POWERPC64LE_UNKNOWN_LINUX_GNU_LINKER: powerpc64le-linux-gnu-gcc
+      CARGO_TARGET_S390X_UNKNOWN_LINUX_GNU_LINKER: s390x-linux-gnu-gcc
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install Node.JS
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Setup cross compile toolchain
+        run: ${{ matrix.setup }}
+
+      - name: Setup rust target
+        run: rustup target add ${{ matrix.target }}
+
+      - uses: bahmutov/npm-install@v1.8.32
+      - name: Build release
+        run: yarn build-release
+        env:
+          RUST_TARGET: ${{ matrix.target }}
+      - name: Build CLI
+        run: |
+          cargo build --release --features cli --target ${{ matrix.target }}
+          mv target/${{ matrix.target }}/release/lightningcss lightningcss
+      - name: Strip debug symbols # https://github.com/rust-lang/rust/issues/46034
+        run: ${{ matrix.strip }} *.node lightningcss
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: bindings-${{ matrix.target }}
+          path: |
+            *.node
+            lightningcss
+
   build-freebsd:
     runs-on: ubuntu-latest
     steps:
@@ -257,6 +312,7 @@ jobs:
     needs:
       - build
       - build-linux
+      - build-cross-ppc64le-s390x
       - build-apple-silicon
       - build-freebsd
       - build-wasm

--- a/scripts/build-npm.js
+++ b/scripts/build-npm.js
@@ -41,6 +41,14 @@ const triples = [
   },
   {
     name: 'aarch64-linux-android'
+  },
+  {
+    name: 'powerpc64le-unknown-linux-gnu',
+    libc: 'glibc',
+  },
+  {
+    name: 's390x-unknown-linux-gnu',
+    libc: 'glibc',
   }
 ];
 const cpuToNodeArch = {
@@ -48,6 +56,7 @@ const cpuToNodeArch = {
   aarch64: 'arm64',
   i686: 'ia32',
   armv7: 'arm',
+  powerpc64le: 'ppc64',
 };
 const sysToNodePlatform = {
   linux: 'linux',


### PR DESCRIPTION
GitHub Actions doesn't have ppc64le or s390x runners, so this cross-compiles from x86_64 using the GNU cross toolchains. The linker env vars are set at the job level so both the node bindings build and the CLI build pick them up.

On the npm side, the two new triples are added to build-npm.js (with a powerpc64le → ppc64 arch mapping for Node.js). node/index.js already handles these dynamically, so no changes needed there.

[ppc64 (ppc64le) github build](https://github.com/eelgaev/lightningcss/actions/runs/24375300000/job/71187466385)
[s390x github build](https://github.com/eelgaev/lightningcss/actions/runs/24375300000/job/71187466347)