### PR TITLE
perf: improve minification of adjacent conditional rules

### DIFF
--- a/src/rules/mod.rs
+++ b/src/rules/mod.rs
@@ -541,11 +541,68 @@ pub(crate) struct MinifyContext<'a, 'i> {
 }
 
 impl<'i, T: Clone> CssRuleList<'i, T> {
+  fn coalesce_adjacent_conditional_rules(&mut self) {
+    // Merge adjacent conditional rules before minifying their contents. Otherwise,
+    // long runs of identical @media/@supports/@container rules repeatedly re-minify
+    // the accumulated rule list as each block is appended.
+    if self.0.len() < 2
+      || !self.0.windows(2).any(|rules| match (&rules[0], &rules[1]) {
+        (CssRule::Media(a), CssRule::Media(b)) => a.query == b.query,
+        (CssRule::Supports(a), CssRule::Supports(b)) => a.condition == b.condition,
+        (CssRule::Container(a), CssRule::Container(b)) => a.name == b.name && a.condition == b.condition,
+        _ => false,
+      })
+    {
+      return;
+    }
+
+    let mut rules = Vec::with_capacity(self.0.len());
+    for rule in std::mem::take(&mut self.0) {
+      match rule {
+        CssRule::Media(mut media) => {
+          if let Some(CssRule::Media(last_rule)) = rules.last_mut() {
+            if last_rule.query == media.query {
+              last_rule.rules.0.append(&mut media.rules.0);
+              continue;
+            }
+          }
+
+          rules.push(CssRule::Media(media));
+        }
+        CssRule::Supports(mut supports) => {
+          if let Some(CssRule::Supports(last_rule)) = rules.last_mut() {
+            if last_rule.condition == supports.condition {
+              last_rule.rules.0.append(&mut supports.rules.0);
+              continue;
+            }
+          }
+
+          rules.push(CssRule::Supports(supports));
+        }
+        CssRule::Container(mut container) => {
+          if let Some(CssRule::Container(last_rule)) = rules.last_mut() {
+            if last_rule.name == container.name && last_rule.condition == container.condition {
+              last_rule.rules.0.append(&mut container.rules.0);
+              continue;
+            }
+          }
+
+          rules.push(CssRule::Container(container));
+        }
+        rule => rules.push(rule),
+      }
+    }
+
+    self.0 = rules;
+  }
+
   pub(crate) fn minify(
     &mut self,
     context: &mut MinifyContext<'_, 'i>,
     parent_is_unused: bool,
   ) -> Result<(), MinifyError> {
+    self.coalesce_adjacent_conditional_rules();
+
     let mut keyframe_rules = HashMap::new();
     let mut layer_rules = HashMap::new();
     let mut has_layers = false;


### PR DESCRIPTION
## Summary

Optimizes minification for long runs of adjacent conditional rules by coalescing matching `@media`, `@supports`, and `@container` blocks before minifying their contents.

The benchmark added in the prerequisite PR (`stylesheet/transform/conditional-run`) is designed to exercise this path with many adjacent conditional rules that share the same condition.

## Related code

- New pre-pass that coalesces adjacent matching conditional rules before minification: [`src/rules/mod.rs#L544-L604`](https://github.com/parcel-bundler/lightningcss/blob/171fa5d4e804e7d25b583ee79c268f2c80723f73/src/rules/mod.rs#L544-L604)
- Existing merge path that previously re-minified the accumulated conditional block after each append: [`src/rules/mod.rs#L662-L694`](https://github.com/parcel-bundler/lightningcss/blob/171fa5d4e804e7d25b583ee79c268f2c80723f73/src/rules/mod.rs#L662-L694)
- Benchmark case that exercises long adjacent runs of `@media`, `@supports`, and `@container`: [`benches/common/mod.rs#L24-L27`](https://github.com/parcel-bundler/lightningcss/blob/0f446902084bd714f233e2f576a46adbdce87d4d/benches/common/mod.rs#L24-L27), [`benches/common/mod.rs#L191-L247`](https://github.com/parcel-bundler/lightningcss/blob/0f446902084bd714f233e2f576a46adbdce87d4d/benches/common/mod.rs#L191-L247)

## Root cause

`CssRuleList::minify` already merges adjacent conditional rules with the same condition while it drains the rule list. However, when it sees another adjacent matching conditional rule, it appends the new inner rules to the previous block and then immediately calls `minify` on the whole accumulated block again.

For a run like:

```css
@media (min-width: 768px) { .a { ... } }
@media (min-width: 768px) { .b { ... } }
@media (min-width: 768px) { .c { ... } }
```

The old flow effectively did this:

1. minify `.a`
2. append `.b`, then minify `.a + .b` again
3. append `.c`, then minify `.a + .b + .c` again
4. repeat for the rest of the run

That means earlier rules in the run are processed repeatedly. For `n` adjacent blocks with the same condition, the repeated work grows roughly like `1 + 2 + ... + n`, i.e. quadratic behavior in the length of the run.

This is especially expensive for generated CSS, where tools can emit many adjacent `@media`, `@supports`, or `@container` blocks with identical conditions.

## Why this is faster

This PR adds a small pre-pass before the main minification loop:

- scan for adjacent conditional rules with the same condition
- merge only those adjacent matching blocks by appending their inner rule lists
- then run the existing minification logic once on the already-coalesced blocks

After the pre-pass, the example above becomes:

```css
@media (min-width: 768px) {
  .a { ... }
  .b { ... }
  .c { ... }
}
```

Then the inner rules are minified once instead of being re-minified every time another adjacent block is appended. This changes the problematic case from repeated cumulative minification to a single minification pass over the merged contents.

The pre-pass is cheap for the common case: it first checks whether there are any adjacent matching conditional rules, and returns early without allocating when there is nothing to coalesce.

## Correctness / safety

This only coalesces adjacent conditional rules with equivalent conditions:

- `@media`: same media query
- `@supports`: same supports condition
- `@container`: same container name and condition

Because the rules are adjacent and have the same condition, moving their inner rules into a single conditional block preserves cascade order and conditional semantics. Non-adjacent rules are not reordered, and different conditions are not merged.

## Validation

- `cargo check --benches`
- Local Criterion comparison for `stylesheet/transform/conditional-run` showed a large improvement after the optimization.