### PR TITLE
feat: add RISC-V (riscv64gc-unknown-linux-gnu) prebuilt binary support

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -7,6 +7,9 @@ linker = "aarch64-linux-gnu-gcc"
 [target.armv7-unknown-linux-gnueabihf]
 linker = "arm-linux-gnueabihf-gcc"
 
+[target.riscv64gc-unknown-linux-gnu]
+linker = "riscv64-linux-gnu-gcc"
+
 [target.aarch64-unknown-linux-musl]
 linker = "aarch64-linux-musl-gcc"
 rustflags = ["-C", "target-feature=-crt-static"]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -121,6 +121,12 @@ jobs:
           - target: x86_64-unknown-linux-musl
             image: ghcr.io/napi-rs/napi-rs/nodejs-rust@sha256:78c9ab1f117f8c535b93c4b91a2f19063dda6e4dba48a6187df49810625992c1
             strip: strip
+          - target: riscv64gc-unknown-linux-gnu
+            strip: llvm-strip
+            image: ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-debian
+            setup: |
+              apt-get update
+              apt-get install -y gcc-riscv64-linux-gnu g++-riscv64-linux-gnu
 
     name: build-${{ matrix.target }}
     runs-on: ubuntu-latest

--- a/scripts/build-npm.js
+++ b/scripts/build-npm.js
@@ -41,13 +41,18 @@ const triples = [
   },
   {
     name: 'aarch64-linux-android'
-  }
+  },
+  {
+    name: 'riscv64gc-unknown-linux-gnu',
+    libc: 'glibc',
+  },
 ];
 const cpuToNodeArch = {
   x86_64: 'x64',
   aarch64: 'arm64',
   i686: 'ia32',
   armv7: 'arm',
+  riscv64gc: 'riscv64',
 };
 const sysToNodePlatform = {
   linux: 'linux',


### PR DESCRIPTION
Add cross-compilation and npm packaging support for RISC-V:

- .cargo/config.toml: add riscv64gc-unknown-linux-gnu linker
- .github/workflows/release.yml: add RISC-V build matrix entry using ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-debian image with gcc-riscv64-linux-gnu cross-compiler
- scripts/build-npm.js: register riscv64gc-unknown-linux-gnu triple with glibc and map cpu arch to riscv64