### PR TITLE
ci(perf): Add CodSpeed benchmarks

### DIFF
--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -1,0 +1,40 @@
+name: codspeed
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  codspeed:
+    name: ${{ matrix.package }} / ${{ matrix.bench }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - package: lightningcss
+            bench: transform
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Install cargo-codspeed
+        run: cargo install cargo-codspeed --locked
+
+      - name: Build benchmark target
+        run: cargo codspeed build -p ${{ matrix.package }} --bench ${{ matrix.bench }}
+
+      - name: Run benchmarks
+        uses: CodSpeedHQ/action@v4
+        with:
+          mode: simulation
+          run: cargo codspeed run -p ${{ matrix.package }} --bench ${{ matrix.bench }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -52,10 +52,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
 name = "anstyle"
 version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
+
+[[package]]
+name = "anyhow"
+version = "1.0.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
+name = "approx"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "assert_cmd"
@@ -94,7 +115,7 @@ version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.1.19",
  "libc",
  "winapi",
 ]
@@ -214,12 +235,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "325918d6fe32f23b19878fe4b34794ae41fc19ddbe53b10571a4874d44ffd39b"
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cbindgen"
 version = "0.24.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b922faaf31122819ec80c4047cc684c6979a087366c069611e33649bf98e18d"
 dependencies = [
- "clap",
+ "clap 3.2.25",
  "heck",
  "indexmap 1.9.3",
  "log",
@@ -248,6 +275,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
 name = "chrono"
 version = "0.4.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -260,6 +293,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
+
+[[package]]
 name = "clap"
 version = "3.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -268,12 +328,31 @@ dependencies = [
  "atty",
  "bitflags 1.3.2",
  "clap_derive",
- "clap_lex",
+ "clap_lex 0.2.4",
  "indexmap 1.9.3",
  "once_cell",
  "strsim",
  "termcolor",
  "textwrap",
+]
+
+[[package]]
+name = "clap"
+version = "4.5.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2797f34da339ce31042b27d23607e051786132987f595b02ba4f6a6dffb7030a"
+dependencies = [
+ "clap_builder",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24a241312cea5059b13574bb9b3861cabf758b879c15190b37b6d6fd63ab6876"
+dependencies = [
+ "anstyle",
+ "clap_lex 1.1.0",
 ]
 
 [[package]]
@@ -299,6 +378,80 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "codspeed"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7ce4a32373a5c84f4fa785099b300b9b1796311abc122b9eb62c65fa615145d"
+dependencies = [
+ "anyhow",
+ "cc",
+ "colored",
+ "getrandom 0.2.15",
+ "glob",
+ "libc",
+ "nix",
+ "serde",
+ "serde_json",
+ "statrs",
+]
+
+[[package]]
+name = "codspeed-criterion-compat"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5557c4e023f427ba208b849193c51c2ebd40534828490cd3f5f7f7fc0284ce5"
+dependencies = [
+ "clap 4.5.60",
+ "codspeed",
+ "codspeed-criterion-compat-walltime",
+ "colored",
+ "regex",
+]
+
+[[package]]
+name = "codspeed-criterion-compat-walltime"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43ac19f0a5c3542301e9d011d658f93c3f550698ec8ba7d7c072692e7924c401"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap 4.5.60",
+ "codspeed",
+ "criterion-plot",
+ "is-terminal",
+ "itertools 0.10.5",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "colored"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
+dependencies = [
+ "lazy_static",
+ "windows-sys",
+]
+
+[[package]]
 name = "const-str"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -318,6 +471,16 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools 0.10.5",
+]
 
 [[package]]
 name = "crossbeam-channel"
@@ -352,6 +515,12 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "cssparser"
@@ -536,6 +705,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
 name = "globset"
 version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -557,6 +732,17 @@ dependencies = [
  "bitflags 2.6.0",
  "ignore",
  "walkdir",
+]
+
+[[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
 ]
 
 [[package]]
@@ -594,6 +780,12 @@ checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "iana-time-zone"
@@ -662,6 +854,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa799dd5ed20a7e349f3b4639aa80d74549c81716d9ec4f994c9b5815598306"
 
 [[package]]
+name = "is-terminal"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
+dependencies = [
+ "hermit-abi 0.5.2",
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
 name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -724,9 +927,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.169"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libloading"
@@ -747,7 +950,8 @@ dependencies = [
  "assert_fs",
  "bitflags 2.6.0",
  "browserslist-rs",
- "clap",
+ "clap 3.2.25",
+ "codspeed-criterion-compat",
  "const-str",
  "cssparser",
  "cssparser-color",
@@ -923,6 +1127,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.31.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
+dependencies = [
+ "bitflags 2.6.0",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -952,6 +1168,12 @@ name = "once_cell"
 version = "1.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
+
+[[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "os_str_bytes"
@@ -1100,6 +1322,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
 dependencies = [
  "siphasher 1.0.2",
+]
+
+[[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
 ]
 
 [[package]]
@@ -1364,12 +1614,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ryu"
-version = "1.0.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
-
-[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1493,14 +1737,15 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.133"
+version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7fceb2473b9166b2294ef05efcb65a3db80803f0b03ef86a5fc88a2b85ee377"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
  "itoa",
  "memchr",
- "ryu",
  "serde",
+ "serde_core",
+ "zmij",
 ]
 
 [[package]]
@@ -1561,6 +1806,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "statrs"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a3fe7c28c6512e766b0874335db33c94ad7b8f9054228ae1c2abd47ce7d335e"
+dependencies = [
+ "approx",
+ "num-traits",
 ]
 
 [[package]]
@@ -1649,6 +1904,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.90",
+]
+
+[[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -1792,6 +2057,16 @@ name = "wasm-bindgen-shared"
 version = "0.2.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "943aab3fdaaa029a6e0271b35ea10b72b943135afe9bffca82384098ad0e06a6"
+
+[[package]]
+name = "web-sys"
+version = "0.3.76"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04dd7223427d52553d3702c004d3b2fe07c148165faa56313cb00211e31c12bc"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "winapi"
@@ -1955,3 +2230,9 @@ dependencies = [
  "quote",
  "syn 2.0.90",
 ]
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,6 +104,7 @@ assert_fs = "1.0"
 predicates = "2.1"
 serde_json = "1"
 pretty_assertions = "1.4.0"
+criterion = { package = "codspeed-criterion-compat", version = "4.5.0" }
 
 [[test]]
 name = "cli_integration_tests"
@@ -117,6 +118,10 @@ required-features = ["visitor"]
 [[example]]
 name = "serialize"
 required-features = ["serde"]
+
+[[bench]]
+name = "transform"
+harness = false
 
 [profile.release]
 lto = true

--- a/benches/common/mod.rs
+++ b/benches/common/mod.rs
@@ -1,0 +1,185 @@
+use criterion::black_box;
+use lightningcss::stylesheet::{MinifyOptions, ParserOptions, PrinterOptions, StyleSheet};
+use std::fmt::Write;
+
+pub struct Fixture {
+  pub name: &'static str,
+  pub css: String,
+}
+
+pub fn stylesheet_fixtures() -> Vec<Fixture> {
+  vec![
+    Fixture {
+      name: "small",
+      css: small_fixture(),
+    },
+    Fixture {
+      name: "medium",
+      css: generated_fixture(48, 96),
+    },
+    Fixture {
+      name: "large",
+      css: generated_fixture(192, 384),
+    },
+  ]
+}
+
+pub fn parse_stylesheet(css: &str) {
+  let stylesheet = StyleSheet::parse(css, ParserOptions::default()).unwrap();
+  black_box(stylesheet);
+}
+
+pub fn transform_stylesheet(css: &str) {
+  let mut stylesheet = StyleSheet::parse(css, ParserOptions::default()).unwrap();
+  stylesheet.minify(MinifyOptions::default()).unwrap();
+  let result = stylesheet
+    .to_css(PrinterOptions {
+      minify: true,
+      ..PrinterOptions::default()
+    })
+    .unwrap();
+  black_box(result);
+}
+
+fn small_fixture() -> String {
+  r#"
+:root {
+  --brand: #3366ff;
+  --surface: color-mix(in srgb, white 88%, var(--brand));
+}
+
+.button {
+  appearance: none;
+  background: linear-gradient(135deg, var(--brand), #0bb3ff);
+  border: 1px solid color-mix(in srgb, var(--brand), black 18%);
+  border-radius: 8px;
+  color: white;
+  display: inline-flex;
+  gap: 0.5rem;
+  padding: 0.625rem 1rem;
+  transition: transform 180ms ease, box-shadow 180ms ease;
+}
+
+@media (hover: hover) {
+  .button:hover {
+    box-shadow: 0 12px 32px rgb(18 52 99 / 22%);
+    transform: translateY(-1px);
+  }
+}
+"#
+  .to_owned()
+}
+
+fn generated_fixture(component_count: usize, utility_count: usize) -> String {
+  let mut css = String::with_capacity(component_count * 920 + utility_count * 96);
+
+  css.push_str(
+    r#"
+@layer reset, components, utilities;
+
+@layer reset {
+  *,
+  ::before,
+  ::after {
+    box-sizing: border-box;
+  }
+
+  body {
+    color: #162033;
+    font-family: ui-sans-serif, system-ui, sans-serif;
+    margin: 0;
+  }
+}
+"#,
+  );
+
+  for i in 0..component_count {
+    let hue = (i * 19) % 360;
+    let next_hue = (hue + 36) % 360;
+    let columns = (i % 4) + 2;
+    let gap = (i % 8) + 8;
+    let width = 36 + (i % 28);
+    let padding = 12 + (i % 10);
+
+    writeln!(
+      css,
+      r#"
+@layer components {{
+  .card-{i},
+  .dashboard-{i} > .panel {{
+    background:
+      linear-gradient(135deg, hsl({hue}deg 64% 96%), hsl({next_hue}deg 72% 92%)),
+      white;
+    border: 1px solid hsl({hue}deg 28% 82%);
+    border-radius: {radius}px;
+    box-shadow: 0 {shadow_y}px {shadow_blur}px rgb(20 31 48 / 12%);
+    color: hsl({hue}deg 45% 22%);
+    display: grid;
+    gap: {gap}px;
+    grid-template-columns: minmax(0, 1fr) auto;
+    padding: {padding}px;
+  }}
+
+  .card-{i}:where(:hover, :focus-visible) {{
+    border-color: hsl({hue}deg 72% 48%);
+    box-shadow: 0 {hover_y}px {hover_blur}px rgb(20 31 48 / 18%);
+    transform: translateY(-1px);
+  }}
+
+  .card-{i} .title {{
+    font-size: clamp(1rem, 0.92rem + 0.3vw, 1.25rem);
+    font-weight: 700;
+    letter-spacing: 0;
+    margin: 0;
+  }}
+
+  .card-{i} .meta {{
+    color: color-mix(in srgb, hsl({hue}deg 45% 22%), white 42%);
+    font-size: 0.875rem;
+  }}
+}}
+
+@media (min-width: {media_width}px) {{
+  .grid-{i} {{
+    display: grid;
+    gap: {gap}px;
+    grid-template-columns: repeat({columns}, minmax(0, 1fr));
+  }}
+}}
+
+@supports (container-type: inline-size) {{
+  .wrap-{i} {{
+    container-type: inline-size;
+  }}
+
+  @container (min-width: {width}rem) {{
+    .wrap-{i} .card-{i} {{
+      padding: {container_padding}px;
+    }}
+  }}
+}}
+"#,
+      radius = 6 + (i % 6),
+      shadow_y = 4 + (i % 5),
+      shadow_blur = 16 + (i % 12),
+      hover_y = 8 + (i % 6),
+      hover_blur = 24 + (i % 18),
+      media_width = 480 + (i % 9) * 80,
+      container_padding = padding + 6
+    )
+    .unwrap();
+  }
+
+  css.push_str("@layer utilities {\n");
+  for i in 0..utility_count {
+    let value = (i % 32) + 1;
+    writeln!(
+      css,
+      "  .m-{i} {{ margin: {value}px !important; }} .p-{i} {{ padding: {value}px !important; }} .gap-{i} {{ gap: {value}px; }}"
+    )
+    .unwrap();
+  }
+  css.push_str("}\n");
+
+  css
+}

--- a/benches/transform.rs
+++ b/benches/transform.rs
@@ -1,0 +1,42 @@
+mod common;
+
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+
+fn bench_stylesheet_parse(c: &mut Criterion) {
+  let fixtures = common::stylesheet_fixtures();
+  let mut group = c.benchmark_group("stylesheet/parse");
+
+  for fixture in &fixtures {
+    group.throughput(Throughput::Bytes(fixture.css.len() as u64));
+    group.bench_with_input(
+      BenchmarkId::from_parameter(fixture.name),
+      fixture.css.as_str(),
+      |b, css| {
+        b.iter(|| common::parse_stylesheet(black_box(css)));
+      },
+    );
+  }
+
+  group.finish();
+}
+
+fn bench_stylesheet_transform(c: &mut Criterion) {
+  let fixtures = common::stylesheet_fixtures();
+  let mut group = c.benchmark_group("stylesheet/transform");
+
+  for fixture in &fixtures {
+    group.throughput(Throughput::Bytes(fixture.css.len() as u64));
+    group.bench_with_input(
+      BenchmarkId::from_parameter(fixture.name),
+      fixture.css.as_str(),
+      |b, css| {
+        b.iter(|| common::transform_stylesheet(black_box(css)));
+      },
+    );
+  }
+
+  group.finish();
+}
+
+criterion_group!(benches, bench_stylesheet_parse, bench_stylesheet_transform);
+criterion_main!(benches);


### PR DESCRIPTION
## Summary

- Add stable Rust benchmarks for the root `lightningcss` crate using `codspeed-criterion-compat`.
- Add reusable benchmark fixtures/helpers under `benches/common` so future crate-local benchmarks can follow the same pattern.
- Add a CodSpeed GitHub Actions workflow with an explicit package/bench matrix for multi-crate expansion.

## Notes

- Since automated benchmarking doesn't require 100% accuracy, we utilized AI.
- The only new workflow action is `CodSpeedHQ/action@v4`, which is needed to configure CodSpeed and upload results.
