### PR TITLE
fix(test): fix hash is not stable on Windows

### DIFF
--- a/src/css_modules.rs
+++ b/src/css_modules.rs
@@ -291,15 +291,14 @@ impl<'a, 'b, 'c> CssModule<'a, 'b, 'c> {
       .map(|path| {
         // Make paths relative to project root so hashes are stable.
         let source = match project_root {
-          Some(project_root) if path.is_absolute() => {
-            diff_paths(path, project_root).map_or(Cow::Borrowed(*path), Cow::Owned)
-          }
+          Some(project_root) => diff_paths(path, project_root).map_or(Cow::Borrowed(*path), Cow::Owned),
           _ => Cow::Borrowed(*path),
         };
-        hash(
-          &source.to_string_lossy(),
-          matches!(config.pattern.segments[0], Segment::Hash),
-        )
+
+        // normalize path on Windows
+        let normalized = source.to_string_lossy().replace("\\", "/");
+
+        hash(&normalized, matches!(config.pattern.segments[0], Segment::Hash))
       })
       .collect();
     Self {


### PR DESCRIPTION
On Windows, the path is separated by "\\\\", not "/", this PR normalize it to prevent hash not stable.

This test was failed on Windows.


```diff
---- tests::test_css_modules stdout ----

thread 'tests::test_css_modules' (27464) panicked at src\lib.rs:27055:7:
assertion failed: `(left == right)`

Diff < left / right > :
- <.Ot1kIW_foo {
+ >.EgL3uq_foo {
   background: red;
 }

```