### PR TITLE
Allow using functions as patterns

### DIFF
--- a/napi/src/lib.rs
+++ b/napi/src/lib.rs
@@ -1,6 +1,7 @@
 #[cfg(feature = "bundler")]
 use at_rule_parser::AtRule;
 use at_rule_parser::{CustomAtRuleConfig, CustomAtRuleParser};
+use crossbeam_channel::{Receiver, Sender};
 use lightningcss::bundler::BundleErrorKind;
 #[cfg(feature = "bundler")]
 use lightningcss::bundler::{Bundler, SourceProvider};
@@ -12,14 +13,14 @@ use lightningcss::stylesheet::{
 };
 use lightningcss::targets::{Browsers, Features, Targets};
 use napi::bindgen_prelude::{FromNapiValue, ToNapiValue};
-use napi::{CallContext, Env, JsObject, JsUnknown};
+use napi::{CallContext, Env, JsObject, JsUnknown, NapiRaw, Ref};
 use parcel_sourcemap::SourceMap;
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
+use std::path::{Path, PathBuf};
 use std::sync::{Arc, RwLock};
 
 mod at_rule_parser;
-#[cfg(feature = "bundler")]
 #[cfg(not(target_arch = "wasm32"))]
 mod threadsafe_function;
 #[cfg(feature = "visitor")]
