### PR TITLE
fix(cli): use map file name in sourceMappingURL, not the full output path

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -254,7 +254,16 @@ pub fn main() -> Result<(), std::io::Error> {
       if cli_args.sourcemap {
         if let Some(map_buf) = map {
           let map_filename = output_file.to_string_lossy() + ".map";
-          code += &format!("\n/*# sourceMappingURL={} */\n", map_filename);
+          // The source map is always written next to the output file, so the
+          // sourceMappingURL must reference it by file name only. Including the
+          // output file's directory prefix (e.g. `dist/`) breaks resolution
+          // because the URL is interpreted relative to the CSS file's own
+          // location. See https://github.com/parcel-bundler/lightningcss/issues/794
+          let source_mapping_url = match output_file.file_name() {
+            Some(file_name) => file_name.to_string_lossy().into_owned() + ".map",
+            None => map_filename.to_string(),
+          };
+          code += &format!("\n/*# sourceMappingURL={} */\n", source_mapping_url);
           fs::write(map_filename.as_ref(), map_buf)?;
         }
       }

--- a/tests/cli_integration_tests.rs
+++ b/tests/cli_integration_tests.rs
@@ -434,16 +434,57 @@ fn sourcemap() -> Result<(), Box<dyn std::error::Error>> {
   cmd.arg("--sourcemap");
   cmd.assert().success();
 
-  outfile.assert(predicate::str::contains(&format!(
-    "/*# sourceMappingURL={}.map */",
-    outfile.path().to_str().unwrap()
-  )));
+  // The sourceMappingURL must be the map file's name only, not the full output
+  // path, so that it resolves relative to the CSS file. See issue #794.
+  outfile.assert(predicate::str::contains("/*# sourceMappingURL=out.css.map */"));
   let mapfile = outdir.child("out.css.map");
   mapfile.assert(predicate::str::contains(r#""version":3"#));
   mapfile.assert(predicate::str::contains(r#""sources":["test.css"]"#));
   mapfile.assert(predicate::str::contains(
     r#""mappings":"AACM;;;;AAIA;;;;AAIA;;;;;;;;;;AAKA;;;;AAIA;;;;AAIA""#,
   ));
+
+  Ok(())
+}
+
+#[test]
+/// When the output file is in a subdirectory, the sourceMappingURL must still
+/// reference the map file by name only (it lives next to the output file), not
+/// by the full output path. Regression test for issue #794.
+fn sourcemap_url_relative_to_output_subdir() -> Result<(), Box<dyn std::error::Error>> {
+  let dir = assert_fs::TempDir::new()?;
+  let infile = dir.child("stylesheet.css");
+  infile.write_str(
+    r#"
+      body {
+        background-color: red;
+      }
+    "#,
+  )?;
+
+  let mut cmd = Command::cargo_bin("lightningcss")?;
+  cmd.current_dir(dir.path());
+  cmd.arg("stylesheet.css");
+  cmd.arg("-o").arg("dist/my-package.css");
+  cmd.arg("--sourcemap");
+  cmd.assert().success();
+
+  let out_contents = fs::read_to_string(dir.child("dist/my-package.css").path())?;
+  assert!(
+    out_contents.contains("/*# sourceMappingURL=my-package.css.map */"),
+    "sourceMappingURL should be the map file name only, got: {out_contents}"
+  );
+  assert!(
+    !out_contents.contains("sourceMappingURL=dist/"),
+    "sourceMappingURL should not include the output directory, got: {out_contents}"
+  );
+
+  // The map file itself is still written alongside the output file.
+  let map_contents = fs::read_to_string(dir.child("dist/my-package.css.map").path())?;
+  assert!(
+    map_contents.contains(r#""version":3"#),
+    "map file should be valid, got: {map_contents}"
+  );
 
   Ok(())
 }


### PR DESCRIPTION
## Summary

When `--sourcemap` is used with an output file in a subdirectory (e.g. `lightningcss --bundle bundle.css -o dist/my-package.css --sourcemap`), the emitted `/*# sourceMappingURL=... */` comment contained the **full output path** instead of just the map file name:

```
# before:  /*# sourceMappingURL=dist/my-package.css.map */   ❌
# after:   /*# sourceMappingURL=my-package.css.map */         ✅
```

Because the URL is resolved relative to the CSS file's own location, the `dist/` prefix makes the browser look for `dist/dist/my-package.css.map`, which breaks source maps for the common `src` -> `dist` project layout described in #794.

This changes the CLI to emit only the map file's **name** in the comment. The `.map` file itself is still written next to the output file using the full path, exactly as before.

## Changes

- **`src/main.rs`** — derive the `sourceMappingURL` value from `output_file.file_name()` (falling back to the full `<output>.map` string if the path has no file-name component). The path used to write the `.map` file is unchanged.
- **`tests/cli_integration_tests.rs`** — update the existing `sourcemap` test (which previously asserted the full path) to expect the basename, and add `sourcemap_url_relative_to_output_subdir`, a regression test reproducing the exact subdirectory scenario from the issue.

## Notes

- No behavior change when the output has no directory component: `-o out.css` still yields `/*# sourceMappingURL=out.css.map */`.
- Only the CLI emits this comment; the napi/Node binding returns the source map as a separate object and is unaffected.

Fixes #794

🤖 Generated with [Claude Code](https://claude.com/claude-code)
