### PR TITLE
Fix backdrop-filter prefix being overwritten instead of merged

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28552,6 +28552,199 @@ mod tests {
       },
     );
 
+    // When both standard backdrop-filter and -webkit-backdrop-filter exist
+    // and the browser supports the standard form natively (Chrome 76+),
+    // the -webkit- prefix should be dropped after merging.
+    prefix_test(
+      r#"
+      .foo {
+        backdrop-filter: blur(5px);
+        -webkit-backdrop-filter: blur(5px);
+      }
+      "#,
+      indoc! {r#"
+      .foo {
+        backdrop-filter: blur(5px);
+      }
+      "#},
+      Browsers {
+        chrome: Some(146 << 16),
+        ..Browsers::default()
+      },
+    );
+
+    prefix_test(
+      r#"
+      .foo {
+        -webkit-backdrop-filter: blur(5px);
+        backdrop-filter: blur(5px);
+      }
+      "#,
+      indoc! {r#"
+      .foo {
+        backdrop-filter: blur(5px);
+      }
+      "#},
+      Browsers {
+        chrome: Some(146 << 16),
+        ..Browsers::default()
+      },
+    );
+
+    // For Safari that needs -webkit-backdrop-filter, both should be preserved.
+    prefix_test(
+      r#"
+      .foo {
+        backdrop-filter: blur(5px);
+        -webkit-backdrop-filter: blur(5px);
+      }
+      "#,
+      indoc! {r#"
+      .foo {
+        -webkit-backdrop-filter: blur(5px);
+        backdrop-filter: blur(5px);
+      }
+      "#},
+      Browsers {
+        safari: Some(15 << 16),
+        ..Browsers::default()
+      },
+    );
+
+    prefix_test(
+      r#"
+      .foo {
+        -webkit-backdrop-filter: blur(5px);
+        backdrop-filter: blur(5px);
+      }
+      "#,
+      indoc! {r#"
+      .foo {
+        -webkit-backdrop-filter: blur(5px);
+        backdrop-filter: blur(5px);
+      }
+      "#},
+      Browsers {
+        safari: Some(15 << 16),
+        ..Browsers::default()
+      },
+    );
+
+    // Safari 17 still needs -webkit-backdrop-filter (unprefixed support starts at 18).
+    prefix_test(
+      r#"
+      .foo {
+        -webkit-backdrop-filter: blur(5px);
+        backdrop-filter: blur(5px);
+      }
+      "#,
+      indoc! {r#"
+      .foo {
+        -webkit-backdrop-filter: blur(5px);
+        backdrop-filter: blur(5px);
+      }
+      "#},
+      Browsers {
+        safari: Some(17 << 16),
+        ..Browsers::default()
+      },
+    );
+
+    // Safari 18+ supports unprefixed backdrop-filter natively — prefix is dropped.
+    prefix_test(
+      r#"
+      .foo {
+        -webkit-backdrop-filter: blur(5px);
+        backdrop-filter: blur(5px);
+      }
+      "#,
+      indoc! {r#"
+      .foo {
+        backdrop-filter: blur(5px);
+      }
+      "#},
+      Browsers {
+        safari: Some(18 << 16),
+        ..Browsers::default()
+      },
+    );
+
+    // Same prefix merging for filter property.
+    prefix_test(
+      r#"
+      .foo {
+        filter: blur(5px);
+        -webkit-filter: blur(5px);
+      }
+      "#,
+      indoc! {r#"
+      .foo {
+        filter: blur(5px);
+      }
+      "#},
+      Browsers {
+        chrome: Some(146 << 16),
+        ..Browsers::default()
+      },
+    );
+
+    prefix_test(
+      r#"
+      .foo {
+        -webkit-filter: blur(5px);
+        filter: blur(5px);
+      }
+      "#,
+      indoc! {r#"
+      .foo {
+        filter: blur(5px);
+      }
+      "#},
+      Browsers {
+        chrome: Some(146 << 16),
+        ..Browsers::default()
+      },
+    );
+
+    // For Safari that needs -webkit-filter, both should be preserved.
+    prefix_test(
+      r#"
+      .foo {
+        filter: blur(5px);
+        -webkit-filter: blur(5px);
+      }
+      "#,
+      indoc! {r#"
+      .foo {
+        -webkit-filter: blur(5px);
+        filter: blur(5px);
+      }
+      "#},
+      Browsers {
+        safari: Some(9 << 16),
+        ..Browsers::default()
+      },
+    );
+
+    prefix_test(
+      r#"
+      .foo {
+        -webkit-filter: blur(5px);
+        filter: blur(5px);
+      }
+      "#,
+      indoc! {r#"
+      .foo {
+        -webkit-filter: blur(5px);
+        filter: blur(5px);
+      }
+      "#},
+      Browsers {
+        safari: Some(9 << 16),
+        ..Browsers::default()
+      },
+    );
+
     prefix_test(
       ".foo { filter: var(--foo) }",
       indoc! { r#"

--- a/src/prefixes.rs
+++ b/src/prefixes.rs
@@ -545,17 +545,17 @@ impl Feature {
       }
       Feature::BackdropFilter => {
         if let Some(version) = browsers.edge {
-          if version >= 1114112 && version <= 1179648 {
+          if version >= 17 << 16 && version <= 18 << 16 {
             prefixes |= VendorPrefix::WebKit;
           }
         }
         if let Some(version) = browsers.ios_saf {
-          if version >= 589824 && version <= 1115648 {
+          if version >= 9 << 16 && version < 18 << 16 {
             prefixes |= VendorPrefix::WebKit;
           }
         }
         if let Some(version) = browsers.safari {
-          if version >= 589824 && version <= 1115648 {
+          if version >= 9 << 16 && version < 18 << 16 {
             prefixes |= VendorPrefix::WebKit;
           }
         }

--- a/src/properties/prefix_handler.rs
+++ b/src/properties/prefix_handler.rs
@@ -117,6 +117,12 @@ macro_rules! define_fallbacks {
                 pastey::paste! { self.[<$name:snake>] = Some(dest.len()) };
                 dest.push(Property::$name(val $(, $p)?));
               } else if let Some(index) = pastey::paste! { self.[<$name:snake>] } {
+                $(
+                  if let Property::$name(_, cur_p) = &dest[index] {
+                    $p |= *cur_p;
+                  }
+                  $p = context.targets.prefixes($p, Feature::$name);
+                )?
                 dest[index] = Property::$name(val $(, $p)?);
               }
             }


### PR DESCRIPTION
When both `backdrop-filter` and `-webkit-backdrop-filter` appear in the same rule, the FallbackHandler previously overwrote the vendor prefix of the first occurrence with the second. This caused the standard declaration to be lost on Chromium and Safari 18+ targets which do not support the WebKit-prefixed variant.

Merge prefixes from both declarations and re-resolve against browser targets so that only needed prefixes are emitted. Also fix the Safari upper bound from 17.6 to 18 to cover all versions that require the -webkit- prefix.