### PR TITLE
fix: change serde attribute to be conditional for ResolveResult enum File variant

### DIFF
--- a/src/bundler.rs
+++ b/src/bundler.rs
@@ -106,7 +106,10 @@ pub enum ResolveResult {
   /// An external URL.
   External(String),
   /// A file path.
-  #[serde(untagged)]
+  #[cfg_attr(
+    any(feature = "serde", feature = "nodejs"),
+    serde(untagged)
+  )]
   File(PathBuf),
 }
 


### PR DESCRIPTION
I encountered this serde attribute without a conditional in the last alpha when using:

```toml
lightningcss = { version = "1.0.0-alpha.71", default-features = false, features = ["bundler", "sourcemap"] }
```