### PR TITLE
ci: add permissions: contents: read to test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [master]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Declares `permissions: contents: read` at the workflow level for `test.yml`.

The test workflow is read-only. Setting an explicit minimum scope follows GitHub's [hardening guide](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token) and the OpenSSF Scorecard Token-Permissions check, and limits blast radius if any third-party action used here is ever compromised (the March 2025 tj-actions/changed-files token-leak incident).

YAML parses cleanly. No other changes.
