### PR TITLE
add known_pseudo_classes to the codebase to prevent unnecessary invalidations on :global and :local

### DIFF
--- a/c/src/lib.rs
+++ b/c/src/lib.rs
@@ -187,6 +187,7 @@ impl Into<MinifyOptions> for TransformOptions {
         Default::default()
       },
       unused_symbols,
+      known_pseudo_classes: HashSet::new(),
     }
   }
 }
@@ -289,6 +290,7 @@ pub extern "C" fn lightningcss_stylesheet_parse(
     error_recovery: options.error_recovery,
     source_index: 0,
     warnings: Some(warnings.clone()),
+    known_pseudo_classes: HashSet::new(),
   };
 
   let stylesheet = unwrap!(StyleSheet::parse(code, opts), error, std::ptr::null_mut());

--- a/napi/src/lib.rs
+++ b/napi/src/lib.rs
@@ -581,6 +581,7 @@ struct Config {
   pub analyze_dependencies: Option<AnalyzeDependenciesOption>,
   pub pseudo_classes: Option<OwnedPseudoClasses>,
   pub unused_symbols: Option<HashSet<String>>,
+  pub known_pseudo_classes: Option<Vec<String>>,
   pub error_recovery: Option<bool>,
   pub custom_at_rules: Option<HashMap<String, CustomAtRuleConfig>>,
 }
@@ -636,6 +637,7 @@ struct BundleConfig {
   pub analyze_dependencies: Option<AnalyzeDependenciesOption>,
   pub pseudo_classes: Option<OwnedPseudoClasses>,
   pub unused_symbols: Option<HashSet<String>>,
+  pub known_pseudo_classes: Option<Vec<String>>,
   pub error_recovery: Option<bool>,
   pub custom_at_rules: Option<HashMap<String, CustomAtRuleConfig>>,
 }
@@ -704,6 +706,12 @@ fn compile<'i>(
       matches!(non_standard, Some(v) if v.deep_selector_combinator),
     );
 
