### PR TITLE
fix: improve missing native binding error message for arm64 musl

### DIFF
--- a/node/index.js
+++ b/node/index.js
@@ -14,10 +14,29 @@ if (process.platform === 'linux') {
 }
 
 let native;
+let platformKey = parts.join('-');
+let packageName = `lightningcss-${platformKey}`;
+let localName = `../lightningcss.${platformKey}.node`;
 try {
-  native = require(`lightningcss-${parts.join('-')}`);
-} catch (err) {
-  native = require(`../lightningcss.${parts.join('-')}.node`);
+  native = require(packageName);
+} catch (packageError) {
+  try {
+    native = require(localName);
+  } catch (localError) {
+    let error = new Error(
+      `Unable to load the Lightning CSS native binding for ${platformKey}. ` +
+      `Tried ${packageName} and ${localName}. ` +
+      `This usually means the optional dependency for your platform was not installed. ` +
+      `Try reinstalling with optional dependencies enabled, or install ${packageName} directly.\n\n` +
+      `Original errors:\n` +
+      `- ${packageName}: ${packageError.message}\n` +
+      `- ${localName}: ${localError.message}`
+    );
+    error.code = localError.code || packageError.code;
+    error.errors = [packageError, localError];
+    error.cause = packageError;
+    throw error;
+  }
 }
 
 module.exports.transform = wrap(native.transform);

--- a/node/test/native-binding.test.mjs
+++ b/node/test/native-binding.test.mjs
@@ -1,0 +1,47 @@
+import {test} from 'uvu';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import vm from 'node:vm';
+import {fileURLToPath} from 'node:url';
+
+const dirname = path.dirname(fileURLToPath(import.meta.url));
+const indexPath = path.join(dirname, '..', 'index.js');
+const indexSource = fs.readFileSync(indexPath, 'utf8');
+
+function loadWithMissingNativeBinding(platform, arch, family) {
+  let context = {
+    process: {platform, arch},
+    module: {exports: {}},
+    require(name) {
+      if (name === 'detect-libc') {
+        return {MUSL: 'musl', familySync: () => family};
+      }
+
+      let error = new Error(`Cannot find module '${name}'`);
+      error.code = 'MODULE_NOT_FOUND';
+      throw error;
+    }
+  };
+  context.exports = context.module.exports;
+
+  try {
+    vm.runInNewContext(indexSource, context, {filename: indexPath});
+  } catch (err) {
+    return err;
+  }
+
+  throw new Error('Expected native binding load to fail');
+}
+
+test('reports the missing arm64 musl native package', () => {
+  let error = loadWithMissingNativeBinding('linux', 'arm64', 'musl');
+
+  assert.match(error.message, /linux-arm64-musl/);
+  assert.match(error.message, /lightningcss-linux-arm64-musl/);
+  assert.match(error.message, /\.\.\/lightningcss\.linux-arm64-musl\.node/);
+  assert.equal(error.code, 'MODULE_NOT_FOUND');
+  assert.equal(error.errors.length, 2);
+});
+
+test.run();


### PR DESCRIPTION
## Summary
- report the expected native package and local fallback when Lightning CSS cannot load a platform binding
- include the original package and fallback load errors so arm64 musl installs point at `lightningcss-linux-arm64-musl` instead of only `../lightningcss.linux-arm64-musl.node`
- add a loader test that simulates a missing Linux arm64 musl optional dependency

Refs parcel-bundler/lightningcss#1269.

## Test plan
- `node --check node/index.js`
- `node --check node/test/native-binding.test.mjs`
- `npm exec -- uvu node/test native-binding.test.mjs`