### PR TITLE
Add support for @position-try at-rule

### DIFF
--- a/napi/src/transformer.rs
+++ b/napi/src/transformer.rs
@@ -315,6 +315,7 @@ impl<'i> Visitor<'i, AtRule<'i>> for JsVisitor {
             CssRule::Viewport(..) => "viewport",
             CssRule::StartingStyle(..) => "starting-style",
             CssRule::ViewTransition(..) => "view-transition",
+            CssRule::PositionTry(..) => "position-try",
             CssRule::Unknown(v) => {
               let name = v.name.as_ref();
               if let Some(visit) = rule_map.custom(stage, "unknown", name) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14621,6 +14621,39 @@ mod tests {
   }
 
   #[test]
+  fn test_position_try() {
+    minify_test(
+      r#"@position-try --outside-right-to-bottom {
+        left: anchor(left);
+        margin: 0;
+        width: auto;
+      }"#,
+      "@position-try --outside-right-to-bottom{left:anchor(left);margin:0;width:auto}",
+    );
+    test(
+      r#"@position-try --foo {
+  top: anchor(bottom);
+  left: anchor(right);
+}"#,
+      indoc! {r#"
+        @position-try --foo {
+          top: anchor(bottom);
+          left: anchor(right);
+        }
+      "#},
+    );
+    // Nested inside @supports
+    minify_test(
+      r#"@supports (anchor-name: --foo) {
+        @position-try --bar {
+          top: anchor(bottom);
+        }
+      }"#,
+      "@supports (anchor-name:--foo){@position-try --bar{top:anchor(bottom)}}",
+    );
+  }
+
+  #[test]
   fn test_font_feature_values() {
     // https://github.com/clagnut/TODS/blob/e693d52ad411507b960cf01a9734265e3efab102/tods.css#L116-L142
     minify_test(

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -8,6 +8,7 @@ use crate::rules::font_feature_values::FontFeatureValuesRule;
 use crate::rules::font_palette_values::FontPaletteValuesRule;
 use crate::rules::layer::{LayerBlockRule, LayerStatementRule};
 use crate::rules::nesting::NestedDeclarationsRule;
+use crate::rules::position_try::PositionTryRule;
 use crate::rules::property::PropertyRule;
 use crate::rules::scope::ScopeRule;
 use crate::rules::starting_style::StartingStyleRule;
@@ -212,6 +213,8 @@ pub enum AtRulePrelude<'i, T> {
   Layer(Vec<LayerName<'i>>),
   /// An @property prelude.
   Property(DashedIdent<'i>),
+  /// An @position-try prelude.
+  PositionTry(DashedIdent<'i>),
   /// A @container prelude.
   /// Spec: https://drafts.csswg.org/css-conditional-5/#container-rule
   /// @container [ <container-name>? <container-query>? ]!
@@ -254,6 +257,7 @@ impl<'i, T> AtRulePrelude<'i, T> {
       | Self::Keyframes(..)
       | Self::Page(..)
       | Self::Property(..)
+      | Self::PositionTry(..)
       | Self::Import(..)
       | Self::CustomMedia(..)
       | Self::Viewport(..)
@@ -708,6 +712,11 @@ impl<'a, 'o, 'b, 'i, T: crate::traits::AtRuleParser<'i>> AtRuleParser<'i> for Ne
         return Ok(AtRulePrelude::Property(name))
       },
 
+      "position-try" => {
+        let name = DashedIdent::parse(input)?;
+        return Ok(AtRulePrelude::PositionTry(name))
+      },
+
       _ => parse_custom_at_rule_prelude(&name, input, self.options, self.at_rule_parser)?
     };
 
@@ -882,6 +891,14 @@ impl<'a, 'o, 'b, 'i, T: crate::traits::AtRuleParser<'i>> AtRuleParser<'i> for Ne
       }
       AtRulePrelude::Property(name) => {
         self.rules.0.push(CssRule::Property(PropertyRule::parse(name, input, loc)?));
+        Ok(())
+      }
+      AtRulePrelude::PositionTry(name) => {
+        self.rules.0.push(CssRule::PositionTry(PositionTryRule {
+          name,
+          declarations: DeclarationBlock::parse(input, self.options)?,
+          loc,
+        }));
         Ok(())
       }
       AtRulePrelude::Import(..)

--- a/src/rules/mod.rs
+++ b/src/rules/mod.rs
@@ -50,6 +50,7 @@ pub mod media;
 pub mod namespace;
 pub mod nesting;
 pub mod page;
+pub mod position_try;
 pub mod property;
 pub mod scope;
 pub mod starting_style;
@@ -92,6 +93,7 @@ use media::MediaRule;
 use namespace::NamespaceRule;
 use nesting::{NestedDeclarationsRule, NestingRule};
 use page::PageRule;
+use position_try::PositionTryRule;
 use scope::ScopeRule;
 use smallvec::{smallvec, SmallVec};
 use starting_style::StartingStyleRule;
@@ -184,6 +186,8 @@ pub enum CssRule<'i, R = DefaultAtRule> {
   StartingStyle(StartingStyleRule<'i, R>),
   /// A `@view-transition` rule.
   ViewTransition(ViewTransitionRule<'i>),
+  /// A `@position-try` rule.
+  PositionTry(PositionTryRule<'i>),
   /// A placeholder for a rule that was removed.
   Ignored,
   /// An unknown at-rule.
@@ -353,6 +357,11 @@ impl<'i, 'de: 'i, R: serde::Deserialize<'de>> serde::Deserialize<'de> for CssRul
           ViewTransitionRule::deserialize(deserializer).map_err(|e| serde::de::Error::custom(e.to_string()))?;
         Ok(CssRule::ViewTransition(rule))
       }
+      "position-try" => {
+        let rule =
+          PositionTryRule::deserialize(deserializer).map_err(|e| serde::de::Error::custom(e.to_string()))?;
+        Ok(CssRule::PositionTry(rule))
+      }
       "ignored" => Ok(CssRule::Ignored),
       "unknown" => {
         let rule =
@@ -397,6 +406,7 @@ impl<'a, 'i, T: ToCss> ToCss for CssRule<'i, T> {
       CssRule::Container(container) => container.to_css(dest),
       CssRule::Scope(scope) => scope.to_css(dest),
       CssRule::ViewTransition(rule) => rule.to_css(dest),
+      CssRule::PositionTry(rule) => rule.to_css(dest),
       CssRule::Unknown(unknown) => unknown.to_css(dest),
       CssRule::Custom(rule) => rule.to_css(dest).map_err(|_| PrinterError {
         kind: PrinterErrorKind::FmtError,
@@ -873,6 +883,11 @@ impl<'i, T: Clone> CssRuleList<'i, T> {
             continue;
           } else {
             font_feature_values_rules.push(rules.len());
+          }
+        }
+        CssRule::PositionTry(rule) => {
+          if context.unused_symbols.contains(rule.name.0.as_ref()) {
+            continue;
           }
         }
         CssRule::Property(property) => {

--- a/src/rules/position_try.rs
+++ b/src/rules/position_try.rs
@@ -1,0 +1,40 @@
+//! The `@position-try` rule.
+
+use super::Location;
+use crate::declaration::DeclarationBlock;
+use crate::error::PrinterError;
+use crate::printer::Printer;
+use crate::traits::ToCss;
+use crate::values::ident::DashedIdent;
+#[cfg(feature = "visitor")]
+use crate::visitor::Visit;
+
+/// A [@position-try](https://drafts.csswg.org/css-anchor-position-1/#position-try) rule.
+#[derive(Debug, PartialEq, Clone)]
+#[cfg_attr(feature = "visitor", derive(Visit))]
+#[cfg_attr(feature = "into_owned", derive(static_self::IntoOwned))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "jsonschema", derive(schemars::JsonSchema))]
+pub struct PositionTryRule<'i> {
+  /// The name of the position-try fallback.
+  #[cfg_attr(feature = "serde", serde(borrow))]
+  pub name: DashedIdent<'i>,
+  /// Declarations in the `@position-try` rule.
+  pub declarations: DeclarationBlock<'i>,
+  /// The location of the rule in the source file.
+  #[cfg_attr(feature = "visitor", skip_visit)]
+  pub loc: Location,
+}
+
+impl<'i> ToCss for PositionTryRule<'i> {
+  fn to_css<W>(&self, dest: &mut Printer<W>) -> Result<(), PrinterError>
+  where
+    W: std::fmt::Write,
+  {
+    #[cfg(feature = "sourcemap")]
+    dest.add_mapping(self.loc);
+    dest.write_str("@position-try ")?;
+    self.name.to_css(dest)?;
+    self.declarations.to_css_block(dest)
+  }
+}


### PR DESCRIPTION
Adds parsing and serialization support for the CSS Anchor Positioning [`@position-try`](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/At-rules/@position-try) at-rule.

Previously, stylesheets containing `@position-try` produced an `Unknown at rule` error.

### Changes
- New `PositionTryRule` in `src/rules/position_try.rs` containing a `DashedIdent` name and a `DeclarationBlock`.
- Wired into the `CssRule` enum, `ToCss` impl, serde deserialization, and `unused_symbols` minification handling in `src/rules/mod.rs`.
- Parser support via a new `AtRulePrelude::PositionTry` variant in `src/parser.rs`.
- Added `"position-try"` mapping in `napi/src/transformer.rs`.
- Tests in `src/lib.rs` covering minified output, pretty-printed output, and nesting inside `@supports`.

Fixes #858.
