### PR TITLE
Print unknown at-rules in the same location

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24230,6 +24230,58 @@ mod tests {
     nesting_test(
       r#"
         .foo {
+          @apply --mixin;
+          @apply --mixin-no-args();
+          @apply --mixin-args(1, 2);
+          @apply --mixin-with-empty-body {};
+          @apply --mixin-with-body {
+            color: red;
+          }
+          .bar {
+            @apply --nested;
+          }
+        }
+      "#,
+      indoc! {r#"
+        .foo {
+          @apply --mixin;
+          @apply --mixin-no-args();
+          @apply --mixin-args(1, 2);
+          @apply --mixin-with-empty-body {
+            
+          }
+          @apply --mixin-with-body {
+            color: red;
+          }
+        }
+
+        .foo .bar {
+          @apply --nested;
+        }
+      "#},
+    );
+
+    minify_test(
+      r#"
+        .foo {
+          @apply --mixin;
+          @apply --mixin-no-args();
+          @apply --mixin-args(1,2);
+          @apply --mixin-with-empty-body {};
+          @apply --mixin-with-body {
+            color: red;
+          };
+          .bar {
+            @apply --nested;
+          }
+        }
+      "#,
+      ".foo{@apply --mixin;@apply --mixin-no-args();@apply --mixin-args(1,2);@apply --mixin-with-empty-body{}@apply --mixin-with-body{color: red;}& .bar{@apply --nested;}}",
+    );
+
+    nesting_test(
+      r#"
+        .foo {
           color: blue;
           & > .bar { color: red; }
         }

--- a/src/rules/style.rs
+++ b/src/rules/style.rs
@@ -11,7 +11,7 @@ use crate::error::ParserError;
 use crate::error::{MinifyError, PrinterError};
 use crate::parser::DefaultAtRule;
 use crate::printer::Printer;
-use crate::rules::CssRuleList;
+use crate::rules::{CssRule, CssRuleList};
 use crate::selector::{
   downlevel_selectors, get_prefix, is_compatible, is_pure_css_modules_selector, is_unused, SelectorList,
 };
@@ -246,8 +246,11 @@ impl<'a, 'i, T: ToCss> StyleRule<'i, T> {
   {
     // If supported, or there are no targets, preserve nesting. Otherwise, write nested rules after parent.
     let supports_nesting = self.rules.0.is_empty() || !should_compile!(dest.targets.current, Nesting);
+    let must_preserve_rule = |rule: &CssRule<'i, T>| matches!(rule, CssRule::Unknown(_));
+    let has_preserved_rules = !supports_nesting && self.rules.0.iter().any(must_preserve_rule);
+    let has_hoisted_rules = !supports_nesting && self.rules.0.iter().any(|rule| !must_preserve_rule(rule));
     let len = self.declarations.declarations.len() + self.declarations.important_declarations.len();
-    let has_declarations = supports_nesting || len > 0 || self.rules.0.is_empty();
+    let has_declarations = supports_nesting || len > 0 || self.rules.0.is_empty() || has_preserved_rules;
 
     if has_declarations {
       #[cfg(feature = "sourcemap")]
@@ -262,7 +265,7 @@ impl<'a, 'i, T: ToCss> StyleRule<'i, T> {
 
       self.declarations.to_css_declarations(
         dest,
-        supports_nesting && !self.rules.0.is_empty(),
+        (supports_nesting && !self.rules.0.is_empty()) || has_preserved_rules,
         &self.selectors,
         self.loc.source_index,
       )?;
@@ -270,8 +273,8 @@ impl<'a, 'i, T: ToCss> StyleRule<'i, T> {
 
     macro_rules! newline {
       () => {
-        if !dest.minify && (supports_nesting || len > 0) && !self.rules.0.is_empty() {
-          if len > 0 {
+        if !dest.minify && (supports_nesting || len > 0 || has_preserved_rules) && !self.rules.0.is_empty() {
+          if len > 0 || has_preserved_rules {
             dest.write_char('\n')?;
           }
           dest.newline()?;
@@ -289,15 +292,41 @@ impl<'a, 'i, T: ToCss> StyleRule<'i, T> {
       };
     }
 
-    // Write nested rules after the parent.
+    // Write nested rules after the parent, except unknown at-rules, which must remain in the style block.
     if supports_nesting {
       newline!();
       self.rules.to_css(dest)?;
       end!();
     } else {
+      let mut first = true;
+      for rule in self.rules.0.iter().filter(|rule| must_preserve_rule(rule)) {
+        if !dest.minify || first {
+          dest.newline()?;
+        }
+        rule.to_css(dest)?;
+        first = false;
+      }
       end!();
-      newline!();
-      dest.with_context(&self.selectors, |dest| self.rules.to_css(dest))?;
+
+      if has_hoisted_rules {
+        newline!();
+        dest.with_context(&self.selectors, |dest| {
+          let mut first = true;
+          for rule in self.rules.0.iter().filter(|rule| !must_preserve_rule(rule)) {
+            if first {
+              first = false;
+            } else {
+              if !dest.minify {
+                dest.write_char('\n')?;
+              }
+              dest.newline()?;
+            }
+            rule.to_css(dest)?;
+          }
+
+          Ok::<(), PrinterError>(())
+        })?;
+      }
     }
 
     Ok(())


### PR DESCRIPTION
This PR is an attempt in fixing #1232 where unknown at-rules were hoisted outside of its parent instead of staying in place. This PR is not adding proper support for `@apply`, but is just used as an example.

I added some tests with various syntaxes as seen in https://drafts.csswg.org/css-mixins-1/#apply-rule. I also added some nesting to make sure that works as expected.

Added some tests with the following input:
```css
.foo {
  @apply --mixin;
  @apply --mixin-no-args();
  @apply --mixin-args(1, 2);
  @apply --mixin-with-empty-body {};
  @apply --mixin-with-body {
    color: red;
  }
  .bar {
    @apply --nested;
  }
}
```

Before, this would generate:
```css
@apply --mixin;

@apply --mixin-no-args();

@apply --mixin-args(1, 2);

@apply --mixin-with-empty-body {
  
}

@apply --mixin-with-body {
  color: red;
}

@apply --nested;
```
As you can see, the `.foo` and `.bar` are even gone, because at some point they won't contain any declarations anymore and are just removed.

But with this PR, it will generate:
```css
.foo {
  @apply --mixin;
  @apply --mixin-no-args();
  @apply --mixin-args(1, 2);
  @apply --mixin-with-empty-body {
    
  }
  @apply --mixin-with-body {
    color: red;
  }
}

.foo .bar {
  @apply --nested;
}
```

Like I mentioned before, this doesn't add proper support for `@apply`, so this is just an attempt in properly printing the correct output. There is no validation related to the actual mixins that are being applied here.

Fixes: https://github.com/parcel-bundler/lightningcss/issues/1232
