### PR TITLE
fix: correct VendorPrefix for ::-ms-input-placeholder pseudo-element

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7597,6 +7597,20 @@ mod tests {
         Token::SquareBracketBlock,
       )),
     );
+
+    // ::-ms-input-placeholder must round-trip with the -ms- prefix, not -moz-.
+    minify_test(
+      "::-ms-input-placeholder {color: red}",
+      "::-ms-input-placeholder{color:red}",
+    );
+    minify_test(
+      "::-webkit-input-placeholder {color: red}",
+      "::-webkit-input-placeholder{color:red}",
+    );
+    minify_test(
+      "::-moz-placeholder {color: red}",
+      "::-moz-placeholder{color:red}",
+    );
   }
 
   #[test]

--- a/src/selector.rs
+++ b/src/selector.rs
@@ -291,7 +291,7 @@ impl<'a, 'i> parcel_selectors::parser::Parser<'i> for SelectorParser<'a, 'i> {
       "placeholder" => Placeholder(VendorPrefix::None),
       "-webkit-input-placeholder" => Placeholder(VendorPrefix::WebKit),
       "-moz-placeholder" => Placeholder(VendorPrefix::Moz),
-      "-ms-input-placeholder" => Placeholder(VendorPrefix::Moz),
+      "-ms-input-placeholder" => Placeholder(VendorPrefix::Ms),
       "marker" => Marker,
       "backdrop" => Backdrop(VendorPrefix::None),
       "-webkit-backdrop" => Backdrop(VendorPrefix::WebKit),


### PR DESCRIPTION
`src/selector.rs` line 294 maps the `::-ms-input-placeholder` pseudo-element to `VendorPrefix::Moz` instead of `VendorPrefix::Ms` — a copy-paste error from the line above (`-moz-placeholder`).

The serializer at line 1244 branches on the stored prefix:

```rust
Placeholder(prefix) => {
    let vp = write_prefix!(prefix);
    if vp == VendorPrefix::WebKit || vp == VendorPrefix::Ms {
        dest.write_str("input-placeholder")
    } else {
        dest.write_str("placeholder")
    }
}
```

Because the stored prefix is `Moz`, the wrong branch fires: the `-moz-` vendor prefix is written, and `placeholder` (not `input-placeholder`) is appended. Any stylesheet that already contains `::-ms-input-placeholder` is silently rewritten to `::-moz-placeholder` — a completely different selector.

**Repro:**

```css
input::-ms-input-placeholder { color: red; }
```

Before this fix, lightningcss outputs:

```css
input::-moz-placeholder{color:red}
```

After this fix:

```css
input::-ms-input-placeholder{color:red}
```

**Fix:** change `VendorPrefix::Moz` to `VendorPrefix::Ms` on line 294. Three round-trip `minify_test` assertions are added to prevent regression.