+    let known_pseudo_classes: HashSet<String> = config
+      .known_pseudo_classes
+      .as_ref()
+      .map(|v| v.iter().cloned().collect())
+      .unwrap_or_default();
+
     let mut stylesheet = StyleSheet::parse_with(
       &code,
       ParserOptions {
@@ -736,6 +744,7 @@ fn compile<'i>(
         source_index: 0,
         error_recovery: config.error_recovery.unwrap_or_default(),
         warnings: warnings.clone(),
+        known_pseudo_classes: known_pseudo_classes.clone(),
       },
       &mut CustomAtRuleParser {
         configs: config.custom_at_rules.clone().unwrap_or_default(),
@@ -756,6 +765,7 @@ fn compile<'i>(
     stylesheet.minify(MinifyOptions {
       targets,
       unused_symbols: config.unused_symbols.clone().unwrap_or_default(),
+      known_pseudo_classes,
     })?;
 
     stylesheet.to_css(PrinterOptions {
@@ -839,6 +849,12 @@ fn compile_bundle<
       matches!(non_standard, Some(v) if v.deep_selector_combinator),
     );
 
+    let known_pseudo_classes: HashSet<String> = config
+      .known_pseudo_classes
+      .as_ref()
+      .map(|v| v.iter().cloned().collect())
+      .unwrap_or_default();
+
     let parser_options = ParserOptions {
       flags,
       css_modules: if let Some(css_modules) = &config.css_modules {
@@ -869,6 +885,7 @@ fn compile_bundle<
       warnings: warnings.clone(),
       filename: String::new(),
       source_index: 0,
+      known_pseudo_classes: known_pseudo_classes.clone(),
     };
 
     let mut at_rule_parser = CustomAtRuleParser {
@@ -892,6 +909,7 @@ fn compile_bundle<
     stylesheet.minify(MinifyOptions {
       targets,
       unused_symbols: config.unused_symbols.clone().unwrap_or_default(),
+      known_pseudo_classes,
     })?;
 
     stylesheet.to_css(PrinterOptions {

--- a/node/index.d.ts
+++ b/node/index.d.ts
@@ -52,6 +52,13 @@ export interface TransformOptions<C extends CustomAtRules> {
    */
   unusedSymbols?: string[],
   /**
+   * A list of pseudo-class names (without the leading `:`) that should be treated as compatible
+   * with all target browsers. This prevents unknown pseudo-classes (e.g. `global`, `local`)
+   * from causing selectors to be wrapped in `:is()` during minification, and suppresses
+   * unknown pseudo-class warnings during parsing.
+   */
+  knownPseudoClasses?: string[],
+  /**
    * Whether to ignore invalid rules and declarations rather than erroring.
    * When enabled, warnings are returned, and the invalid rule or declaration is
    * omitted from the output code.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,7 +69,7 @@ mod tests {
   use cssparser::SourceLocation;
   use indoc::indoc;
   use pretty_assertions::assert_eq;
-  use std::collections::HashMap;
+  use std::collections::{HashMap, HashSet};
   use std::sync::{Arc, RwLock};
 
   #[track_caller]
@@ -7962,6 +7962,70 @@ mod tests {
     "#,
       ".foo{font-family:SFMono-Regular,Menlo,Monaco,Consolas,Liberation Mono,Courier New,monospace!important}",
     );
+  }
+
+  #[test]
+  fn test_known_pseudo_classes() {
+    // Without known_pseudo_classes, multiple selectors containing unknown pseudo-classes
+    // get wrapped in :is() during minification when targeting browsers.
+    let targets = Targets {
+      browsers: Some(Browsers {
+        chrome: Some(95 << 16),
+        ..Browsers::default()
+      }),
+      ..Targets::default()
+    };
+
+    // Baseline: unknown pseudo-classes cause :is() wrapping with multiple selectors.
+    let source = ":global(.foo) .bar, :global(.baz) .bar { color: red }";
+    let mut stylesheet = StyleSheet::parse(source, ParserOptions::default()).unwrap();
+    stylesheet.minify(MinifyOptions {
+      targets,
+      ..MinifyOptions::default()
+    }).unwrap();
+    let res = stylesheet.to_css(PrinterOptions {
+      minify: true,
+      targets,
+      ..PrinterOptions::default()
+    }).unwrap();
+    assert_eq!(res.code, ":is(:global(.foo) .bar,:global(.baz) .bar){color:red}");
+
+    // With known_pseudo_classes: :is() wrapping is prevented.
+    let known = HashSet::from(["global".to_string()]);
+    let mut stylesheet = StyleSheet::parse(source, ParserOptions {
+      known_pseudo_classes: known.clone(),
+      ..ParserOptions::default()
+    }).unwrap();
+    stylesheet.minify(MinifyOptions {
+      targets,
+      known_pseudo_classes: known,
+      ..MinifyOptions::default()
+    }).unwrap();
+    let res = stylesheet.to_css(PrinterOptions {
+      minify: true,
+      targets,
+      ..PrinterOptions::default()
+    }).unwrap();
+    assert_eq!(res.code, ":global(.foo) .bar,:global(.baz) .bar{color:red}");
+
+    // Non-functional pseudo-class variant.
+    let source_nonfunc = ":global .foo, :global .bar { color: red }";
+    let known = HashSet::from(["global".to_string()]);
+    let mut stylesheet = StyleSheet::parse(source_nonfunc, ParserOptions {
+      known_pseudo_classes: known.clone(),
+      ..ParserOptions::default()
+    }).unwrap();
+    stylesheet.minify(MinifyOptions {
+      targets,
+      known_pseudo_classes: known,
+      ..MinifyOptions::default()
+    }).unwrap();
+    let res = stylesheet.to_css(PrinterOptions {
+      minify: true,
+      targets,
+      ..PrinterOptions::default()
+    }).unwrap();
+    assert_eq!(res.code, ":global .foo,:global .bar{color:red}");
   }
 
   #[test]

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -42,6 +42,7 @@ use crate::visitor::{Visit, VisitTypes, Visitor};
 use bitflags::bitflags;
 use cssparser::*;
 use parcel_selectors::parser::{NestingRequirement, ParseErrorRecovery};
+use std::collections::HashSet;
 use std::sync::{Arc, RwLock};
 
 bitflags! {
@@ -73,6 +74,9 @@ pub struct ParserOptions<'o, 'i> {
   pub warnings: Option<Arc<RwLock<Vec<Error<ParserError<'i>>>>>>,
   /// Feature flags to enable.
   pub flags: ParserFlags,
+  /// A set of pseudo-class names (without the leading `:`) that are known to the caller.
+  /// These will not emit `UnsupportedPseudoClass` warnings during parsing.
+  pub known_pseudo_classes: HashSet<String>,
 }
 
 impl<'o, 'i> ParserOptions<'o, 'i> {

--- a/src/rules/mod.rs
+++ b/src/rules/mod.rs
@@ -525,6 +525,7 @@ pub(crate) struct MinifyContext<'a, 'i> {
   pub important_handler: &'a mut DeclarationHandler<'i>,
   pub handler_context: PropertyHandlerContext<'i, 'a>,
   pub unused_symbols: &'a HashSet<String>,
+  pub known_pseudo_classes: &'a HashSet<String>,
   pub custom_media: Option<HashMap<CowArcStr<'i>, CustomMediaRule<'i>>>,
   pub css_modules: bool,
   pub pure_css_modules: bool,
@@ -673,7 +674,7 @@ impl<'i, T: Clone> CssRuleList<'i, T> {
           // we need to either wrap in :is() or split them into multiple rules.
           let incompatible = if style.selectors.0.len() > 1
             && context.targets.current.should_compile_selectors()
-            && !style.is_compatible(context.targets.current)
+            && !style.is_compatible(context.targets.current, context.known_pseudo_classes)
           {
             // The :is() selector accepts a forgiving selector list, so use that if possible.
             // Note that :is() does not allow pseudo elements, so we need to check for that.
@@ -698,7 +699,7 @@ impl<'i, T: Clone> CssRuleList<'i, T> {
                 .cloned()
                 .partition::<SmallVec<[Selector; 1]>, _>(|selector| {
                   let list = SelectorList::new(smallvec![selector.clone()]);
-                  is_compatible(&list.0, context.targets.current)
+                  is_compatible(&list.0, context.targets.current, context.known_pseudo_classes)
                 });
               style.selectors = SelectorList::new(compatible);
               incompatible
@@ -965,8 +966,8 @@ fn merge_style_rules<'i, T>(
 ) -> bool {
   // Merge declarations if the selectors are equivalent, and both are compatible with all targets.
   if style.selectors == last_style_rule.selectors
-    && style.is_compatible(context.targets.current)
-    && last_style_rule.is_compatible(context.targets.current)
+    && style.is_compatible(context.targets.current, context.known_pseudo_classes)
+    && last_style_rule.is_compatible(context.targets.current, context.known_pseudo_classes)
     && style.rules.0.is_empty()
     && last_style_rule.rules.0.is_empty()
     && (!context.css_modules || style.loc.source_index == last_style_rule.loc.source_index)
@@ -1004,7 +1005,7 @@ fn merge_style_rules<'i, T>(
     }
 
     // Append the selectors to the last rule if the declarations are the same, and all selectors are compatible.
-    if style.is_compatible(context.targets.current) && last_style_rule.is_compatible(context.targets.current) {
+    if style.is_compatible(context.targets.current, context.known_pseudo_classes) && last_style_rule.is_compatible(context.targets.current, context.known_pseudo_classes) {
       last_style_rule.selectors.0.extend(style.selectors.0.drain(..));
       if style.vendor_prefix.contains(VendorPrefix::None) && context.targets.current.should_compile_selectors() {
         last_style_rule.vendor_prefix = style.vendor_prefix;

--- a/src/rules/style.rs
+++ b/src/rules/style.rs
@@ -1,5 +1,6 @@
 //! Style rules.
 
+use std::collections::HashSet;
 use std::hash::{Hash, Hasher};
 use std::ops::Range;
 
@@ -113,8 +114,8 @@ impl<'i, T> StyleRule<'i, T> {
 
   /// Returns whether the selectors in the rule are compatible
   /// with all of the given browser targets.
-  pub fn is_compatible(&self, targets: Targets) -> bool {
-    is_compatible(&self.selectors.0, targets)
+  pub fn is_compatible(&self, targets: Targets, known_pseudo_classes: &HashSet<String>) -> bool {
+    is_compatible(&self.selectors.0, targets, known_pseudo_classes)
   }
 
   /// Returns the line and column range of the property key and value at the given index in this style rule.

--- a/src/selector.rs
+++ b/src/selector.rs
@@ -199,7 +199,7 @@ impl<'a, 'o, 'i> parcel_selectors::parser::Parser<'i> for SelectorParser<'a, 'o,
       },
 
       _ => {
-        if !name.starts_with('-') {
+        if !name.starts_with('-') && !self.options.known_pseudo_classes.contains(name.as_ref()) {
           self.options.warn(loc.new_custom_error(SelectorParseErrorKind::UnsupportedPseudoClass(name.clone())));
         }
         Custom { name: name.into() }
@@ -237,7 +237,7 @@ impl<'a, 'o, 'i> parcel_selectors::parser::Parser<'i> for SelectorParser<'a, 'o,
       "local" if self.options.css_modules.is_some() => Local { selector: Box::new(Selector::parse(self, parser)?) },
       "global" if self.options.css_modules.is_some() => Global { selector: Box::new(Selector::parse(self, parser)?) },
       _ => {
-        if !name.starts_with('-') {
+        if !name.starts_with('-') && !self.options.known_pseudo_classes.contains(name.as_ref()) {
           self.options.warn(parser.new_custom_error(SelectorParseErrorKind::UnsupportedPseudoClass(name.clone())));
         }
         let mut args = Vec::new();
@@ -1809,7 +1809,7 @@ where
   Ok(())
 }
 
-pub(crate) fn is_compatible(selectors: &[Selector], targets: Targets) -> bool {
+pub(crate) fn is_compatible(selectors: &[Selector], targets: Targets, known_pseudo_classes: &HashSet<String>) -> bool {
   for selector in selectors {
     let iter = selector.iter_raw_match_order();
     for component in iter {
@@ -1867,7 +1867,7 @@ pub(crate) fn is_compatible(selectors: &[Selector], targets: Targets) -> bool {
         Component::Empty | Component::Root => Feature::Selectors3,
         Component::Negation(selectors) => {
           // :not() selector list is not forgiving.
-          if !targets.is_compatible(Feature::Selectors3) || !is_compatible(&*selectors, targets) {
+          if !targets.is_compatible(Feature::Selectors3) || !is_compatible(&*selectors, targets, known_pseudo_classes) {
             return false;
           }
           continue;
@@ -1879,7 +1879,7 @@ pub(crate) fn is_compatible(selectors: &[Selector], targets: Targets) -> bool {
           _ => Feature::Selectors3,
         },
         Component::NthOf(n) => {
-          if !targets.is_compatible(Feature::NthChildOf) || !is_compatible(n.selectors(), targets) {
+          if !targets.is_compatible(Feature::NthChildOf) || !is_compatible(n.selectors(), targets, known_pseudo_classes) {
             return false;
           }
           continue;
@@ -1888,7 +1888,7 @@ pub(crate) fn is_compatible(selectors: &[Selector], targets: Targets) -> bool {
         // These support forgiving selector lists, so no need to check nested selectors.
         Component::Is(selectors) => {
           // ... except if we are going to unwrap them.
-          if should_unwrap_is(selectors) && is_compatible(selectors, targets) {
+          if should_unwrap_is(selectors) && is_compatible(selectors, targets, known_pseudo_classes) {
             continue;
           }
 
@@ -1897,7 +1897,7 @@ pub(crate) fn is_compatible(selectors: &[Selector], targets: Targets) -> bool {
         Component::Where(_) | Component::Nesting => Feature::IsSelector,
         Component::Any(..) => return false,
         Component::Has(selectors) => {
-          if !targets.is_compatible(Feature::HasSelector) || !is_compatible(&*selectors, targets) {
+          if !targets.is_compatible(Feature::HasSelector) || !is_compatible(&*selectors, targets, known_pseudo_classes) {
             return false;
           }
           continue;
@@ -1964,6 +1964,8 @@ pub(crate) fn is_compatible(selectors: &[Selector], targets: Targets) -> bool {
             | PseudoClass::ActiveViewTransition
             | PseudoClass::ActiveViewTransitionType { .. } => return false,
 
+            PseudoClass::Custom { name } if known_pseudo_classes.contains(name.as_ref()) => continue,
+            PseudoClass::CustomFunction { name, .. } if known_pseudo_classes.contains(name.as_ref()) => continue,
             PseudoClass::Custom { .. } | _ => return false,
           }
         }

--- a/src/stylesheet.rs
+++ b/src/stylesheet.rs
@@ -99,6 +99,11 @@ pub struct MinifyOptions {
   /// A list of known unused symbols, including CSS class names,
   /// ids, and `@keyframe` names. The declarations of these will be removed.
   pub unused_symbols: HashSet<String>,
+  /// A set of pseudo-class names (without the leading `:`) that should be treated
+  /// as compatible with all target browsers. This prevents unknown pseudo-classes
+  /// (e.g. `global`, `local`) from causing selectors to be wrapped in `:is()`
+  /// during minification.
+  pub known_pseudo_classes: HashSet<String>,
 }
 
 /// A result returned from `to_css`, including the serialize CSS
@@ -252,6 +257,7 @@ where
       important_handler: &mut important_handler,
       handler_context: context,
       unused_symbols: &options.unused_symbols,
+      known_pseudo_classes: &options.known_pseudo_classes,
       custom_media,
       css_modules: self.options.css_modules.is_some(),
       pure_css_modules: self.options.css_modules.as_ref().map(|c| c.pure).unwrap_or_default(),

--- a/website/pages/transpilation.md
+++ b/website/pages/transpilation.md
@@ -657,3 +657,20 @@ let { code, map } = transform({
 Currently the following features are supported:
 
 * `deepSelectorCombinator` – enables parsing the Vue/Angular `>>>` and `/deep/` selector combinators.
+
+## Known pseudo classes
+
+When Lightning CSS encounters a pseudo-class it doesn't recognize, it treats the selector as incompatible with your browser targets. During minification, this can cause selectors to be wrapped in `:is()`, which may lead to unintended style invalidations depending on your setup.
+
+This commonly happens with pseudo-classes like `:global()` and `:local()` from CSS modules tooling, but it applies to any custom pseudo-class that Lightning CSS doesn't have built-in support for.
+
+The `knownPseudoClasses` option lets you tell Lightning CSS about these pseudo-classes so it leaves them alone. Names should be provided without the leading `:`.
+
+```js
+let { code, map } = transform({
+  // ...
+  knownPseudoClasses: ['global', 'local']
+});
+```
+
+This prevents the `:is()` wrapping and also suppresses the "unsupported pseudo-class" warnings that would otherwise be emitted during parsing.


### PR DESCRIPTION
## Why?

At Slack we use lightningcss for our CSS minification, but not for CSS modules. We have noticed lightningcss will wrap unknown pseudos with an `:is()` selector which causes unnecessary invalidations in our app because CSS module processing comes later in our toolchain. 

## What?

This pull request adds optional support for unknown pseudos to bypass lightningcss' modifications of selectors like `:global` and `:local` so that we can avoid the unnecessary CSS invalidation those additions cause.

## Notes

This is my first time contributing to this project and one of my first times working with Rust. I'm happy to field any suggestions or feedback you might have.