### PR TITLE
Don’t deduplicate `font-family: monospace, monospace`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6364,6 +6364,19 @@ mod tests {
       "@font-face{font-family:\"revert-layer\"}",
     );
 
+    minify_test(
+        ".foo{font-family:named-font,named-font}",
+        ".foo{font-family:named-font}",
+    );
+    minify_test(
+        ".foo{font-family:monospace,monospace}",
+        ".foo{font-family:monospace,monospace}",
+    );
+    minify_test(
+        ".foo{font-family:monospace,monospace;font-size:16px}",
+        ".foo{font-family:monospace,monospace;font-size:16px}",
+    );
+
     prefix_test(
       r#"
       .foo {

--- a/src/properties/font.rs
+++ b/src/properties/font.rs
@@ -924,7 +924,14 @@ impl<'i> FontHandler<'i> {
     let variant_caps = std::mem::take(&mut self.variant_caps);
 
     if let Some(family) = &mut family {
-      if family.len() > 1 {
+      if family.iter().all(|f| matches!(f, FontFamily::Generic(GenericFontFamily::Monospace))) {
+        // Browsers have a different default size for monospace, typically 13px instead of 16px.
+        // This is often undesired. You can avoid it by including another name in the stack,
+        // so `font-family: monospace, monospace` is a common workaround.
+        // (You can also avoid it with a font-size declaration in absolute units like px or rem.)
+        // So, don’t completely deduplicate it, we’d risk making the text 18.75% smaller.
+        family.truncate(2);
+      } else if family.len() > 1 {
         // Dedupe.
         let mut seen = HashSet::new();
         family.retain(|f| seen.insert(f.clone()));


### PR DESCRIPTION
~~Unless size is specified too, then it’s safe.~~

~~Monospace is the main place this has visible effects, but it’s conservative to apply it to all Generic; it can theoretically have effects with more, especially if you add languages to the mix.~~

I *believe* `monospace` is the only name where duplication has effects. Different languages can vary sizes as well, but that’s not a CSS concern.

Fixes #1221.