### PR TITLE
fix(calc): enhance sum term reduction in calculations to prevent segmentation faults

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8129,6 +8129,10 @@ mod tests {
       ".foo { width: calc(100vw / 2 - 6px + 0px) }",
       ".foo{width:calc(50vw - 6px)}",
     );
+    minify_test(
+      ".foo { width: calc((2px + max(1em, 2vw)) - (2px + min(1px, 1vw))) }",
+      ".foo{width:calc(max(1em,2vw) - min(1px,1vw))}",
+    );
     minify_test(".foo { width: calc(1px + 1) }", ".foo{width:calc(1px + 1)}");
     minify_test(
       ".foo { width: calc( (1em - calc( 10px + 1em)) / 2) }",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8401,6 +8401,26 @@ mod tests {
       ".foo{width:calc(2*min(1px,1vmin) - min(1px,1vmin))}",
     );
     minify_test(
+      ".foo { right: calc(32px + ((min(100vw, 1724px) - 464px) / 12) + ((100vw - min(100vw - 112px, 1612px)) / 2)); }",
+      ".foo{right:calc(min(100vw,1724px)/12 + 50vw - 6.66667px + min(100vw - 112px,1612px)/-2)}",
+    );
+    minify_test(
+      ".foo { width: calc((1em + 2px) + (3px + 4em)); }",
+      ".foo{width:calc(5px + 5em)}",
+    );
+    minify_test(
+      ".foo { width: calc((1em + 2px) + (3% + 4em)); }",
+      ".foo{width:calc(2px + 3% + 5em)}",
+    );
+    minify_test(
+      ".foo { width: calc((1 + 2px) + (3 + 4px)); }",
+      ".foo{width:calc(4 + 6px)}",
+    );
+    minify_test(
+      ".foo { width: calc((1em - 2px) + (3px - 4em)); }",
+      ".foo{width:calc(1px - 3em)}",
+    );
+    minify_test(
       ".foo { width: calc(100% - clamp(1.125rem, 1.25vw, 1.2375rem) - clamp(1.125rem, 1.25vw, 1.2375rem)); }",
       ".foo{width:calc(100% - clamp(1.125rem,1.25vw,1.2375rem) - clamp(1.125rem,1.25vw,1.2375rem))}",
     );
@@ -29727,6 +29747,17 @@ mod tests {
       }
     "#,
       ParserError::UnexpectedToken(crate::properties::custom::Token::Function("var".into())),
+    );
+
+    error_test(
+      r#"
+      @property --property-name {
+        syntax: '<percentage>';
+        inherits: false;
+        initial-value: calc((1% + 2) + (3% + 4));
+      }
+    "#,
+      ParserError::UnexpectedToken(crate::properties::custom::Token::Function("calc".into())),
     );
 
     error_test(

--- a/src/selector.rs
+++ b/src/selector.rs
@@ -100,10 +100,7 @@ impl<'a, 'i> parcel_selectors::parser::Parser<'i> for SelectorParser<'a, 'i> {
     name: CowRcStr<'i>,
   ) -> Result<PseudoClass<'i>, ParseError<'i, Self::Error>> {
     use PseudoClass::*;
-    let scroll_navigation_controls = self
-      .options
-      .flags
-      .contains(ParserFlags::SCROLL_NAVIGATION_CONTROLS);
+    let scroll_navigation_controls = self.options.flags.contains(ParserFlags::SCROLL_NAVIGATION_CONTROLS);
     let pseudo_class = match_ignore_ascii_case! { &name,
       // https://drafts.csswg.org/selectors-4/#useraction-pseudos
       "hover" => Hover,
@@ -501,7 +498,6 @@ pub enum PseudoClass<'i> {
   /// The [:target-after](https://drafts.csswg.org/css-overflow-5/#selectordef-target-after) pseudo class.
   TargetAfter,
   /// The [:target-within](https://drafts.csswg.org/selectors-4/#the-target-within-pseudo) pseudo class.
-
   TargetWithin,
   /// The [:visited](https://drafts.csswg.org/selectors-4/#visited-pseudo) pseudo class.
   Visited,

--- a/src/values/calc.rs
+++ b/src/values/calc.rs
@@ -927,6 +927,76 @@ impl<V: std::ops::Mul<f32, Output = V>> std::ops::Mul<f32> for Calc<V> {
 }
 
 impl<V: AddInternal + std::convert::Into<Calc<V>> + std::convert::TryFrom<Calc<V>> + std::fmt::Debug> Calc<V> {
+  fn add_sum_terms(a: Calc<V>, b: Calc<V>) -> Result<Calc<V>, <V as std::convert::TryFrom<Calc<V>>>::Error> {
+    let mut terms = Vec::new();
+    Self::collect_sum_terms(a, &mut terms);
+    Self::collect_sum_terms(b, &mut terms);
+
+    let mut reduced: Vec<Calc<V>> = Vec::new();
+    for term in terms {
+      Self::push_reduced_sum_term(&mut reduced, term)?;
+    }
+
+    if reduced.len() == 1 {
+      return Ok(reduced.pop().unwrap());
+    }
+
+    let mut terms = reduced.into_iter();
+    let mut res = terms.next().unwrap();
+    for term in terms {
+      res = Calc::Sum(Box::new(res), Box::new(term));
+    }
+    Ok(V::try_from(res)?.into())
+  }
+
+  fn push_reduced_sum_term(
+    reduced: &mut Vec<Calc<V>>,
+    mut term: Calc<V>,
+  ) -> Result<(), <V as std::convert::TryFrom<Calc<V>>>::Error> {
+    let mut i = 0;
+    while i < reduced.len() {
+      if !Self::should_try_combine_terms(&reduced[i], &term) {
+        i += 1;
+        continue;
+      }
+
+      let existing = reduced.remove(i);
+      match existing.add(term)? {
+        Calc::Sum(a, b) => {
+          // Values of the same literal kind may still be incompatible units.
+          // Keep the unchanged side, and continue trying to reduce the other.
+          reduced.insert(i, *a);
+          term = *b;
+          i += 1;
+        }
+        combined => {
+          term = combined;
+          i = 0;
+        }
+      }
+    }
+
+    reduced.push(term);
+    Ok(())
+  }
+
+  fn collect_sum_terms(calc: Calc<V>, terms: &mut Vec<Calc<V>>) {
+    match calc {
+      Calc::Sum(a, b) => {
+        Self::collect_sum_terms(*a, terms);
+        Self::collect_sum_terms(*b, terms);
+      }
+      calc => terms.push(calc),
+    }
+  }
+
+  fn should_try_combine_terms(a: &Calc<V>, b: &Calc<V>) -> bool {
+    matches!(
+      (a, b),
+      (Calc::Value(_), Calc::Value(_)) | (Calc::Number(_), Calc::Number(_))
+    )
+  }
+
   pub(crate) fn add(self, other: Calc<V>) -> Result<Calc<V>, <V as TryFrom<Calc<V>>>::Error> {
     Ok(match (self, other) {
       (Calc::Value(a), Calc::Value(b)) => (a.add(*b)).into(),
@@ -957,7 +1027,7 @@ impl<V: AddInternal + std::convert::Into<Calc<V>> + std::convert::TryFrom<Calc<V
       (a, Calc::Function(b)) => Calc::Sum(Box::new(a), Box::new(Calc::Function(b))),
       (Calc::Value(a), b) => (a.add(V::try_from(b)?)).into(),
       (a, Calc::Value(b)) => (V::try_from(a)?.add(*b)).into(),
-      (a @ Calc::Sum(..), b @ Calc::Sum(..)) => V::try_from(a)?.add(V::try_from(b)?).into(),
+      (a @ Calc::Sum(..), b @ Calc::Sum(..)) => Self::add_sum_terms(a, b)?,
     })
   }
 }

--- a/src/values/calc.rs
+++ b/src/values/calc.rs
@@ -6,7 +6,7 @@ use crate::macros::enum_property;
 use crate::printer::Printer;
 use crate::targets::{should_compile, Browsers};
 use crate::traits::private::AddInternal;
-use crate::traits::{IsCompatible, Parse, Sign, ToCss, TryMap, TryOp, TrySign};
+use crate::traits::{IsCompatible, Parse, Sign, ToCss, TryMap, TryOp, TrySign, Zero};
 #[cfg(feature = "visitor")]
 use crate::visitor::Visit;
 use cssparser::*;
@@ -317,6 +317,7 @@ impl<
       + TryFrom<Calc<V>>
       + TryFrom<Angle>
       + TryInto<Angle>
+      + Zero
       + Clone
       + std::fmt::Debug,
   > Parse<'i> for Calc<V>
@@ -339,6 +340,7 @@ impl<
       + TryFrom<Calc<V>>
       + TryFrom<Angle>
       + TryInto<Angle>
+      + Zero
       + Clone
       + std::fmt::Debug,
   > Calc<V>
@@ -926,7 +928,9 @@ impl<V: std::ops::Mul<f32, Output = V>> std::ops::Mul<f32> for Calc<V> {
   }
 }
 
-impl<V: AddInternal + std::convert::Into<Calc<V>> + std::convert::TryFrom<Calc<V>> + std::fmt::Debug> Calc<V> {
+impl<V: AddInternal + std::convert::Into<Calc<V>> + std::convert::TryFrom<Calc<V>> + Zero + std::fmt::Debug>
+  Calc<V>
+{
   fn add_sum_terms(a: Calc<V>, b: Calc<V>) -> Result<Calc<V>, <V as std::convert::TryFrom<Calc<V>>>::Error> {
     let mut terms = Vec::new();
     Self::collect_sum_terms(a, &mut terms);
@@ -935,6 +939,10 @@ impl<V: AddInternal + std::convert::Into<Calc<V>> + std::convert::TryFrom<Calc<V
     let mut reduced: Vec<Calc<V>> = Vec::new();
     for term in terms {
       Self::push_reduced_sum_term(&mut reduced, term)?;
+    }
+
+    if reduced.is_empty() {
+      return Ok(V::zero().into());
     }
 
     if reduced.len() == 1 {
@@ -976,7 +984,10 @@ impl<V: AddInternal + std::convert::Into<Calc<V>> + std::convert::TryFrom<Calc<V
       }
     }
 
-    reduced.push(term);
+    if !Self::is_zero_term(&term) {
+      reduced.push(term);
+    }
+
     Ok(())
   }
 
@@ -995,6 +1006,14 @@ impl<V: AddInternal + std::convert::Into<Calc<V>> + std::convert::TryFrom<Calc<V
       (a, b),
       (Calc::Value(_), Calc::Value(_)) | (Calc::Number(_), Calc::Number(_))
     )
+  }
+
+  fn is_zero_term(term: &Calc<V>) -> bool {
+    match term {
+      Calc::Value(v) => v.is_zero(),
+      Calc::Number(n) => n.is_zero(),
+      _ => false,
+    }
   }
 
   pub(crate) fn add(self, other: Calc<V>) -> Result<Calc<V>, <V as TryFrom<Calc<V>>>::Error> {


### PR DESCRIPTION
Some `calc` expressions such as `calc((100dvh - 10.5rem) + (4vh + 230px));` error with "too much recursion" on the playground, or a segfault in userland.

This PR improves the sum term collection and reduction so the segfaults are avoided.

Resolves https://github.com/parcel-bundler/lightningcss/issues/910