### PR TITLE
Support for the alpha() relative color function

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19335,8 +19335,8 @@ mod tests {
     );
 
     // Supplementary testing
-    // TODO: 目前的 calc 不支持除数为 0，导致 alpha / 0 报错，而 alpha / 1 可以通过。
-    // 依赖：https://github.com/parcel-bundler/lightningcss/pull/1122
+    // TODO: calc does not support division by zero yet, so `alpha / 0` fails while `alpha / 1` works.
+    // Depends on: https://github.com/parcel-bundler/lightningcss/pull/1122
     // test(
     //   "alpha(from green / calc(alpha / 0))",
     //   "rgb(0, 128, 0)",
@@ -19390,6 +19390,7 @@ mod tests {
     // Supplementary testing
     // nested alpha() precision.
     test("alpha(from alpha(from red / 0.5) / calc(alpha + 0.25))", "#ff0000bf");
+    test("alpha(from alpha(from red / -0.5) / calc(alpha + 0.6))", "#f009");
     test("alpha(from alpha(from green / 0%) / 100%)", "green");
 
     // Unresolved relative colors keep their tokens.
@@ -19432,9 +19433,33 @@ mod tests {
       "color(from alpha(from color(display-p3 1 0 0) / 0.5) display-p3 r g b / alpha)",
       "color(display-p3 1 0 0 / 0.5)",
     );
+    test(
+      "color(from alpha(from red / 1.5) srgb r g b / calc(alpha - 0.2))",
+      "color(srgb 1 0 0 / 0.8)", // alpha = 1 - 0.2
+    );
 
-    // TODO：添加一个带有 fallback 的输出，需要设置浏览器为较旧的版本
-    // 最终输出：.foo{color:#ff0f0e;color:color(display-p3 1 0 0)}
+    // Test in image()
+    minify_test(
+      ".foo { mask: image(alpha(from red / 1))}",
+      ".foo{mask:image(red)}",
+    );
+
+    // Test in linear-gradient()
+    minify_test(
+      ".foo { mask: linear-gradient(90deg, alpha(from red / 0%), red) }",
+      ".foo{mask:linear-gradient(90deg,#f000,red)}",
+    );
+    // Compare relative color
+    // TODO: Support <color-interpolation-method>
+    minify_test(
+      ".foo { mask: linear-gradient(90deg in hsl longer hue, rgb(from red r g b / 0), red) }",
+      ".foo{mask:linear-gradient(90deg in hsl longer hue, #f000, red)}",
+    );
+    minify_test(
+      ".foo { mask: linear-gradient(90deg in hsl longer hue, alpha(from red / 0%), red) }",
+      ".foo{mask:linear-gradient(90deg in hsl longer hue, #f000, red)}",
+    );
+
     minify_test(
       ".foo { color: alpha(from color(display-p3 1 0 0) / 0.5) }",
       ".foo{color:color(display-p3 1 0 0/.5)}",
@@ -21215,6 +21240,36 @@ mod tests {
         ".foo{color:#fff}",
       );
     }
+  }
+
+  #[test]
+  fn test_relative_alpha_color_fallbacks() {
+    prefix_test(
+      ".foo { color: alpha(from color(srgb 1 0 0) / 0.5) }",
+      indoc! { r#"
+        .foo {
+          color: #ff000080;
+          color: color(srgb 1 0 0 / .5);
+        }
+      "#},
+      Browsers {
+        chrome: Some(90 << 16),
+        ..Browsers::default()
+      },
+    );
+    prefix_test(
+      ".foo { color: alpha(from color(display-p3 1 0 0) / 0.5) }",
+      indoc! { r#"
+        .foo {
+          color: #ff0f0e80;
+          color: color(display-p3 1 0 0 / .5);
+        }
+      "#},
+      Browsers {
+        chrome: Some(90 << 16),
+        ..Browsers::default()
+      },
+    );
   }
 
   #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19231,17 +19231,26 @@ mod tests {
 
   #[test]
   fn test_relative_color() {
+    #[track_caller]
     fn test(input: &str, output: &str) {
-      let output = CssColor::parse_string(output)
-        .unwrap()
-        .to_css_string(PrinterOptions {
-          minify: true,
-          ..PrinterOptions::default()
-        })
-        .unwrap();
+      let parsed = match CssColor::parse_string(output) {
+        Ok(c) => c,
+        Err(e) => panic!(
+          "test_relative_color: parse expected output failed\nerror: {e:?}\ninput: {input}\noutput: {output}",
+        ),
+      };
+      let output_css = match parsed.to_css_string(PrinterOptions {
+        minify: true,
+        ..PrinterOptions::default()
+      }) {
+        Ok(s) => s,
+        Err(e) => panic!(
+          "test_relative_color: stringify expected output failed\nerror: {e}\nerror(debug): {e:?}\ninput: {input}\noutput: {output}",
+        ),
+      };
       minify_test(
         &format!(".foo {{ color: {} }}", input),
-        &format!(".foo{{color:{}}}", output),
+        &format!(".foo{{color:{}}}", output_css),
       );
     }
 
@@ -19282,6 +19291,153 @@ mod tests {
     minify_test(
       ".foo{color:lch(from currentColor l c sin(h))}",
       ".foo{color:lch(from currentColor l c sin(h))}",
+    );
+
+    // The following tests were converted from WPT:
+    // https://github.com/web-platform-tests/wpt/blob/master/css/css-color/parsing/alpha-color-parsing-valid.html
+
+    // Basic usage with literal alpha.
+    test("alpha(from red / 0.5)", "rgba(255, 0, 0, 0.5)");
+    test("alpha(from blue / 1)", "rgb(0, 0, 255)");
+    test("alpha(from green / 0)", "rgba(0, 128, 0, 0)");
+
+    // Percentage alpha.
+    test("alpha(from red / 50%)", "rgba(255, 0, 0, 0.5)");
+    test("alpha(from red / 0%)", "rgba(255, 0, 0, 0)");
+    test("alpha(from red / 100%)", "rgb(255, 0, 0)");
+
+    // None alpha.
+    test("alpha(from red / none)", "rgba(255, 0, 0, 0)");
+
+    // Omitted alpha (defaults to origin's alpha).
+    test("alpha(from red)", "rgb(255, 0, 0)");
+    // test() does not support keywords such as currentcolor; change it to minify_test()
+    minify_test(
+      ".foo{color:alpha(from currentcolor)}",
+      ".foo{color:alpha(from currentcolor)}",
+    );
+
+    // Alpha keyword referencing origin's alpha.
+    minify_test(
+      ".foo{color:alpha(from currentcolor / alpha)}",
+      ".foo{color:alpha(from currentcolor / alpha)}",
+    );
+    test("alpha(from rgba(255, 0, 0, 0.8) / alpha)", "rgba(255, 0, 0, 0.8)");
+
+    // Calc with alpha keyword.
+    test(
+      "alpha(from rgba(255, 0, 0, 0.8) / calc(alpha * 0.5))",
+      "rgba(255, 0, 0, 0.4)",
+    );
+    test(
+      "alpha(from rgba(255, 0, 0, 0.8) / calc(alpha + 0.1))",
+      "rgba(255, 0, 0, 0.9)",
+    );
+
+    // Supplementary testing
+    // TODO: 目前的 calc 不支持除数为 0，导致 alpha / 0 报错，而 alpha / 1 可以通过。
+    // 依赖：https://github.com/parcel-bundler/lightningcss/pull/1122
+    // test(
+    //   "alpha(from green / calc(alpha / 0))",
+    //   "rgb(0, 128, 0)",
+    // );
+    test("alpha(from green / calc(alpha / 1))", "rgb(0, 128, 0)");
+
+    // Test sibling-index() and sibling-count()
+    minify_test(
+      ".foo{color:alpha(from green / sibling-index())}",
+      ".foo{color:alpha(from green / sibling-index())}",
+    );
+    minify_test(
+      ".foo{color:alpha(from green / calc(sibling-index() * 0.2))}",
+      ".foo{color:alpha(from green / calc(sibling-index() * .2))}",
+    );
+    minify_test(
+      ".foo{color:alpha(from green / sibling-count())}",
+      ".foo{color:alpha(from green / sibling-count())}",
+    );
+
+    // Nested in other color functions.
+    minify_test(
+      ".foo{color:color-mix(in srgb, alpha(from red / 0.5), blue)}",
+      ".foo{color:#5500aabf}",
+    );
+    test("rgb(from alpha(from red / 0.5) r g b / alpha)", "rgba(255, 0, 0, 0.5)");
+
+    // Other color functions as origin.
+    test("alpha(from color-mix(in srgb, red, blue) / 0.5)", "#80008080");
+    test("alpha(from rgb(from red r g b) / 0.8)", "rgba(255, 0, 0, 0.8)");
+
+    // Non-sRGB color spaces preserved.
+    test(
+      "alpha(from color(display-p3 1 0 0) / 0.5)",
+      "color(display-p3 1 0 0 / 0.5)",
+    );
+    test("alpha(from lab(50 20 -30) / 0.5)", "lab(50% 20 -30 / 0.5)");
+    test("alpha(from oklch(0.5 0.2 120) / 0.5)", "oklch(50% 0.2 120 / 0.5)");
+
+    // System and named colors.
+    // https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Values/system-color#syntax
+    minify_test(
+      ".foo{color:alpha(from ActiveText / 0.5)}",
+      ".foo{color:alpha(from ActiveText / .5)}",
+    );
+
+    // Out-of-range alpha values.
+    test("alpha(from red / 2)", "rgb(255, 0, 0)");
+    test("alpha(from red / -1)", "rgba(255, 0, 0, 0)");
+
+    // Supplementary testing
+    // nested alpha() precision.
+    test("alpha(from alpha(from red / 0.5) / calc(alpha + 0.25))", "#ff0000bf");
+    test("alpha(from alpha(from green / 0%) / 100%)", "green");
+
+    // Unresolved relative colors keep their tokens.
+    minify_test(
+      ".foo{color:rgb(from alpha(from currentColor / 0.5) r g b)}",
+      ".foo{color:rgb(from alpha(from currentColor / .5) r g b)}",
+    );
+    minify_test(
+      ".foo{color:alpha(from red / var(--alpha))}",
+      ".foo{color:alpha(from red / var(--alpha))}",
+    );
+
+    // RGBA origin alpha preserve/replace.
+    test("alpha(from rgba(255, 0, 0, 0.3))", "rgba(255, 0, 0, 0.3)");
+    test("alpha(from rgba(255, 0, 0, 0.3) / 0.8)", "rgba(255, 0, 0, 0.8)");
+
+    // color(srgb) preserves its color space.
+    test("alpha(from color(srgb 1 0 0) / 50%)", "color(srgb 1 0 0 / 0.5)");
+
+    // alpha() nested in more relative color functions.
+    test("hsl(from alpha(from red / 0.5) h s l / alpha)", "rgba(255, 0, 0, 0.5)");
+    test("hwb(from alpha(from red / 0.5) h w b / alpha)", "rgba(255, 0, 0, 0.5)");
+    test(
+      "lab(from alpha(from lab(50% 20 -30) / 0.5) l a b / alpha)",
+      "lab(50% 20 -30 / 0.5)",
+    );
+    test(
+      "lch(from alpha(from lch(50% 20 30) / 0.5) l c h / alpha)",
+      "lch(50% 20 30 / 0.5)",
+    );
+    test(
+      "oklab(from alpha(from oklab(50% 0.2 -0.3) / 0.5) l a b / alpha)",
+      "oklab(50% 0.2 -0.3 / 0.5)",
+    );
+    test(
+      "oklch(from alpha(from oklch(50% 0.2 120) / 0.5) l c h / alpha)",
+      "oklch(50% 0.2 120 / 0.5)",
+    );
+    test(
+      "color(from alpha(from color(display-p3 1 0 0) / 0.5) display-p3 r g b / alpha)",
+      "color(display-p3 1 0 0 / 0.5)",
+    );
+
+    // TODO：添加一个带有 fallback 的输出，需要设置浏览器为较旧的版本
+    // 最终输出：.foo{color:#ff0f0e;color:color(display-p3 1 0 0)}
+    minify_test(
+      ".foo { color: alpha(from color(display-p3 1 0 0) / 0.5) }",
+      ".foo{color:color(display-p3 1 0 0/.5)}",
     );
 
     // The following tests were converted from WPT: https://github.com/web-platform-tests/wpt/blob/master/css/css-color/parsing/relative-color-valid.html
@@ -31140,6 +31296,18 @@ mod tests {
     );
     prefix_test(
       ".foo { color: rgb(from light-dark(yellow, red) r g b / 10%); }",
+      indoc! { r#"
+      .foo {
+        color: var(--lightningcss-light, #ffff001a) var(--lightningcss-dark, #ff00001a);
+      }
+      "#},
+      Browsers {
+        chrome: Some(90 << 16),
+        ..Browsers::default()
+      },
+    );
+    prefix_test(
+      ".foo { color: alpha(from light-dark(yellow, red) / 10%); }",
       indoc! { r#"
       .foo {
         color: var(--lightningcss-light, #ffff001a) var(--lightningcss-dark, #ff00001a);

--- a/src/properties/custom.rs
+++ b/src/properties/custom.rs
@@ -470,7 +470,7 @@ fn try_parse_color_token<'i, 't>(
   input: &mut Parser<'i, 't>,
 ) -> Option<CssColor> {
   match_ignore_ascii_case! { &*f,
-    "rgb" | "rgba" | "hsl" | "hsla" | "hwb" | "lab" | "lch" | "oklab" | "oklch" | "color" | "color-mix" | "light-dark" => {
+    "rgb" | "rgba" | "hsl" | "hsla" | "hwb" | "lab" | "lch" | "oklab" | "oklch" | "color" | "color-mix" | "light-dark" | "alpha" => {
       let s = input.state();
       input.reset(&state);
       if let Ok(color) = CssColor::parse(input) {

--- a/src/values/color.rs
+++ b/src/values/color.rs
@@ -328,6 +328,82 @@ impl CssColor {
     CssColor::RGBA(RGBA::transparent())
   }
 
+  fn alpha(&self) -> Result<f32, ()> {
+    Ok(match self {
+      CssColor::RGBA(rgba) => rgba.alpha_f32(),
+      CssColor::LAB(lab) => match &**lab {
+        LABColor::LAB(lab) => lab.alpha,
+        LABColor::LCH(lch) => lch.alpha,
+        LABColor::OKLAB(lab) => lab.alpha,
+        LABColor::OKLCH(lch) => lch.alpha,
+      },
+      CssColor::Predefined(predefined) => match &**predefined {
+        PredefinedColor::SRGB(rgb) => rgb.alpha,
+        PredefinedColor::SRGBLinear(rgb) => rgb.alpha,
+        PredefinedColor::DisplayP3(rgb) => rgb.alpha,
+        PredefinedColor::A98(rgb) => rgb.alpha,
+        PredefinedColor::ProPhoto(rgb) => rgb.alpha,
+        PredefinedColor::Rec2020(rgb) => rgb.alpha,
+        PredefinedColor::XYZd50(xyz) => xyz.alpha,
+        PredefinedColor::XYZd65(xyz) => xyz.alpha,
+      },
+      CssColor::Float(float) => match &**float {
+        FloatColor::RGB(rgb) => rgb.alpha,
+        FloatColor::HSL(hsl) => hsl.alpha,
+        FloatColor::HWB(hwb) => hwb.alpha,
+      },
+      CssColor::LightDark(..) | CssColor::CurrentColor | CssColor::System(..) => return Err(()),
+    })
+  }
+
+  fn with_alpha(self, alpha: f32) -> CssColor {
+    match self {
+      CssColor::RGBA(rgba) => {
+        // Store as Float to preserve the exact f32 alpha value through subsequent
+        // relative color computations. Going through u8 here would quantize 0.5 to
+        // 128/255 ≈ 0.50196 and accumulate error in nested alpha()/color-mix() calls.
+        let mut rgb = RGB::from(rgba);
+        rgb.alpha = alpha;
+        CssColor::Float(Box::new(FloatColor::RGB(rgb)))
+      }
+      CssColor::LAB(mut lab) => {
+        match &mut *lab {
+          LABColor::LAB(lab) => lab.alpha = alpha,
+          LABColor::LCH(lch) => lch.alpha = alpha,
+          LABColor::OKLAB(lab) => lab.alpha = alpha,
+          LABColor::OKLCH(lch) => lch.alpha = alpha,
+        }
+        CssColor::LAB(lab)
+      }
+      CssColor::Predefined(mut predefined) => {
+        match &mut *predefined {
+          PredefinedColor::SRGB(rgb) => rgb.alpha = alpha,
+          PredefinedColor::SRGBLinear(rgb) => rgb.alpha = alpha,
+          PredefinedColor::DisplayP3(rgb) => rgb.alpha = alpha,
+          PredefinedColor::A98(rgb) => rgb.alpha = alpha,
+          PredefinedColor::ProPhoto(rgb) => rgb.alpha = alpha,
+          PredefinedColor::Rec2020(rgb) => rgb.alpha = alpha,
+          PredefinedColor::XYZd50(xyz) => xyz.alpha = alpha,
+          PredefinedColor::XYZd65(xyz) => xyz.alpha = alpha,
+        }
+        CssColor::Predefined(predefined)
+      }
+      CssColor::Float(mut float) => {
+        match &mut *float {
+          FloatColor::RGB(rgb) => rgb.alpha = alpha,
+          FloatColor::HSL(hsl) => hsl.alpha = alpha,
+          FloatColor::HWB(hwb) => hwb.alpha = alpha,
+        }
+        CssColor::Float(float)
+      }
+      CssColor::LightDark(light, dark) => CssColor::LightDark(
+        Box::new((*light).with_alpha(alpha)),
+        Box::new((*dark).with_alpha(alpha)),
+      ),
+      color => color,
+    }
+  }
+
   /// Converts the color to RGBA.
   pub fn to_rgb(&self) -> Result<CssColor, ()> {
     match self {
@@ -718,6 +794,14 @@ impl RelativeComponentParser {
     }
   }
 
+  fn alpha(alpha: f32) -> Self {
+    Self {
+      names: ("", "", ""),
+      components: (0.0, 0.0, 0.0, alpha),
+      types: (ChannelType::empty(), ChannelType::empty(), ChannelType::empty()),
+    }
+  }
+
   fn get_ident(&self, ident: &str, allowed_types: ChannelType) -> Option<(f32, ChannelType)> {
     if ident.eq_ignore_ascii_case(self.names.0) && allowed_types.intersects(self.types.0) {
       return Some((self.components.0, self.types.0));
@@ -1074,6 +1158,9 @@ fn parse_color_function<'i, 't>(
     "rgb" | "rgba" => {
        parse_rgb(input, &mut parser)
     },
+    "alpha" => {
+      parse_relative_alpha(input)
+    },
     "color-mix" => {
       input.parse_nested_block(parse_color_mix)
     },
@@ -1156,6 +1243,47 @@ fn parse_lch<'i, 't, T: TryFrom<CssColor> + ColorSpace, F: Fn(f32, f32, f32, f32
       Ok(CssColor::LAB(Box::new(lab)))
     })
   })
+}
+
+/// Parses the alpha() function.
+/// alpha() = alpha([from <color>] [ / [<alpha-value> | none] ]? )
+#[inline]
+fn parse_relative_alpha<'i, 't>(input: &mut Parser<'i, 't>) -> Result<CssColor, ParseError<'i, ParserError<'i>>> {
+  // https://drafts.csswg.org/css-color-5/#relative-alpha
+  input.parse_nested_block(|input| {
+    input.expect_ident_matching("from")?;
+    let from = CssColor::parse(input)?;
+    let res = parse_relative_alpha_from(from, input)?;
+    input.expect_exhausted()?;
+    Ok(res)
+  })
+}
+
+#[inline]
+fn parse_relative_alpha_from<'i, 't>(
+  from: CssColor,
+  input: &mut Parser<'i, 't>,
+) -> Result<CssColor, ParseError<'i, ParserError<'i>>> {
+  if let CssColor::LightDark(light, dark) = from {
+    let state = input.state();
+    let light = parse_relative_alpha_from(*light, input)?;
+    input.reset(&state);
+    let dark = parse_relative_alpha_from(*dark, input)?;
+    return Ok(CssColor::LightDark(Box::new(light), Box::new(dark)));
+  }
+
+  let alpha = from.alpha().map_err(|_| input.new_custom_error(ParserError::InvalidValue))?;
+  let alpha = if input.try_parse(|input| input.expect_delim('/')).is_ok() {
+    let parser = ComponentParser {
+      allow_none: true,
+      from: Some(RelativeComponentParser::alpha(alpha)),
+    };
+    parse_number_or_percentage(input, &parser, 1.0)?.clamp(0.0, 1.0)
+  } else {
+    alpha
+  };
+
+  Ok(from.with_alpha(alpha))
 }
 
 #[inline]

--- a/src/values/color.rs
+++ b/src/values/color.rs
@@ -794,7 +794,7 @@ impl RelativeComponentParser {
     }
   }
 
-  fn alpha(alpha: f32) -> Self {
+  fn alpha_only(alpha: f32) -> Self {
     Self {
       names: ("", "", ""),
       components: (0.0, 0.0, 0.0, alpha),
@@ -1272,15 +1272,15 @@ fn parse_relative_alpha_from<'i, 't>(
     return Ok(CssColor::LightDark(Box::new(light), Box::new(dark)));
   }
 
-  let alpha = from.alpha().map_err(|_| input.new_custom_error(ParserError::InvalidValue))?;
+  let from_alpha = from.alpha().map_err(|_| input.new_custom_error(ParserError::InvalidValue))?;
   let alpha = if input.try_parse(|input| input.expect_delim('/')).is_ok() {
     let parser = ComponentParser {
       allow_none: true,
-      from: Some(RelativeComponentParser::alpha(alpha)),
+      from: Some(RelativeComponentParser::alpha_only(from_alpha)),
     };
     parse_number_or_percentage(input, &parser, 1.0)?.clamp(0.0, 1.0)
   } else {
-    alpha
+    from_alpha
   };
 
   Ok(from.with_alpha(alpha))


### PR DESCRIPTION
`alpha() = alpha([from <color>] [ / [<alpha-value> | none] ]? )` 
http://drafts.csswg.org/css-color-5#relative-alpha

Fixes: https://github.com/parcel-bundler/lightningcss/issues/1255