@@ -91,10 +92,12 @@ fn get_visitor(_env: Env, _opts: &JsObject) -> Option<JsVisitor> {
 pub fn transform(ctx: CallContext) -> napi::Result<JsUnknown> {
   let opts = ctx.get::<JsObject>(0)?;
   let mut visitor = get_visitor(*ctx.env, &opts);
+  let pattern = get_pattern(*ctx.env, &opts);
 
   let config: Config = ctx.env.from_js_value(opts)?;
+  println!("after js transform");
   let code = unsafe { std::str::from_utf8_unchecked(&config.code) };
-  let res = compile(code, &config, &mut visitor);
+  let res = compile(code, &config, &mut visitor, pattern);
 
   match res {
     Ok(res) => res.into_js(*ctx.env),
@@ -107,6 +110,7 @@ pub fn transform_style_attribute(ctx: CallContext) -> napi::Result<JsUnknown> {
   let mut visitor = get_visitor(*ctx.env, &opts);
 
   let config: AttrConfig = ctx.env.from_js_value(opts)?;
+  println!("after js transform_style_attribute");
   let code = unsafe { std::str::from_utf8_unchecked(&config.code) };
   let res = compile_attr(code, &config, &mut visitor);
 
@@ -116,23 +120,64 @@ pub fn transform_style_attribute(ctx: CallContext) -> napi::Result<JsUnknown> {
   }
 }
 
+fn handle_error<T>(tx: Sender<napi::Result<T>>, res: napi::Result<()>) -> napi::Result<()> {
+  match res {
+    Ok(_) => Ok(()),
+    Err(e) => {
+      tx.send(Err(e)).expect("send error");
+      Ok(())
+    }
+  }
+}
+
+fn await_promise<T, Cb>(env: Env, result: JsUnknown, tx: Sender<napi::Result<T>>, parse: Cb) -> napi::Result<()>
+  where
+  T: 'static,
+  Cb: 'static + Fn(JsUnknown) -> Result<T, napi::Error>,
+{
+  // If the result is a promise, wait for it to resolve, and send the result to the channel.
+  // Otherwise, send the result immediately.
+  if result.is_promise()? {
+    let result: JsObject = result.try_into()?;
+    let then: napi::JsFunction = get_named_property(&result, "then")?;
+    let tx2 = tx.clone();
+    let cb = env.create_function_from_closure("callback", move |ctx| {
+      let res = parse(ctx.get::<JsUnknown>(0)?)?;
+      tx.send(Ok(res)).unwrap();
+      ctx.env.get_undefined()
+    })?;
+    let eb = env.create_function_from_closure("error_callback", move |ctx| {
+      let res = ctx.get::<JsUnknown>(0)?;
+      tx2.send(Err(napi::Error::from(res))).unwrap();
+      ctx.env.get_undefined()
+    })?;
+    then.call(Some(&result), &[cb, eb])?;
+  } else {
+    let result = parse(result)?;
+    tx.send(Ok(result)).unwrap();
+  }
+
+  Ok(())
+}
+
 #[cfg(feature = "bundler")]
 #[cfg(not(target_arch = "wasm32"))]
 mod bundle {
   use super::*;
   use crossbeam_channel::{self, Receiver, Sender};
   use lightningcss::bundler::{FileProvider, ResolveResult};
-  use napi::{Env, JsBoolean, JsFunction, JsString, NapiRaw};
-  use std::path::{Path, PathBuf};
-  use std::str::FromStr;
+  use napi::{Env, JsFunction, JsString, NapiRaw};
+  use std::path::{Path};
   use std::sync::Mutex;
   use threadsafe_function::{ThreadSafeCallContext, ThreadsafeFunction, ThreadsafeFunctionCallMode};
 
   pub fn bundle(ctx: CallContext) -> napi::Result<JsUnknown> {
     let opts = ctx.get::<JsObject>(0)?;
     let mut visitor = get_visitor(*ctx.env, &opts);
+    let pattern = get_pattern(*ctx.env, &opts);
 
     let config: BundleConfig = ctx.env.from_js_value(opts)?;
+  println!("after js bundle");
     let fs = FileProvider::new();
 
     // This is pretty silly, but works around a rust limitation that you cannot
@@ -148,6 +193,7 @@ mod bundle {
       &fs,
       &config,
       visitor.as_mut().map(|visitor| annotate(|stylesheet| stylesheet.visit(visitor))),
+      pattern
     );
 
     match res {
@@ -238,35 +284,6 @@ mod bundle {
     tx: Sender<napi::Result<String>>,
   }
 
-  fn await_promise<T, Cb>(env: Env, result: JsUnknown, tx: Sender<napi::Result<T>>, parse: Cb) -> napi::Result<()>
-  where
-    T: 'static,
-    Cb: 'static + Fn(JsUnknown) -> Result<T, napi::Error>,
-  {
-    // If the result is a promise, wait for it to resolve, and send the result to the channel.
-    // Otherwise, send the result immediately.
-    if result.is_promise()? {
-      let result: JsObject = result.try_into()?;
-      let then: JsFunction = get_named_property(&result, "then")?;
-      let tx2 = tx.clone();
-      let cb = env.create_function_from_closure("callback", move |ctx| {
-        let res = parse(ctx.get::<JsUnknown>(0)?)?;
-        tx.send(Ok(res)).unwrap();
-        ctx.env.get_undefined()
-      })?;
-      let eb = env.create_function_from_closure("error_callback", move |ctx| {
-        let res = ctx.get::<JsUnknown>(0)?;
-        tx2.send(Err(napi::Error::from(res))).unwrap();
-        ctx.env.get_undefined()
-      })?;
-      then.call(Some(&result), &[cb, eb])?;
-    } else {
-      let result = parse(result)?;
-      tx.send(Ok(result)).unwrap();
-    }
-
-    Ok(())
-  }
 
   fn resolve_on_js_thread(ctx: ThreadSafeCallContext<ResolveMessage>) -> napi::Result<()> {
     let specifier = ctx.env.create_string(&ctx.value.specifier)?;
@@ -275,16 +292,6 @@ mod bundle {
     await_promise(ctx.env, result, ctx.value.tx, move |unknown| {
       ctx.env.from_js_value(unknown)
     })
-  }
-
-  fn handle_error<T>(tx: Sender<napi::Result<T>>, res: napi::Result<()>) -> napi::Result<()> {
-    match res {
-      Ok(_) => Ok(()),
-      Err(e) => {
-        tx.send(Err(e)).expect("send error");
-        Ok(())
-      }
-    }
   }
 
   fn resolve_on_js_thread_wrapper(ctx: ThreadSafeCallContext<ResolveMessage>) -> napi::Result<()> {
@@ -308,6 +315,7 @@ mod bundle {
   pub fn bundle_async(ctx: CallContext) -> napi::Result<JsObject> {
     let opts = ctx.get::<JsObject>(0)?;
     let visitor = get_visitor(*ctx.env, &opts);
+    let pattern = get_pattern(*ctx.env, &opts);
 
     let config: BundleConfig = ctx.env.from_js_value(&opts)?;
 
@@ -342,10 +350,10 @@ mod bundle {
         inputs: Mutex::new(Vec::new()),
       };
 
-      run_bundle_task(provider, config, visitor, *ctx.env)
+      run_bundle_task(provider, config, visitor, pattern, *ctx.env)
     } else {
       let provider = FileProvider::new();
-      run_bundle_task(provider, config, visitor, *ctx.env)
+      run_bundle_task(provider, config, visitor, pattern, *ctx.env)
     }
   }
 
@@ -357,6 +365,7 @@ mod bundle {
     provider: P,
     config: BundleConfig,
     visitor: Option<JsVisitor>,
+    pattern: Option<JsPattern>,
     env: Env,
   ) -> napi::Result<JsObject>
   where
@@ -406,11 +415,16 @@ mod bundle {
             })
           }
         }),
+        pattern
       );
 
-      deferred.resolve(move |env| match res {
-        Ok(v) => v.into_js(env),
-        Err(err) => Err(err.into_js_error(env, None)?),
+      deferred.resolve(move |env| {
+          let res = match res {
+            Ok(v) => v.into_js(env),
+            Err(err) => Err(err.into_js_error(env, None)?),
+          };
+          println!("res: {}", res.is_ok());
+          res
       });
     });
 
@@ -430,6 +444,7 @@ mod bundle {
   pub fn bundle(ctx: CallContext) -> napi::Result<JsUnknown> {
     let opts = ctx.get::<JsObject>(0)?;
     let mut visitor = get_visitor(*ctx.env, &opts);
+    let pattern = get_pattern(*ctx.env, &opts);
 
     let resolver = get_named_property::<JsObject>(&opts, "resolver")?;
     let read = get_named_property::<JsFunction>(&resolver, "read")?;
@@ -461,6 +476,7 @@ mod bundle {
       &provider,
       &config,
       visitor.as_mut().map(|visitor| annotate(|stylesheet| stylesheet.visit(visitor))),
+      pattern
     );
 
     match res {
@@ -557,6 +573,8 @@ mod bundle {
 #[cfg(feature = "bundler")]
 pub use bundle::*;
 
+use crate::threadsafe_function::{ThreadSafeCallContext, ThreadsafeFunction};
+
 // ---------------------------------------------
 
 #[derive(Debug, Deserialize)]
@@ -607,13 +625,122 @@ enum CssModulesOption {
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct CssModulesConfig {
-  pattern: Option<String>,
   dashed_idents: Option<bool>,
   animation: Option<bool>,
   container: Option<bool>,
   grid: Option<bool>,
   custom_idents: Option<bool>,
   pure: Option<bool>,
+}
+
+enum JsPattern {
+  Simple(String),
+  Provider(PatternProvider)
+}
+
+struct WriteMessage {
+  hash: String,
+  path: PathBuf,
+  local: String,
+  content_hash: Option<String>,
+  tx: Sender<napi::Result<String>>,
+}
+
+struct PatternProvider {
+  resolve: ThreadsafeFunction<WriteMessage>,
+  content_hash: Option<bool>,
+}
+
+impl std::fmt::Debug for PatternProvider {
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    f.debug_struct("PatternProvider")
+      .field("resolve", &"ThreadsafeFunction<PatternMessage>")
+      .field("content_hash", &self.content_hash)
+      .finish()
+  }
+}
+
+impl lightningcss::css_modules::PatternProvider for PatternProvider {
+  fn write(
+      &self,
+      hash: &str,
+      path: &Path,
+      local: &str,
+      content_hash: Option<&str>,
+      dest: &mut dyn std::fmt::Write,
+    ) -> Result<(), std::fmt::Error> {
+    let (tx, rx) = crossbeam_channel::unbounded::<napi::Result<String>>();
+    self.resolve.call(WriteMessage {
+      hash: hash.into(),
+      path: path.into(),
+      local: local.into(),
+      content_hash: content_hash.map(Into::into),
+      tx
+    }, crate::threadsafe_function::ThreadsafeFunctionCallMode::Blocking);
+    dest.write_str(&rx.recv().unwrap().map_err(|_| std::fmt::Error)?)
+  }
+
+  fn needs_content_hash(&self) -> bool {
+      self.content_hash.is_some_and(|v| v)
+  }
+}
+
+fn get_pattern(env: Env, opts: &JsObject) -> Option<JsPattern> {
+  fn write_on_js_thread(ctx: ThreadSafeCallContext<WriteMessage>) -> napi::Result<()> {
+    let hash = ctx.env.create_string(&ctx.value.hash)?;
+    let path = ctx.env.create_string(&ctx.value.path.to_string_lossy())?;
+    let local = ctx.env.create_string(&ctx.value.local)?;
+
+    let result;
+
+    if let Some(content_hash) = ctx.value.content_hash {
+      let content_hash = ctx.env.create_string(&content_hash)?;
+      result = ctx.callback.unwrap().call(None, &[hash, path, local, content_hash])?
+    } else {
+      result = ctx.callback.unwrap().call(None, &[hash, path, local])?
+    }
+
+    await_promise(ctx.env, result, ctx.value.tx, |unknown| {
+      napi::JsString::try_from(unknown)?.into_utf8()?.into_owned()
+    })
+  }
+
+  fn write_on_js_thread_wrapper(ctx: ThreadSafeCallContext<WriteMessage>) -> napi::Result<()> {
+    let tx = ctx.value.tx.clone();
+    handle_error(tx, write_on_js_thread(ctx))
+  }
+
+  let css_modules = get_named_property::<JsObject>(opts, "cssModules").ok()?;
+  let pattern = css_modules.get_named_property::<JsUnknown>("pattern").ok()?;
+  match pattern.get_type().ok()? {
+    napi::ValueType::String => Some(JsPattern::Simple(pattern.coerce_to_string().unwrap().into_utf8().unwrap().into_owned().unwrap())),
+    napi::ValueType::Object => {
+      let mut pattern = pattern.coerce_to_object().unwrap();
+
+      let resolve = get_named_property::<napi::JsFunction>(&pattern, "resolve").ok()?;
+      let resolve = ThreadsafeFunction::create(env.raw(), unsafe { resolve.raw() }, 0, write_on_js_thread_wrapper).ok()?;
+
+      // This is a workaround for a nasty bug caused by napi-rs
+      // When deserializing, each field of an object is eagerly deserialized.
+      // This causes issues when trying to deserialize functions, as those produce an error in the
+      // deserializer. To mitigate, we remove the field before it gets deserialized into the config.
+      // See: https://github.com/napi-rs/napi-rs/blob/b1239101d38c607a9ca427f8a8490a6ee168e91d/crates/napi/src/js_values/de.rs#L346-L363
+      pattern.delete_named_property("resolve").expect("pattern should be removed");
+
+      let content_hash = pattern.get_named_property::<JsUnknown>("contentHash").ok()?;
+      let content_hash = if matches!(content_hash.get_type(), Ok(napi::ValueType::Boolean)) {
+        content_hash.coerce_to_bool().ok().map(|v| v.get_value().ok()).flatten()
+      } else {
+        None
+      };
+
+      Some(JsPattern::Provider(PatternProvider {
+        resolve,
+        content_hash
+      }))
+    }
+    _ => None
+  }
 }
 
 #[cfg(feature = "bundler")]
@@ -681,6 +808,7 @@ fn compile<'i>(
   code: &'i str,
   config: &Config,
   #[allow(unused_variables)] visitor: &mut Option<JsVisitor>,
+  pattern: Option<JsPattern>
 ) -> Result<TransformResult<'i>, CompileError<'i, napi::Error>> {
   let drafts = config.drafts.as_ref();
   let non_standard = config.non_standard.as_ref();
@@ -719,10 +847,13 @@ fn compile<'i>(
             CssModulesOption::Bool(true) => Some(lightningcss::css_modules::Config::default()),
             CssModulesOption::Bool(false) => None,
             CssModulesOption::Config(c) => Some(lightningcss::css_modules::Config {
-              pattern: if let Some(pattern) = c.pattern.as_ref() {
-                match lightningcss::css_modules::Pattern::parse(pattern) {
-                  Ok(p) => p,
-                  Err(e) => return Err(CompileError::PatternError(e)),
+              pattern: if let Some(pattern) = pattern {
+                match pattern {
+                  JsPattern::Simple(ref pattern) => match lightningcss::css_modules::Pattern::parse(pattern) {
+                    Ok(p) => p,
+                    Err(e) => return Err(CompileError::PatternError(e)),
+                  },
+                  JsPattern::Provider(pattern) => lightningcss::css_modules::Pattern::Provider(Arc::new(pattern))
                 }
               } else {
                 Default::default()
@@ -818,6 +949,7 @@ fn compile_bundle<'i, 'o, P: SourceProvider, F: FnOnce(&mut StyleSheet<'i, AtRul
   fs: &'i P,
   config: &'o BundleConfig,
   visit: Option<F>,
+  pattern: Option<JsPattern>
 ) -> Result<TransformResult<'i>, CompileError<'i, P::Error>> {
   use std::path::Path;
 
@@ -850,10 +982,13 @@ fn compile_bundle<'i, 'o, P: SourceProvider, F: FnOnce(&mut StyleSheet<'i, AtRul
           CssModulesOption::Bool(true) => Some(lightningcss::css_modules::Config::default()),
           CssModulesOption::Bool(false) => None,
           CssModulesOption::Config(c) => Some(lightningcss::css_modules::Config {
-            pattern: if let Some(pattern) = c.pattern.as_ref() {
-              match lightningcss::css_modules::Pattern::parse(pattern) {
-                Ok(p) => p,
-                Err(e) => return Err(CompileError::PatternError(e)),
+            pattern: if let Some(pattern) = pattern {
+              match pattern {
+                JsPattern::Simple(ref pattern) => match lightningcss::css_modules::Pattern::parse(pattern) {
+                  Ok(p) => p,
+                  Err(e) => return Err(CompileError::PatternError(e)),
+                },
+                JsPattern::Provider(pattern) => lightningcss::css_modules::Pattern::Provider(Arc::new(pattern))
               }
             } else {
               Default::default()

--- a/napi/src/lib.rs
+++ b/napi/src/lib.rs
@@ -131,7 +131,7 @@ fn handle_error<T>(tx: Sender<napi::Result<T>>, res: napi::Result<()>) -> napi::
 }
 
 fn await_promise<T, Cb>(env: Env, result: JsUnknown, tx: Sender<napi::Result<T>>, parse: Cb) -> napi::Result<()>
-  where
+where
   T: 'static,
   Cb: 'static + Fn(JsUnknown) -> Result<T, napi::Error>,
 {
@@ -167,7 +167,7 @@ mod bundle {
   use crossbeam_channel::{self, Receiver, Sender};
   use lightningcss::bundler::{FileProvider, ResolveResult};
   use napi::{Env, JsFunction, JsString, NapiRaw};
-  use std::path::{Path};
+  use std::path::Path;
   use std::sync::Mutex;
   use threadsafe_function::{ThreadSafeCallContext, ThreadsafeFunction, ThreadsafeFunctionCallMode};
 
@@ -177,7 +177,7 @@ mod bundle {
     let pattern = get_pattern(*ctx.env, &opts);
 
     let config: BundleConfig = ctx.env.from_js_value(opts)?;
-  println!("after js bundle");
+    println!("after js bundle");
     let fs = FileProvider::new();
 
     // This is pretty silly, but works around a rust limitation that you cannot
@@ -193,7 +193,7 @@ mod bundle {
       &fs,
       &config,
       visitor.as_mut().map(|visitor| annotate(|stylesheet| stylesheet.visit(visitor))),
-      pattern
+      pattern,
     );
 
     match res {
@@ -283,7 +283,6 @@ mod bundle {
     stylesheet: &'static mut StyleSheet<'static, AtRule<'static>>,
     tx: Sender<napi::Result<String>>,
   }
-
 
   fn resolve_on_js_thread(ctx: ThreadSafeCallContext<ResolveMessage>) -> napi::Result<()> {
     let specifier = ctx.env.create_string(&ctx.value.specifier)?;
@@ -415,16 +414,16 @@ mod bundle {
             })
           }
         }),
-        pattern
+        pattern,
       );
 
       deferred.resolve(move |env| {
-          let res = match res {
-            Ok(v) => v.into_js(env),
-            Err(err) => Err(err.into_js_error(env, None)?),
-          };
-          println!("res: {}", res.is_ok());
-          res
+        let res = match res {
+          Ok(v) => v.into_js(env),
+          Err(err) => Err(err.into_js_error(env, None)?),
+        };
+        println!("res: {}", res.is_ok());
+        res
       });
     });
 
@@ -476,7 +475,7 @@ mod bundle {
       &provider,
       &config,
       visitor.as_mut().map(|visitor| annotate(|stylesheet| stylesheet.visit(visitor))),
-      pattern
+      pattern,
     );
 
     match res {
@@ -635,7 +634,7 @@ struct CssModulesConfig {
 
 enum JsPattern {
   Simple(String),
-  Provider(PatternProvider)
+  Provider(PatternProvider),
 }
 
 struct WriteMessage {
@@ -662,26 +661,29 @@ impl std::fmt::Debug for PatternProvider {
 
 impl lightningcss::css_modules::PatternProvider for PatternProvider {
   fn write(
-      &self,
-      hash: &str,
-      path: &Path,
-      local: &str,
-      content_hash: Option<&str>,
-      dest: &mut dyn std::fmt::Write,
-    ) -> Result<(), std::fmt::Error> {
+    &self,
+    hash: &str,
+    path: &Path,
+    local: &str,
+    content_hash: Option<&str>,
+    dest: &mut dyn std::fmt::Write,
+  ) -> Result<(), std::fmt::Error> {
     let (tx, rx) = crossbeam_channel::unbounded::<napi::Result<String>>();
-    self.resolve.call(WriteMessage {
-      hash: hash.into(),
-      path: path.into(),
-      local: local.into(),
-      content_hash: content_hash.map(Into::into),
-      tx
-    }, crate::threadsafe_function::ThreadsafeFunctionCallMode::Blocking);
+    self.resolve.call(
+      WriteMessage {
+        hash: hash.into(),
+        path: path.into(),
+        local: local.into(),
+        content_hash: content_hash.map(Into::into),
+        tx,
+      },
+      crate::threadsafe_function::ThreadsafeFunctionCallMode::Blocking,
+    );
     dest.write_str(&rx.recv().unwrap().map_err(|_| std::fmt::Error)?)
   }
 
   fn needs_content_hash(&self) -> bool {
-      self.content_hash.is_some_and(|v| v)
+    self.content_hash.is_some_and(|v| v)
   }
 }
 
@@ -713,12 +715,15 @@ fn get_pattern(env: Env, opts: &JsObject) -> Option<JsPattern> {
   let css_modules = get_named_property::<JsObject>(opts, "cssModules").ok()?;
   let pattern = css_modules.get_named_property::<JsUnknown>("pattern").ok()?;
   match pattern.get_type().ok()? {
-    napi::ValueType::String => Some(JsPattern::Simple(pattern.coerce_to_string().unwrap().into_utf8().unwrap().into_owned().unwrap())),
+    napi::ValueType::String => Some(JsPattern::Simple(
+      pattern.coerce_to_string().unwrap().into_utf8().unwrap().into_owned().unwrap(),
+    )),
     napi::ValueType::Object => {
       let mut pattern = pattern.coerce_to_object().unwrap();
 
       let resolve = get_named_property::<napi::JsFunction>(&pattern, "resolve").ok()?;
-      let resolve = ThreadsafeFunction::create(env.raw(), unsafe { resolve.raw() }, 0, write_on_js_thread_wrapper).ok()?;
+      let resolve =
+        ThreadsafeFunction::create(env.raw(), unsafe { resolve.raw() }, 0, write_on_js_thread_wrapper).ok()?;
 
       // This is a workaround for a nasty bug caused by napi-rs
       // When deserializing, each field of an object is eagerly deserialized.
@@ -734,12 +739,9 @@ fn get_pattern(env: Env, opts: &JsObject) -> Option<JsPattern> {
         None
       };
 
-      Some(JsPattern::Provider(PatternProvider {
-        resolve,
-        content_hash
-      }))
+      Some(JsPattern::Provider(PatternProvider { resolve, content_hash }))
     }
-    _ => None
+    _ => None,
   }
 }
 
@@ -808,7 +810,7 @@ fn compile<'i>(
   code: &'i str,
   config: &Config,
   #[allow(unused_variables)] visitor: &mut Option<JsVisitor>,
-  pattern: Option<JsPattern>
+  pattern: Option<JsPattern>,
 ) -> Result<TransformResult<'i>, CompileError<'i, napi::Error>> {
   let drafts = config.drafts.as_ref();
   let non_standard = config.non_standard.as_ref();
@@ -853,7 +855,7 @@ fn compile<'i>(
                     Ok(p) => p,
                     Err(e) => return Err(CompileError::PatternError(e)),
                   },
-                  JsPattern::Provider(pattern) => lightningcss::css_modules::Pattern::Provider(Arc::new(pattern))
+                  JsPattern::Provider(pattern) => lightningcss::css_modules::Pattern::Provider(Arc::new(pattern)),
                 }
               } else {
                 Default::default()
@@ -949,7 +951,7 @@ fn compile_bundle<'i, 'o, P: SourceProvider, F: FnOnce(&mut StyleSheet<'i, AtRul
   fs: &'i P,
   config: &'o BundleConfig,
   visit: Option<F>,
-  pattern: Option<JsPattern>
+  pattern: Option<JsPattern>,
 ) -> Result<TransformResult<'i>, CompileError<'i, P::Error>> {
   use std::path::Path;
 
@@ -988,7 +990,7 @@ fn compile_bundle<'i, 'o, P: SourceProvider, F: FnOnce(&mut StyleSheet<'i, AtRul
                   Ok(p) => p,
                   Err(e) => return Err(CompileError::PatternError(e)),
                 },
-                JsPattern::Provider(pattern) => lightningcss::css_modules::Pattern::Provider(Arc::new(pattern))
+                JsPattern::Provider(pattern) => lightningcss::css_modules::Pattern::Provider(Arc::new(pattern)),
               }
             } else {
               Default::default()

--- a/napi/src/lib.rs
+++ b/napi/src/lib.rs
@@ -13,12 +13,12 @@ use lightningcss::stylesheet::{
 };
 use lightningcss::targets::{Browsers, Features, Targets};
 use napi::bindgen_prelude::{FromNapiValue, ToNapiValue};
-use napi::{CallContext, Env, JsObject, JsUnknown, NapiRaw, Ref};
+use napi::{CallContext, Env, JsFunction, JsObject, JsString, JsUnknown, NapiRaw, Ref};
 use parcel_sourcemap::SourceMap;
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
-use std::sync::{Arc, RwLock};
+use std::sync::{Arc, OnceLock, RwLock};
 
 mod at_rule_parser;
 #[cfg(not(target_arch = "wasm32"))]
@@ -92,10 +92,9 @@ fn get_visitor(_env: Env, _opts: &JsObject) -> Option<JsVisitor> {
 pub fn transform(ctx: CallContext) -> napi::Result<JsUnknown> {
   let opts = ctx.get::<JsObject>(0)?;
   let mut visitor = get_visitor(*ctx.env, &opts);
-  let pattern = get_pattern(*ctx.env, &opts);
+  let pattern = get_pattern(*ctx.env, &opts)?;
 
   let config: Config = ctx.env.from_js_value(opts)?;
-  println!("after js transform");
   let code = unsafe { std::str::from_utf8_unchecked(&config.code) };
   let res = compile(code, &config, &mut visitor, pattern);
 
@@ -110,7 +109,6 @@ pub fn transform_style_attribute(ctx: CallContext) -> napi::Result<JsUnknown> {
   let mut visitor = get_visitor(*ctx.env, &opts);
 
   let config: AttrConfig = ctx.env.from_js_value(opts)?;
-  println!("after js transform_style_attribute");
   let code = unsafe { std::str::from_utf8_unchecked(&config.code) };
   let res = compile_attr(code, &config, &mut visitor);
 
@@ -139,7 +137,7 @@ where
   // Otherwise, send the result immediately.
   if result.is_promise()? {
     let result: JsObject = result.try_into()?;
-    let then: napi::JsFunction = get_named_property(&result, "then")?;
+    let then: JsFunction = get_named_property(&result, "then")?;
     let tx2 = tx.clone();
     let cb = env.create_function_from_closure("callback", move |ctx| {
       let res = parse(ctx.get::<JsUnknown>(0)?)?;
@@ -174,10 +172,9 @@ mod bundle {
   pub fn bundle(ctx: CallContext) -> napi::Result<JsUnknown> {
     let opts = ctx.get::<JsObject>(0)?;
     let mut visitor = get_visitor(*ctx.env, &opts);
-    let pattern = get_pattern(*ctx.env, &opts);
+    let pattern = get_pattern(*ctx.env, &opts)?;
 
     let config: BundleConfig = ctx.env.from_js_value(opts)?;
-    println!("after js bundle");
     let fs = FileProvider::new();
 
     // This is pretty silly, but works around a rust limitation that you cannot
@@ -314,7 +311,7 @@ mod bundle {
   pub fn bundle_async(ctx: CallContext) -> napi::Result<JsObject> {
     let opts = ctx.get::<JsObject>(0)?;
     let visitor = get_visitor(*ctx.env, &opts);
-    let pattern = get_pattern(*ctx.env, &opts);
+    let pattern = get_pattern(*ctx.env, &opts)?;
 
     let config: BundleConfig = ctx.env.from_js_value(&opts)?;
 
@@ -418,12 +415,10 @@ mod bundle {
       );
 
       deferred.resolve(move |env| {
-        let res = match res {
+        match res {
           Ok(v) => v.into_js(env),
           Err(err) => Err(err.into_js_error(env, None)?),
-        };
-        println!("res: {}", res.is_ok());
-        res
+        }
       });
     });
 
@@ -443,7 +438,7 @@ mod bundle {
   pub fn bundle(ctx: CallContext) -> napi::Result<JsUnknown> {
     let opts = ctx.get::<JsObject>(0)?;
     let mut visitor = get_visitor(*ctx.env, &opts);
-    let pattern = get_pattern(*ctx.env, &opts);
+    let pattern = get_pattern(*ctx.env, &opts)?;
 
     let resolver = get_named_property::<JsObject>(&opts, "resolver")?;
     let read = get_named_property::<JsFunction>(&resolver, "read")?;
@@ -653,7 +648,7 @@ struct PatternProvider {
 impl std::fmt::Debug for PatternProvider {
   fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
     f.debug_struct("PatternProvider")
-      .field("resolve", &"ThreadsafeFunction<PatternMessage>")
+      .field("resolve", &std::any::type_name_of_val(&self.resolve))
       .field("content_hash", &self.content_hash)
       .finish()
   }
@@ -687,7 +682,9 @@ impl lightningcss::css_modules::PatternProvider for PatternProvider {
   }
 }
 
-fn get_pattern(env: Env, opts: &JsObject) -> Option<JsPattern> {
+static RESOLVE_SYMBOL: std::sync::Mutex<OnceLock<Ref<()>>> = std::sync::Mutex::new(OnceLock::new());
+
+fn get_pattern(env: Env, opts: &JsObject) -> napi::Result<Option<JsPattern>> {
   fn write_on_js_thread(ctx: ThreadSafeCallContext<WriteMessage>) -> napi::Result<()> {
     let hash = ctx.env.create_string(&ctx.value.hash)?;
     let path = ctx.env.create_string(&ctx.value.path.to_string_lossy())?;
@@ -712,29 +709,56 @@ fn get_pattern(env: Env, opts: &JsObject) -> Option<JsPattern> {
     handle_error(tx, write_on_js_thread(ctx))
   }
 
-  let css_modules = get_named_property::<JsObject>(opts, "cssModules").ok()?;
-  let pattern = css_modules.get_named_property::<JsUnknown>("pattern").ok()?;
-  match pattern.get_type().ok()? {
+  let Ok(css_modules) = get_named_property::<JsObject>(opts, "cssModules") else {
+    return Ok(None);
+  };
+  let Ok(pattern) = css_modules.get_named_property::<JsUnknown>("pattern") else {
+    return Ok(None);
+  };
+
+  Ok(match pattern.get_type()? {
     napi::ValueType::String => Some(JsPattern::Simple(
-      pattern.coerce_to_string().unwrap().into_utf8().unwrap().into_owned().unwrap(),
+      JsString::try_from(pattern).expect("pattern should be a string").into_utf8().expect("pattern should be UTF-8").into_owned().unwrap(),
     )),
     napi::ValueType::Object => {
-      let mut pattern = pattern.coerce_to_object().unwrap();
+      let mut pattern = JsObject::try_from(pattern).expect("pattern should be an object");
 
-      let resolve = get_named_property::<napi::JsFunction>(&pattern, "resolve").ok()?;
-      let resolve =
-        ThreadsafeFunction::create(env.raw(), unsafe { resolve.raw() }, 0, write_on_js_thread_wrapper).ok()?;
+      let mut reference = RESOLVE_SYMBOL.lock().map_err(|e| napi::Error::new(napi::Status::GenericFailure, e))?;
 
-      // This is a workaround for a nasty bug caused by napi-rs
-      // When deserializing, each field of an object is eagerly deserialized.
-      // This causes issues when trying to deserialize functions, as those produce an error in the
-      // deserializer. To mitigate, we remove the field before it gets deserialized into the config.
-      // See: https://github.com/napi-rs/napi-rs/blob/b1239101d38c607a9ca427f8a8490a6ee168e91d/crates/napi/src/js_values/de.rs#L346-L363
-      pattern.delete_named_property("resolve").expect("pattern should be removed");
+      if reference.get().is_none() {
+        reference.set(env.create_reference(env.create_symbol(Some("__lightningcss_resolve__"))?)?).map_err(|_| ()).expect("RESOLVE_SYMBOL should not be initialized");
+      }
 
-      let content_hash = pattern.get_named_property::<JsUnknown>("contentHash").ok()?;
-      let content_hash = if matches!(content_hash.get_type(), Ok(napi::ValueType::Boolean)) {
-        content_hash.coerce_to_bool().ok().map(|v| v.get_value().ok()).flatten()
+      let reference: &mut napi::Ref<()> = reference.get_mut().expect("RESOLVE_SYMBOL should be initialized");
+
+      reference.reference(&env)?;
+      let symbol = env.get_reference_value::<napi::JsSymbol>(reference)?;
+
+      let resolve = if pattern.has_own_property_js(symbol).is_ok_and(|v| v) {
+        let resolve = pattern.get_property::<_, JsFunction>(symbol)?;
+        ThreadsafeFunction::create(env.raw(), unsafe { resolve.raw() }, 0, write_on_js_thread_wrapper)?
+      } else {
+        let resolve = get_named_property::<JsFunction>(&pattern, "resolve").map_err(|_| napi::Error::from_reason("pattern object should contain a `resolve` field"))?;
+        let func = ThreadsafeFunction::create(env.raw(), unsafe { resolve.raw() }, 0, write_on_js_thread_wrapper)?;
+
+        // This is a workaround for a nasty bug caused by napi-rs
+        // When deserializing, each field of an object is eagerly deserialized.
+        // This causes issues when trying to deserialize functions, as those produce an error in the
+        // deserializer. To mitigate, we move the field to a symbol based key before it gets deserialized into the config.
+        // See: https://github.com/napi-rs/napi-rs/blob/b1239101d38c607a9ca427f8a8490a6ee168e91d/crates/napi/src/js_values/de.rs#L346-L363
+        pattern.delete_named_property("resolve")?;
+        pattern.set_property(symbol, resolve)?;
+        func
+      };
+
+      reference.unref(env)?;
+
+      let content_hash = if let Ok(content_hash) = pattern.get_named_property::<JsUnknown>("contentHash") {
+        if matches!(content_hash.get_type(), Ok(napi::ValueType::Boolean)) {
+          content_hash.coerce_to_bool().ok().map(|v| v.get_value().ok()).flatten()
+        } else {
+          None
+        }
       } else {
         None
       };
@@ -742,7 +766,7 @@ fn get_pattern(env: Env, opts: &JsObject) -> Option<JsPattern> {
       Some(JsPattern::Provider(PatternProvider { resolve, content_hash }))
     }
     _ => None,
-  }
+  })
 }
 
 #[cfg(feature = "bundler")]
@@ -1235,7 +1259,7 @@ impl<'i, E: IntoJsError + std::error::Error> CompileError<'i, E> {
       | CompileError::MinifyError(Error { loc, .. })
       | CompileError::BundleError(Error { loc, .. }) => {
         // Generate an error with location information.
-        let syntax_error = env.get_global()?.get_named_property::<napi::JsFunction>("SyntaxError")?;
+        let syntax_error = env.get_global()?.get_named_property::<JsFunction>("SyntaxError")?;
         let reason = env.create_string_from_std(reason)?;
         let obj = syntax_error.new_instance(&[reason])?;
         (obj.into_unknown(), loc)
@@ -1274,7 +1298,7 @@ trait IntoJsError {
 impl IntoJsError for std::io::Error {
   fn into_js_error(self, env: Env) -> napi::Result<JsUnknown> {
     let reason = self.to_string();
-    let syntax_error = env.get_global()?.get_named_property::<napi::JsFunction>("SyntaxError")?;
+    let syntax_error = env.get_global()?.get_named_property::<JsFunction>("SyntaxError")?;
     let reason = env.create_string_from_std(reason)?;
     let obj = syntax_error.new_instance(&[reason])?;
     Ok(obj.into_unknown())

--- a/napi/src/lib.rs
+++ b/napi/src/lib.rs
@@ -414,11 +414,9 @@ mod bundle {
         pattern,
       );
 
-      deferred.resolve(move |env| {
-        match res {
-          Ok(v) => v.into_js(env),
-          Err(err) => Err(err.into_js_error(env, None)?),
-        }
+      deferred.resolve(move |env| match res {
+        Ok(v) => v.into_js(env),
+        Err(err) => Err(err.into_js_error(env, None)?),
       });
     });
 
@@ -718,15 +716,25 @@ fn get_pattern(env: Env, opts: &JsObject) -> napi::Result<Option<JsPattern>> {
 
   Ok(match pattern.get_type()? {
     napi::ValueType::String => Some(JsPattern::Simple(
-      JsString::try_from(pattern).expect("pattern should be a string").into_utf8().expect("pattern should be UTF-8").into_owned().unwrap(),
+      JsString::try_from(pattern)
+        .expect("pattern should be a string")
+        .into_utf8()
+        .expect("pattern should be UTF-8")
+        .into_owned()
+        .unwrap(),
     )),
     napi::ValueType::Object => {
       let mut pattern = JsObject::try_from(pattern).expect("pattern should be an object");
 
-      let mut reference = RESOLVE_SYMBOL.lock().map_err(|e| napi::Error::new(napi::Status::GenericFailure, e))?;
+      let mut reference = RESOLVE_SYMBOL
+        .lock()
+        .map_err(|e| napi::Error::new(napi::Status::GenericFailure, e))?;
 
       if reference.get().is_none() {
-        reference.set(env.create_reference(env.create_symbol(Some("__lightningcss_resolve__"))?)?).map_err(|_| ()).expect("RESOLVE_SYMBOL should not be initialized");
+        reference
+          .set(env.create_reference(env.create_symbol(Some("__lightningcss_resolve__"))?)?)
+          .map_err(|_| ())
+          .expect("RESOLVE_SYMBOL should not be initialized");
       }
 
       let reference: &mut napi::Ref<()> = reference.get_mut().expect("RESOLVE_SYMBOL should be initialized");
@@ -738,7 +746,8 @@ fn get_pattern(env: Env, opts: &JsObject) -> napi::Result<Option<JsPattern>> {
         let resolve = pattern.get_property::<_, JsFunction>(symbol)?;
         ThreadsafeFunction::create(env.raw(), unsafe { resolve.raw() }, 0, write_on_js_thread_wrapper)?
       } else {
-        let resolve = get_named_property::<JsFunction>(&pattern, "resolve").map_err(|_| napi::Error::from_reason("pattern object should contain a `resolve` field"))?;
+        let resolve = get_named_property::<JsFunction>(&pattern, "resolve")
+          .map_err(|_| napi::Error::from_reason("pattern object should contain a `resolve` field"))?;
         let func = ThreadsafeFunction::create(env.raw(), unsafe { resolve.raw() }, 0, write_on_js_thread_wrapper)?;
 
         // This is a workaround for a nasty bug caused by napi-rs

--- a/node/index.d.ts
+++ b/node/index.d.ts
@@ -314,7 +314,7 @@ export interface Warning {
 
 export interface CSSModulesConfig {
   /** The pattern to use when renaming class names and other identifiers. Default is `[hash]_[local]`. */
-  pattern?: string,
+  pattern?: CSSModulePattern | string,
   /** Whether to rename dashed identifiers, e.g. custom properties. */
   dashedIdents?: boolean,
   /** Whether to enable hashing for `@keyframes`. */
@@ -327,6 +327,13 @@ export interface CSSModulesConfig {
   customIdents?: boolean,
   /** Whether to require at least one class or id selector in each rule. */
   pure?: boolean
+}
+
+export interface CSSModulePattern {
+  /** The function to use to resolve patterns */
+  resolve: (hash: string, path: string, local: string, content_hash?: string) => string,
+  /** Whether to pass in the content_hash param into `resolve`. */
+  content_hash: boolean
 }
 
 export type CSSModuleExports = {

--- a/node/index.d.ts
+++ b/node/index.d.ts
@@ -333,7 +333,7 @@ export interface CSSModulesConfig {
 
 export interface CSSModulePattern {
   /** The function to use to resolve patterns */
-  resolve: (hash: string, path: string, local: string, content_hash?: string) => string,
+  resolve: (hash: string, path: string, local: string, content_hash?: string) => MaybePromise<string>,
   /** Whether to pass in the content_hash param into `resolve`. */
   content_hash: boolean
 }

--- a/src/bundler.rs
+++ b/src/bundler.rs
@@ -106,10 +106,7 @@ pub enum ResolveResult {
   /// An external URL.
   External(String),
   /// A file path.
-  #[cfg_attr(
-    any(feature = "serde", feature = "nodejs"),
-    serde(untagged)
-  )]
+  #[cfg_attr(any(feature = "serde", feature = "nodejs"), serde(untagged))]
   File(PathBuf),
 }
 

--- a/src/css_modules.rs
+++ b/src/css_modules.rs
@@ -23,6 +23,7 @@ use std::collections::HashMap;
 use std::fmt::Write;
 use std::hash::{Hash, Hasher};
 use std::path::Path;
+use std::sync::Arc;
 
 /// Configuration for CSS modules.
 #[derive(Clone, Debug, PartialEq)]
@@ -63,16 +64,47 @@ impl Default for Config {
   }
 }
 
+/// A trait for objects acting like patterns
+pub trait PatternProvider: std::fmt::Debug {
+  /// Write the pattern to a destination.
+  fn write(
+    &self,
+    hash: &str,
+    path: &Path,
+    local: &str,
+    content_hash: Option<&str>,
+    dest: &mut dyn Write,
+  ) -> Result<(), std::fmt::Error>;
+
+  /// Whether the `content-hash` parameter needs to be passed into [write].
+  fn needs_content_hash(&self) -> bool;
+}
+
 /// A CSS modules class name pattern.
-#[derive(Clone, Debug, PartialEq)]
-pub struct Pattern {
-  /// The list of segments in the pattern.
-  pub segments: SmallVec<[Segment; 2]>,
+#[derive(Clone, Debug)]
+pub enum Pattern {
+  /// A string pattern
+  Simple {
+    /// The list of segments in the pattern.
+    segments: SmallVec<[Segment; 2]>,
+  },
+  /// An object acting like a pattern
+  Provider(Arc<dyn PatternProvider + Send + Sync>),
+}
+
+impl PartialEq for Pattern {
+  fn eq(&self, other: &Self) -> bool {
+    match (self, other) {
+      (Self::Simple { segments }, Pattern::Simple { segments: other }) => segments.eq(other),
+      (Self::Provider(this), Pattern::Provider(other)) => Arc::ptr_eq(this, other),
+      _ => false,
+    }
+  }
 }
 
 impl Default for Pattern {
   fn default() -> Self {
-    Pattern {
+    Pattern::Simple {
       segments: smallvec![Segment::Hash, Segment::Literal(Cow::Borrowed("_")), Segment::Local],
     }
   }
@@ -132,51 +164,56 @@ impl Pattern {
       }
     }
 
-    Ok(Pattern { segments })
+    Ok(Pattern::Simple { segments })
   }
 
   /// Whether the pattern contains any `[content-hash]` segments.
   pub fn has_content_hash(&self) -> bool {
-    self.segments.iter().any(|s| matches!(s, Segment::ContentHash))
+    match self {
+      Self::Simple { segments } => segments.iter().any(|s| matches!(s, Segment::ContentHash)),
+      Self::Provider(provider) => provider.needs_content_hash(),
+    }
   }
 
   /// Write the substituted pattern to a destination.
-  pub fn write<W, E>(
+  pub fn write(
     &self,
     hash: &str,
     path: &Path,
     local: &str,
-    content_hash: &str,
-    mut write: W,
-  ) -> Result<(), E>
-  where
-    W: FnMut(&str) -> Result<(), E>,
-  {
-    for segment in &self.segments {
-      match segment {
-        Segment::Literal(s) => {
-          write(s)?;
-        }
-        Segment::Name => {
-          let stem = path.file_stem().unwrap().to_str().unwrap();
-          if stem.contains('.') {
-            write(&stem.replace('.', "-"))?;
-          } else {
-            write(stem)?;
+    content_hash: Option<&str>,
+    dest: &mut dyn Write,
+  ) -> Result<(), std::fmt::Error> {
+    match self {
+      Self::Simple { segments } => {
+        for segment in segments {
+          match segment {
+            Segment::Literal(s) => {
+              dest.write_str(&s)?;
+            }
+            Segment::Name => {
+              let stem = path.file_stem().unwrap().to_str().unwrap();
+              if stem.contains('.') {
+                dest.write_str(&stem.replace('.', "-"))?;
+              } else {
+                dest.write_str(stem)?;
+              }
+            }
+            Segment::Local => {
+              dest.write_str(local)?;
+            }
+            Segment::Hash => {
+              dest.write_str(hash)?;
+            }
+            Segment::ContentHash => {
+              dest.write_str(content_hash.expect("content hash should not be None"))?;
+            }
           }
         }
-        Segment::Local => {
-          write(local)?;
-        }
-        Segment::Hash => {
-          write(hash)?;
-        }
-        Segment::ContentHash => {
-          write(content_hash)?;
-        }
+        Ok(())
       }
+      Self::Provider(provider) => provider.write(hash, path, local, content_hash, dest),
     }
-    Ok(())
   }
 
   #[inline]
@@ -186,9 +223,9 @@ impl Pattern {
     hash: &str,
     path: &Path,
     local: &str,
-    content_hash: &str,
+    content_hash: Option<&str>,
   ) -> Result<String, std::fmt::Error> {
-    self.write(hash, path, local, content_hash, |s| res.write_str(s))?;
+    self.write(hash, path, local, content_hash, &mut res)?;
     Ok(res)
   }
 }
@@ -299,7 +336,10 @@ impl<'a, 'c> CssModule<'a, 'c> {
         };
         hash(
           &source.to_string_lossy(),
-          matches!(config.pattern.segments[0], Segment::Hash),
+          match config.pattern {
+            Pattern::Simple { ref segments } => matches!(segments[0], Segment::Hash),
+            Pattern::Provider(_) => false,
+          },
         )
       })
       .collect();
@@ -325,11 +365,10 @@ impl<'a, 'c> CssModule<'a, 'c> {
             &self.hashes[source_index as usize],
             &self.sources[source_index as usize],
             local,
-            if let Some(content_hashes) = &self.content_hashes {
-              &content_hashes[source_index as usize]
-            } else {
-              ""
-            },
+            self
+              .content_hashes
+              .as_ref()
+              .map(|content_hashes| content_hashes[source_index as usize].as_str()),
           )
           .unwrap(),
         composes: vec![],
@@ -349,11 +388,10 @@ impl<'a, 'c> CssModule<'a, 'c> {
             &self.hashes[source_index as usize],
             &self.sources[source_index as usize],
             &local[2..],
-            if let Some(content_hashes) = &self.content_hashes {
-              &content_hashes[source_index as usize]
-            } else {
-              ""
-            },
+            self
+              .content_hashes
+              .as_ref()
+              .map(|content_hashes| content_hashes[source_index as usize].as_str()),
           )
           .unwrap(),
         composes: vec![],
@@ -376,11 +414,10 @@ impl<'a, 'c> CssModule<'a, 'c> {
               &self.hashes[source_index as usize],
               &self.sources[source_index as usize],
               name,
-              if let Some(content_hashes) = &self.content_hashes {
-                &content_hashes[source_index as usize]
-              } else {
-                ""
-              },
+              self
+                .content_hashes
+                .as_ref()
+                .map(|content_hashes| content_hashes[source_index as usize].as_str()),
             )
             .unwrap(),
           composes: vec![],
@@ -410,11 +447,10 @@ impl<'a, 'c> CssModule<'a, 'c> {
               &self.hashes[*source_index as usize],
               &self.sources[*source_index as usize],
               &name[2..],
-              if let Some(content_hashes) = &self.content_hashes {
-                &content_hashes[*source_index as usize]
-              } else {
-                ""
-              },
+              self
+                .content_hashes
+                .as_ref()
+                .map(|content_hashes| content_hashes[*source_index as usize].as_str()),
             )
             .unwrap(),
         )
@@ -435,11 +471,10 @@ impl<'a, 'c> CssModule<'a, 'c> {
                   &self.hashes[source_index as usize],
                   &self.sources[source_index as usize],
                   &name[2..],
-                  if let Some(content_hashes) = &self.content_hashes {
-                    &content_hashes[source_index as usize]
-                  } else {
-                    ""
-                  },
+                  self
+                    .content_hashes
+                    .as_ref()
+                    .map(|content_hashes| content_hashes[source_index as usize].as_str()),
                 )
                 .unwrap(),
               composes: vec![],
@@ -482,11 +517,10 @@ impl<'a, 'c> CssModule<'a, 'c> {
                       &self.hashes[source_index as usize],
                       &self.sources[source_index as usize],
                       name.0.as_ref(),
-                      if let Some(content_hashes) = &self.content_hashes {
-                        &content_hashes[source_index as usize]
-                      } else {
-                        ""
-                      },
+                      self
+                        .content_hashes
+                        .as_ref()
+                        .map(|content_hashes| content_hashes[source_index as usize].as_str()),
                     )
                     .unwrap(),
                 },

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -296,12 +296,11 @@ impl<'a, 'c, W: std::fmt::Write + Sized> Printer<'a, 'c, W> {
           &css_module.hashes[self.loc.source_index as usize],
           &css_module.sources[self.loc.source_index as usize],
           ident,
-          if let Some(content_hashes) = &css_module.content_hashes {
-            &content_hashes[self.loc.source_index as usize]
-          } else {
-            ""
-          },
-          |s| {
+          css_module
+            .content_hashes
+            .as_ref()
+            .map(|content_hashes| content_hashes[self.loc.source_index as usize].as_str()),
+          &mut FnWriter(|s| {
             self.col += s.len() as u32;
             if first {
               first = false;
@@ -309,7 +308,7 @@ impl<'a, 'c, W: std::fmt::Write + Sized> Printer<'a, 'c, W> {
             } else {
               serialize_name(s, dest)
             }
-          },
+          }),
         )?;
 
         css_module.add_local(&ident, &ident, self.loc.source_index);
@@ -331,15 +330,14 @@ impl<'a, 'c, W: std::fmt::Write + Sized> Printer<'a, 'c, W> {
           &css_module.hashes[self.loc.source_index as usize],
           &css_module.sources[self.loc.source_index as usize],
           &ident[2..],
-          if let Some(content_hashes) = &css_module.content_hashes {
-            &content_hashes[self.loc.source_index as usize]
-          } else {
-            ""
-          },
-          |s| {
+          css_module
+            .content_hashes
+            .as_ref()
+            .map(|content_hashes| content_hashes[self.loc.source_index as usize].as_str()),
+          &mut FnWriter(|s| {
             self.col += s.len() as u32;
             serialize_name(s, dest)
-          },
+          }),
         )?;
 
         if is_declaration {
@@ -417,5 +415,13 @@ impl<'a, 'b, 'c, W: std::fmt::Write + Sized> std::fmt::Write for Printer<'a, 'c,
   fn write_str(&mut self, s: &str) -> std::fmt::Result {
     self.col += s.len() as u32;
     self.dest.write_str(s)
+  }
+}
+
+struct FnWriter<F: FnMut(&str) -> std::fmt::Result>(F);
+
+impl<F: FnMut(&str) -> std::fmt::Result> std::fmt::Write for FnWriter<F> {
+  fn write_str(&mut self, s: &str) -> std::fmt::Result {
+    self.0(s)
   }
 }

--- a/src/properties/grid.rs
+++ b/src/properties/grid.rs
@@ -402,16 +402,20 @@ where
   let css_module_grid_enabled = dest.css_module.as_ref().map_or(false, |css_module| css_module.config.grid);
   if css_module_grid_enabled {
     if let Some(css_module) = &mut dest.css_module {
-      if let Some(last) = css_module.config.pattern.segments.last() {
-        if !matches!(last, crate::css_modules::Segment::Local) {
-          return Err(Error {
-            kind: PrinterErrorKind::InvalidCssModulesPatternInGrid,
-            loc: Some(ErrorLocation {
-              filename: dest.filename().into(),
-              line: dest.loc.line,
-              column: dest.loc.column,
-            }),
-          });
+      // FIXME: I can't think of a good way to do this for a provider pattern, given that its output
+      // is dynamic by its nature
+      if let crate::css_modules::Pattern::Simple { ref segments } = css_module.config.pattern {
+        if let Some(last) = segments.last() {
+          if !matches!(last, crate::css_modules::Segment::Local) {
+            return Err(Error {
+              kind: PrinterErrorKind::InvalidCssModulesPatternInGrid,
+              loc: Some(ErrorLocation {
+                filename: dest.filename().into(),
+                line: dest.loc.line,
+                column: dest.loc.column,
+              }),
+            });
+          }
         }
       }
     }

--- a/src/selector.rs
+++ b/src/selector.rs
@@ -100,10 +100,7 @@ impl<'a, 'i> parcel_selectors::parser::Parser<'i> for SelectorParser<'a, 'i> {
     name: CowRcStr<'i>,
   ) -> Result<PseudoClass<'i>, ParseError<'i, Self::Error>> {
     use PseudoClass::*;
-    let scroll_navigation_controls = self
-      .options
-      .flags
-      .contains(ParserFlags::SCROLL_NAVIGATION_CONTROLS);
+    let scroll_navigation_controls = self.options.flags.contains(ParserFlags::SCROLL_NAVIGATION_CONTROLS);
     let pseudo_class = match_ignore_ascii_case! { &name,
       // https://drafts.csswg.org/selectors-4/#useraction-pseudos
       "hover" => Hover,
@@ -501,7 +498,6 @@ pub enum PseudoClass<'i> {
   /// The [:target-after](https://drafts.csswg.org/css-overflow-5/#selectordef-target-after) pseudo class.
   TargetAfter,
   /// The [:target-within](https://drafts.csswg.org/selectors-4/#the-target-within-pseudo) pseudo class.
-
   TargetWithin,
   /// The [:visited](https://drafts.csswg.org/selectors-4/#visited-pseudo) pseudo class.
   Visited,

--- a/src/stylesheet.rs
+++ b/src/stylesheet.rs
@@ -157,7 +157,11 @@ where
       if config.pattern.has_content_hash() {
         content_hashes = Some(vec![hash(
           &code,
-          matches!(config.pattern.segments[0], crate::css_modules::Segment::ContentHash),
+          if let crate::css_modules::Pattern::Simple { ref segments } = config.pattern {
+            matches!(segments[0], crate::css_modules::Segment::ContentHash)
+          } else {
+            false
+          },
         )]);
       }
     }


### PR DESCRIPTION
The Rust `Pattern` is now an enum that can be either a string or an `Arc<dyn PatternProvider>`, the latter of which implements `write` and `needs_content_hash` (which stands in for the code checking for the inclusion of `[content-hash]` in the pattern.

The only real change on the JS side is that you can pass in an object of the form:
```ts
export interface CSSModulePattern {
  /** The function to use to resolve patterns */
  resolve: (hash: string, path: string, local: string, content_hash?: string) => MaybePromise<string>,
  /** Whether to pass in the content_hash param into `resolve`. */
  content_hash: boolean
}
```
instead of a string into the `cssModules.pattern` field

Resolves: #491