### PR TITLE
docs: clarify API availability in the WASM build

### DIFF
--- a/website/pages/docs.md
+++ b/website/pages/docs.md
@@ -80,7 +80,7 @@ let {code, map} = transform({
 console.log(new TextDecoder().decode(code));
 ```
 
-Note that the `bundle` and visitor APIs are not currently available in the WASM build.
+The `bundle` and `bundleAsync` APIs are also available in the WASM build. In browsers and Deno, bundling requires a custom `resolver` to load imported files. In Node, this is handled automatically.
 
 ## With webpack
 


### PR DESCRIPTION
Visitor APIs are supported in https://github.com/parcel-bundler/lightningcss/pull/373
Bundle APIs are supported in https://github.com/parcel-bundler/lightningcss/pull/583

The only caveat is that the Deno/browser version requires a custom resolver.

I skipped the Visitor APIs in the updated paragraph since there don't seem to be any caveats worth mentioning.