### PR TITLE
fix: preserve `backdrop-filter` when webkit fallback is present

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28331,6 +28331,15 @@ mod tests {
       "#,
       ".foo{-webkit-backdrop-filter:blur(10px);backdrop-filter:blur(10px)}",
     );
+    minify_test(
+      r#"
+        .foo {
+          backdrop-filter: blur(10px);
+          -webkit-backdrop-filter: blur(20px);
+        }
+      "#,
+      ".foo{backdrop-filter:blur(10px);-webkit-backdrop-filter:blur(20px)}",
+    );
     prefix_test(
       r#"
       .foo {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28322,6 +28322,15 @@ mod tests {
         ..Browsers::default()
       },
     );
+    minify_test(
+      r#"
+        .foo {
+          backdrop-filter: blur(10px);
+          -webkit-backdrop-filter: blur(10px);
+        }
+      "#,
+      ".foo{-webkit-backdrop-filter:blur(10px);backdrop-filter:blur(10px)}",
+    );
     prefix_test(
       r#"
       .foo {

--- a/src/properties/prefix_handler.rs
+++ b/src/properties/prefix_handler.rs
@@ -126,6 +126,25 @@ macro_rules! define_fallbacks {
                 pastey::paste! { self.[<$name:snake>] = Some(dest.len()) };
                 dest.push(Property::$name(val $(, $p)?));
               } else if let Some(index) = pastey::paste! { self.[<$name:snake>] } {
+                $(
+                  if let Some(Property::$name(_, prefixes)) = dest.get_mut(index) {
+                    if prefixes.intersects($p) {
+                      let mut remaining_prefixes = *prefixes;
+                      remaining_prefixes.remove($p);
+                      if remaining_prefixes.is_empty() {
+                        dest[index] = Property::$name(val, $p);
+                      } else {
+                        *prefixes = remaining_prefixes;
+                        pastey::paste! { self.[<$name:snake>] = Some(dest.len()) };
+                        dest.push(Property::$name(val, $p));
+                      }
+                    } else {
+                      pastey::paste! { self.[<$name:snake>] = Some(dest.len()) };
+                      dest.push(Property::$name(val, $p));
+                    }
+                    return true;
+                  }
+                )?
                 dest[index] = Property::$name(val $(, $p)?);
               }
             }

--- a/src/properties/prefix_handler.rs
+++ b/src/properties/prefix_handler.rs
@@ -97,6 +97,15 @@ macro_rules! define_fallbacks {
               let mut val = val.clone();
               $(
                 $p = context.targets.prefixes($p, Feature::$name);
+                if let Some(index) = pastey::paste! { self.[<$name:snake>] } {
+                  if let Some(Property::$name(cur, prefixes)) = dest.get_mut(index) {
+                    if *cur == val {
+                      *prefixes |= $p;
+                      *prefixes = context.targets.prefixes(*prefixes, Feature::$name);
+                      return true;
+                    }
+                  }
+                }
               )?
               if pastey::paste! { self.[<$name:snake>] }.is_none() {
                 let fallbacks = val.get_fallbacks(context.targets);


### PR DESCRIPTION
closes: 

closes https://github.com/parcel-bundler/lightningcss/issues/695
https://github.com/vercel/next.js/issues/78302
https://github.com/utooland/utoo/issues/3090


