### PR TITLE
fix: preserve light-dark in custom properties

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -182,6 +182,21 @@ impl<'i, 'o> PropertyHandlerContext<'i, 'o> {
     }
   }
 
+  pub fn remove_conditional_property(&mut self, property_id: &crate::properties::PropertyId) {
+    for entry in &mut self.supports {
+      let declarations = if self.is_important {
+        &mut entry.important_declarations
+      } else {
+        &mut entry.declarations
+      };
+      declarations.retain(|property| property.property_id() != *property_id);
+    }
+
+    self
+      .supports
+      .retain(|entry| !entry.declarations.is_empty() || !entry.important_declarations.is_empty());
+  }
+
   pub fn add_unparsed_fallbacks(&mut self, unparsed: &mut UnparsedProperty<'i>) {
     if self.context != DeclarationContext::StyleRule && self.context != DeclarationContext::StyleAttribute {
       return;

--- a/src/declaration.rs
+++ b/src/declaration.rs
@@ -626,6 +626,7 @@ impl<'i> DeclarationHandler<'i> {
           if self.decls[*index] == *property {
             return true;
           }
+          context.remove_conditional_property(&PropertyId::Custom(custom.name.clone()));
           let mut custom = custom.clone();
           self.add_conditional_fallbacks(&mut custom, context);
           self.decls[*index] = Property::Custom(custom);
@@ -679,8 +680,19 @@ impl<'i> DeclarationHandler<'i> {
     context: &mut PropertyHandlerContext<'i, '_>,
   ) {
     if context.context != DeclarationContext::Keyframes {
+      let light_dark_fallbacks = custom.value.get_light_dark_fallbacks(context.targets);
       let fallbacks = custom.value.get_fallbacks(context.targets);
       for (condition, fallback) in fallbacks {
+        context.add_conditional_property(
+          condition,
+          Property::Custom(CustomProperty {
+            name: custom.name.clone(),
+            value: fallback,
+          }),
+        );
+      }
+
+      for (condition, fallback) in light_dark_fallbacks {
         context.add_conditional_property(
           condition,
           Property::Custom(CustomProperty {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31404,8 +31404,15 @@ mod tests {
       "#,
       indoc! { r#"
       :root {
-        --background: light-dark(#fff, #000);
-        --text: light-dark(#000, #fff);
+        --background: var(--lightningcss-light, #fff) var(--lightningcss-dark, #000);
+        --text: var(--lightningcss-light, #000) var(--lightningcss-dark, #fff);
+      }
+
+      @supports (color: light-dark(#000, #fff)) {
+        :root {
+          --background: light-dark(#fff, #000);
+          --text: light-dark(#000, #fff);
+        }
       }
 
       p {
@@ -31425,7 +31432,43 @@ mod tests {
       ".foo { --theme: light-dark(var(--light), var(--dark)); }",
       indoc! { r#"
       .foo {
-        --theme: light-dark(var(--light), var(--dark));
+        --theme: var(--lightningcss-light, var(--light)) var(--lightningcss-dark, var(--dark));
+      }
+
+      @supports (color: light-dark(#000, #fff)) {
+        .foo {
+          --theme: light-dark(var(--light), var(--dark));
+        }
+      }
+      "#},
+      Browsers {
+        chrome: Some(90 << 16),
+        ..Browsers::default()
+      },
+    );
+    prefix_test(
+      ".foo { --theme: light-dark(white, black); --theme: red; }",
+      indoc! { r#"
+      .foo {
+        --theme: red;
+      }
+      "#},
+      Browsers {
+        chrome: Some(90 << 16),
+        ..Browsers::default()
+      },
+    );
+    prefix_test(
+      ".foo { --theme: red; --theme: light-dark(white, black); }",
+      indoc! { r#"
+      .foo {
+        --theme: var(--lightningcss-light, #fff) var(--lightningcss-dark, #000);
+      }
+
+      @supports (color: light-dark(#000, #fff)) {
+        .foo {
+          --theme: light-dark(#fff, #000);
+        }
       }
       "#},
       Browsers {
@@ -31437,12 +31480,80 @@ mod tests {
       ".foo { --theme: light-dark(white, black); color: light-dark(white, black); }",
       indoc! { r#"
       .foo {
-        --theme: light-dark(#fff, #000);
+        --theme: var(--lightningcss-light, #fff) var(--lightningcss-dark, #000);
         color: var(--lightningcss-light, #fff) var(--lightningcss-dark, #000);
+      }
+
+      @supports (color: light-dark(#000, #fff)) {
+        .foo {
+          --theme: light-dark(#fff, #000);
+        }
       }
       "#},
       Targets {
         include: Features::LightDark,
+        ..Targets::default()
+      },
+    );
+    nesting_test_with_targets(
+      ".foo { --theme: light-dark(lab(0% 0 0), lab(100% 0 0)); }",
+      indoc! { r#"
+      .foo {
+        --theme: var(--lightningcss-light, #000) var(--lightningcss-dark, #fff);
+      }
+
+      @supports (color: lab(0% 0 0)) {
+        .foo {
+          --theme: var(--lightningcss-light, lab(0% 0 0)) var(--lightningcss-dark, lab(100% 0 0));
+        }
+      }
+
+      @supports (color: light-dark(#000, #fff)) {
+        .foo {
+          --theme: light-dark(#000, #fff);
+        }
+      }
+
+      @supports (color: light-dark(#000, #fff)) and (color: lab(0% 0 0)) {
+        .foo {
+          --theme: light-dark(lab(0% 0 0), lab(100% 0 0));
+        }
+      }
+      "#},
+      Targets {
+        browsers: Some(Browsers {
+          chrome: Some(90 << 16),
+          ..Browsers::default()
+        }),
+        include: Features::LightDark | Features::LabColors,
+        ..Targets::default()
+      },
+    );
+    nesting_test_with_targets(
+      ".foo { --theme: light-dark(lab(0% 0 0), lab(100% 0 0)); --theme: red; }",
+      indoc! { r#"
+      .foo {
+        --theme: red;
+      }
+      "#},
+      Targets {
+        browsers: Some(Browsers {
+          chrome: Some(90 << 16),
+          ..Browsers::default()
+        }),
+        include: Features::LightDark | Features::LabColors,
+        ..Targets::default()
+      },
+    );
+    nesting_test_with_targets(
+      ".foo { --theme: light-dark(white, black); }",
+      indoc! { r#"
+      .foo {
+        --theme: light-dark(#fff, #000);
+      }
+      "#},
+      Targets {
+        exclude: Features::LightDark,
         ..Targets::default()
       },
     );
@@ -31708,6 +31819,67 @@ mod tests {
       Browsers {
         chrome: Some(4 << 16),
         ..Browsers::default()
+      },
+    );
+
+    nesting_test_with_targets(
+      r#"
+      @supports (--theme: light-dark(red, blue)) {
+        .foo {
+          color: light-dark(white, black);
+        }
+      }
+      "#,
+      indoc! {r#"
+      @supports (--theme: light-dark(red, blue)) {
+        .foo {
+          color: var(--lightningcss-light, #fff) var(--lightningcss-dark, #000);
+        }
+      }
+      "#},
+      Targets {
+        include: Features::LightDark,
+        ..Targets::default()
+      },
+    );
+    nesting_test_with_targets(
+      r#"
+      @supports (color: var(--theme, light-dark(red, blue))) {
+        .foo {
+          color: light-dark(white, black);
+        }
+      }
+      "#,
+      indoc! {r#"
+      @supports (color: var(--theme, light-dark(red, blue))) {
+        .foo {
+          color: var(--lightningcss-light, #fff) var(--lightningcss-dark, #000);
+        }
+      }
+      "#},
+      Targets {
+        include: Features::LightDark,
+        ..Targets::default()
+      },
+    );
+    nesting_test_with_targets(
+      r#"
+      @supports (color: attr(data-theme type(<color>), light-dark(red, blue))) {
+        .foo {
+          color: light-dark(white, black);
+        }
+      }
+      "#,
+      indoc! {r#"
+      @supports (color: attr(data-theme type(<color>), light-dark(red, blue))) {
+        .foo {
+          color: var(--lightningcss-light, #fff) var(--lightningcss-dark, #000);
+        }
+      }
+      "#},
+      Targets {
+        include: Features::LightDark,
+        ..Targets::default()
       },
     );
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30108,6 +30108,46 @@ mod tests {
     "#,
       "@property --property-name{syntax:\"<color>\";inherits:true;initial-value:#00f}.foo{color:var(--property-name)}",
     );
+    prefix_test(
+      r#"
+      @property --theme {
+        syntax: "<color>";
+        inherits: true;
+        initial-value: light-dark(white, black);
+      }
+      "#,
+      indoc! { r#"
+      @property --theme {
+        syntax: "<color>";
+        inherits: true;
+        initial-value: light-dark(#fff, #000);
+      }
+      "#},
+      Browsers {
+        chrome: Some(90 << 16),
+        ..Browsers::default()
+      },
+    );
+    nesting_test_with_targets(
+      r#"
+      @property --theme {
+        syntax: "<color>";
+        inherits: true;
+        initial-value: light-dark(white, black);
+      }
+      "#,
+      indoc! { r#"
+      @property --theme {
+        syntax: "<color>";
+        inherits: true;
+        initial-value: light-dark(#fff, #000);
+      }
+      "#},
+      Targets {
+        include: Features::LightDark,
+        ..Targets::default()
+      },
+    );
 
     test(
       r#"
@@ -31347,6 +31387,63 @@ mod tests {
       Browsers {
         chrome: Some(90 << 16),
         ..Browsers::default()
+      },
+    );
+    prefix_test(
+      r#"
+      :root {
+        --background: light-dark(white, black);
+        --text: light-dark(black, white);
+      }
+
+      p {
+        color: var(--text);
+        background: var(--background);
+        color-scheme: dark;
+      }
+      "#,
+      indoc! { r#"
+      :root {
+        --background: light-dark(#fff, #000);
+        --text: light-dark(#000, #fff);
+      }
+
+      p {
+        color: var(--text);
+        background: var(--background);
+        --lightningcss-light: ;
+        --lightningcss-dark: initial;
+        color-scheme: dark;
+      }
+      "#},
+      Browsers {
+        chrome: Some(90 << 16),
+        ..Browsers::default()
+      },
+    );
+    prefix_test(
+      ".foo { --theme: light-dark(var(--light), var(--dark)); }",
+      indoc! { r#"
+      .foo {
+        --theme: light-dark(var(--light), var(--dark));
+      }
+      "#},
+      Browsers {
+        chrome: Some(90 << 16),
+        ..Browsers::default()
+      },
+    );
+    nesting_test_with_targets(
+      ".foo { --theme: light-dark(white, black); color: light-dark(white, black); }",
+      indoc! { r#"
+      .foo {
+        --theme: light-dark(#fff, #000);
+        color: var(--lightningcss-light, #fff) var(--lightningcss-dark, #000);
+      }
+      "#},
+      Targets {
+        include: Features::LightDark,
+        ..Targets::default()
       },
     );
     prefix_test(

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -5,7 +5,7 @@ use crate::dependencies::{Dependency, DependencyOptions};
 use crate::error::{Error, ErrorLocation, PrinterError, PrinterErrorKind};
 use crate::rules::{Location, StyleContext};
 use crate::selector::SelectorList;
-use crate::targets::{Targets, TargetsWithSupportsScope};
+use crate::targets::{Features, Targets, TargetsWithSupportsScope};
 use crate::vendor_prefix::VendorPrefix;
 use cssparser::{serialize_identifier, serialize_name};
 #[cfg(feature = "sourcemap")]
@@ -405,6 +405,19 @@ impl<'a, 'c, W: std::fmt::Write + Sized> Printer<'a, 'c, W> {
     }
     let res = f(self);
     self.context = parent;
+    res
+  }
+
+  pub(crate) fn with_feature_disabled<T, U, F: FnOnce(&mut Printer<'a, 'c, W>) -> Result<T, U>>(
+    &mut self,
+    feature: Features,
+    f: F,
+  ) -> Result<T, U> {
+    let targets = self.targets.current;
+    self.targets.current.include.remove(feature);
+    self.targets.current.exclude.insert(feature);
+    let res = f(self);
+    self.targets.current = targets;
     res
   }
 

--- a/src/properties/custom.rs
+++ b/src/properties/custom.rs
@@ -485,15 +485,6 @@ fn try_parse_color_token<'i, 't>(
 }
 
 impl<'i> TokenList<'i> {
-  pub(crate) fn to_css_custom_property<W>(&self, dest: &mut Printer<W>) -> Result<(), PrinterError>
-  where
-    W: std::fmt::Write,
-  {
-    // The var()-based light-dark() fallback is resolved when a custom property is
-    // computed, so it cannot respond to a color-scheme set on a descendant.
-    dest.with_feature_disabled(Features::LightDark, |dest| self.to_css(dest, true))
-  }
-
   pub(crate) fn to_css<W>(&self, dest: &mut Printer<W>, is_custom_property: bool) -> Result<(), PrinterError>
   where
     W: std::fmt::Write,
@@ -1058,6 +1049,53 @@ impl<'i> TokenList<'i> {
     TokenList(tokens)
   }
 
+  pub(crate) fn light_dark_supports_condition() -> SupportsCondition<'i> {
+    SupportsCondition::Declaration {
+      property_id: PropertyId::Color,
+      value: "light-dark(#000, #fff)".into(),
+    }
+  }
+
+  pub(crate) fn light_dark_supports_conditions() -> [SupportsCondition<'i>; 3] {
+    let light_dark = Self::light_dark_supports_condition();
+    let mut p3 = light_dark.clone();
+    p3.and(&ColorFallbackKind::P3.supports_condition());
+    let mut lab = light_dark.clone();
+    lab.and(&ColorFallbackKind::LAB.supports_condition());
+    [light_dark, p3, lab]
+  }
+
+  pub(crate) fn get_light_dark_fallbacks(&self, targets: Targets) -> Vec<(SupportsCondition<'i>, Self)> {
+    if !should_compile!(targets, LightDark) || !self.get_features().contains(Features::LightDark) {
+      return Vec::new();
+    }
+
+    let mut fallbacks = self.get_necessary_fallbacks(targets);
+    let lowest_fallback = fallbacks.lowest();
+    fallbacks.remove(lowest_fallback);
+
+    let mut res = vec![(
+      Self::light_dark_supports_condition(),
+      if lowest_fallback.is_empty() {
+        self.clone()
+      } else {
+        self.get_fallback(lowest_fallback)
+      },
+    )];
+
+    if fallbacks.contains(ColorFallbackKind::P3) {
+      let [_, condition, _] = Self::light_dark_supports_conditions();
+      res.push((condition, self.get_fallback(ColorFallbackKind::P3)));
+    }
+
+    if fallbacks.contains(ColorFallbackKind::LAB) {
+      let [_, _, condition] = Self::light_dark_supports_conditions();
+      res.push((condition, self.get_fallback(ColorFallbackKind::LAB)));
+    }
+
+    res
+  }
+
   pub(crate) fn get_fallbacks(&mut self, targets: Targets) -> Vec<(SupportsCondition<'i>, Self)> {
     // Get the full list of possible fallbacks, and remove the lowest one, which will replace
     // the original declaration. The remaining fallbacks need to be added as @supports rules.
@@ -1098,6 +1136,14 @@ impl<'i> TokenList<'i> {
   }
 
   pub(crate) fn get_features(&self) -> Features {
+    self.get_features_internal(true)
+  }
+
+  pub(crate) fn get_features_for_supports(&self) -> Features {
+    self.get_features_internal(false)
+  }
+
+  fn get_features_internal(&self, include_variable_fallbacks: bool) -> Features {
     let mut features = Features::empty();
     for token in &self.0 {
       match token {
@@ -1109,21 +1155,23 @@ impl<'i> TokenList<'i> {
           match unresolved_color {
             UnresolvedColor::LightDark { light, dark } => {
               features |= Features::LightDark;
-              features |= light.get_features();
-              features |= dark.get_features();
+              features |= light.get_features_internal(include_variable_fallbacks);
+              features |= dark.get_features_internal(include_variable_fallbacks);
             }
             _ => {}
           }
         }
         TokenOrValue::Function(f) => {
-          features |= f.arguments.get_features();
+          if include_variable_fallbacks || !f.name.0.eq_ignore_ascii_case("attr") {
+            features |= f.arguments.get_features_internal(include_variable_fallbacks);
+          }
         }
-        TokenOrValue::Var(v) => {
+        TokenOrValue::Var(v) if include_variable_fallbacks => {
           if let Some(fallback) = &v.fallback {
             features |= fallback.get_features();
           }
         }
-        TokenOrValue::Env(v) => {
+        TokenOrValue::Env(v) if include_variable_fallbacks => {
           if let Some(fallback) = &v.fallback {
             features |= fallback.get_features();
           }

--- a/src/properties/custom.rs
+++ b/src/properties/custom.rs
@@ -485,6 +485,15 @@ fn try_parse_color_token<'i, 't>(
 }
 
 impl<'i> TokenList<'i> {
+  pub(crate) fn to_css_custom_property<W>(&self, dest: &mut Printer<W>) -> Result<(), PrinterError>
+  where
+    W: std::fmt::Write,
+  {
+    // The var()-based light-dark() fallback is resolved when a custom property is
+    // computed, so it cannot respond to a color-scheme set on a descendant.
+    dest.with_feature_disabled(Features::LightDark, |dest| self.to_css(dest, true))
+  }
+
   pub(crate) fn to_css<W>(&self, dest: &mut Printer<W>, is_custom_property: bool) -> Result<(), PrinterError>
   where
     W: std::fmt::Write,

--- a/src/properties/mod.rs
+++ b/src/properties/mod.rs
@@ -787,7 +787,11 @@ macro_rules! define_properties {
             unparsed.value.to_css(dest, false)
           }
           Custom(custom) => {
-            custom.value.to_css(dest, matches!(custom.name, CustomPropertyName::Custom(..)))
+            if matches!(custom.name, CustomPropertyName::Custom(..)) {
+              custom.value.to_css_custom_property(dest)
+            } else {
+              custom.value.to_css(dest, false)
+            }
           }
         }
       }

--- a/src/properties/mod.rs
+++ b/src/properties/mod.rs
@@ -787,11 +787,7 @@ macro_rules! define_properties {
             unparsed.value.to_css(dest, false)
           }
           Custom(custom) => {
-            if matches!(custom.name, CustomPropertyName::Custom(..)) {
-              custom.value.to_css_custom_property(dest)
-            } else {
-              custom.value.to_css(dest, false)
-            }
+            custom.value.to_css(dest, matches!(custom.name, CustomPropertyName::Custom(..)))
           }
         }
       }

--- a/src/rules/container.rs
+++ b/src/rules/container.rs
@@ -489,10 +489,7 @@ impl<'a, 'i, T: ToCss> ToCss for ContainerRule<'i, T> {
 
     if let Some(condition) = &self.condition {
       // Don't downlevel range syntax in container queries.
-      let exclude = dest.targets.current.exclude;
-      dest.targets.current.exclude.insert(Features::MediaQueries);
-      condition.to_css(dest)?;
-      dest.targets.current.exclude = exclude;
+      dest.with_feature_disabled(Features::MediaQueries, |dest| condition.to_css(dest))?;
     }
 
     dest.whitespace()?;

--- a/src/rules/property.rs
+++ b/src/rules/property.rs
@@ -7,6 +7,7 @@ use crate::{
   error::{ParserError, PrinterError},
   printer::Printer,
   properties::custom::TokenList,
+  targets::Features,
   traits::{Parse, ToCss},
   values::{
     ident::DashedIdent,
@@ -142,7 +143,7 @@ impl<'i> ToCss for PropertyRule<'i> {
 
       dest.write_str("initial-value:")?;
       dest.whitespace()?;
-      initial_value.to_css(dest)?;
+      dest.with_feature_disabled(Features::LightDark, |dest| initial_value.to_css(dest))?;
 
       if !dest.minify {
         dest.write_char(';')?;

--- a/src/rules/supports.rs
+++ b/src/rules/supports.rs
@@ -172,11 +172,17 @@ impl<'i> SupportsCondition<'i> {
     fn get_supported_features_internal(value: &SupportsCondition) -> Option<Features> {
       match value {
         SupportsCondition::And(list) => list.iter().map(|c| get_supported_features_internal(c)).try_union_all(),
-        SupportsCondition::Declaration { value, .. } => {
+        SupportsCondition::Declaration { property_id, value } => {
+          // Custom properties accept arbitrary token streams, and unknown properties
+          // make the condition false. Neither case proves support for features in the value.
+          if matches!(property_id, PropertyId::Custom(_)) {
+            return Some(Features::empty());
+          }
+
           let mut input = ParserInput::new(&value);
           let mut parser = Parser::new(&mut input);
           if let Ok(tokens) = TokenList::parse(&mut parser, &Default::default(), 0) {
-            Some(tokens.get_features())
+            Some(tokens.get_features_for_supports())
           } else {
             Some(Features::empty())
           }

--- a/src/targets.rs
+++ b/src/targets.rs
@@ -255,7 +255,7 @@ impl Targets {
 
 #[derive(Debug)]
 pub(crate) struct TargetsWithSupportsScope {
-  stack: Vec<Features>,
+  stack: Vec<(Features, Features)>,
   pub(crate) current: Targets,
 }
 
@@ -269,21 +269,27 @@ impl TargetsWithSupportsScope {
 
   /// Returns true if inserted
   pub fn enter_supports(&mut self, features: Features) -> bool {
-    if features.is_empty() || self.current.exclude.contains(features) {
-      // Already excluding all features
+    if features.is_empty() {
       return false;
     }
 
     let newly_excluded = features - self.current.exclude;
-    self.stack.push(newly_excluded);
+    let included = features & self.current.include;
+    if newly_excluded.is_empty() && included.is_empty() {
+      return false;
+    }
+
+    self.stack.push((newly_excluded, included));
+    self.current.include.remove(included);
     self.current.exclude.insert(newly_excluded);
     true
   }
 
   /// Should be only called if inserted
   pub fn exit_supports(&mut self) {
-    if let Some(last) = self.stack.pop() {
-      self.current.exclude.remove(last);
+    if let Some((excluded, included)) = self.stack.pop() {
+      self.current.exclude.remove(excluded);
+      self.current.include.insert(included);
     }
   }
 }
@@ -312,6 +318,23 @@ fn supports_scope_correctly() {
   targets.exit_supports();
   assert!(!targets.current.exclude.contains(Features::OklabColors));
   assert!(!targets.current.exclude.contains(Features::LabColors));
+}
+
+#[test]
+fn supports_scope_overrides_included_features() {
+  let mut targets = TargetsWithSupportsScope::new(Targets {
+    include: Features::LightDark,
+    ..Targets::default()
+  });
+
+  assert!(targets.current.include.contains(Features::LightDark));
+  assert!(targets.enter_supports(Features::LightDark));
+  assert!(!targets.current.include.contains(Features::LightDark));
+  assert!(targets.current.exclude.contains(Features::LightDark));
+
+  targets.exit_supports();
+  assert!(targets.current.include.contains(Features::LightDark));
+  assert!(!targets.current.exclude.contains(Features::LightDark));
 }
 
 macro_rules! should_compile {


### PR DESCRIPTION
Resolves https://github.com/parcel-bundler/lightningcss/issues/821

This PR keeps the existing `light-dark()` polyfill for custom properties so old browser behavior and common design-system token patterns remain intact. 

But it also adds native `light-dark()` `@supports` overrides for supporting browsers which includes correct handling for LAB/P3 fallbacks, `!important`, `support` checks like custom properties or var()/attr() fallbacks and redeclarations.

`@property initial-value` preserves native `light-dark()` as is because otherwise it would invalidate typed custom-property registration.

Main downside is more generated CSS for custom properties with `light-dark()` but only when targeting browsers that need the polyfill behavior.