### PR TITLE
Fix: deduplicate unparsed -webkit-mask declarations

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -161,11 +161,20 @@ impl<'i, 'o> PropertyHandlerContext<'i, 'o> {
     }
 
     if let Some(entry) = self.supports.iter_mut().find(|supports| condition == supports.condition) {
-      if self.is_important {
-        entry.important_declarations.push(property);
+      let declarations = if self.is_important {
+        &mut entry.important_declarations
       } else {
-        entry.declarations.push(property);
+        &mut entry.declarations
+      };
+
+      // Apply the same prefix merging as the main declaration list to generated fallbacks.
+      if let Property::Unparsed(unparsed) = &property {
+        if unparsed.merge_prefixes_into_last(declarations) {
+          return;
+        }
       }
+
+      declarations.push(property);
     } else {
       let mut important_declarations = Vec::new();
       let mut declarations = Vec::new();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28058,6 +28058,124 @@ mod tests {
       },
     );
 
+    // Authored `-webkit-mask` + `mask` pairs with identical values merge their prefixes
+    // rather than producing a duplicate `-webkit-mask`.
+    prefix_test(
+      r#"
+        .foo {
+          -webkit-mask: var(--a);
+          mask: var(--a);
+        }
+      "#,
+      indoc! { r#"
+        .foo {
+          -webkit-mask: var(--a);
+          mask: var(--a);
+        }
+      "#},
+      Browsers {
+        chrome: Some(90 << 16),
+        ..Browsers::default()
+      },
+    );
+
+    prefix_test(
+      r#"
+        .foo {
+          mask: var(--a);
+          -webkit-mask: var(--a);
+        }
+      "#,
+      indoc! { r#"
+        .foo {
+          -webkit-mask: var(--a);
+          mask: var(--a);
+        }
+      "#},
+      Browsers {
+        chrome: Some(90 << 16),
+        ..Browsers::default()
+      },
+    );
+
+    minify_test(
+      ".foo { mask: var(--a); -webkit-mask: var(--a) }",
+      ".foo{-webkit-mask:var(--a);mask:var(--a)}",
+    );
+
+    // Fallbacks generated for authored pairs are also merged in the @supports rule.
+    prefix_test(
+      r#"
+        .foo {
+          -webkit-mask: linear-gradient(lab(56.208% 94.4644 98.8928), lab(51% 70.4544 -115.586)) 40px var(--foo);
+          mask: linear-gradient(lab(56.208% 94.4644 98.8928), lab(51% 70.4544 -115.586)) 40px var(--foo);
+        }
+      "#,
+      indoc! { r#"
+        .foo {
+          -webkit-mask: linear-gradient(#ff0f0e, #7773ff) 40px var(--foo);
+          mask: linear-gradient(#ff0f0e, #7773ff) 40px var(--foo);
+        }
+
+        @supports (color: lab(0% 0 0)) {
+          .foo {
+            -webkit-mask: linear-gradient(lab(56.208% 94.4644 98.8928), lab(51% 70.4544 -115.586)) 40px var(--foo);
+            mask: linear-gradient(lab(56.208% 94.4644 98.8928), lab(51% 70.4544 -115.586)) 40px var(--foo);
+          }
+        }
+      "#},
+      Browsers {
+        chrome: Some(90 << 16),
+        ..Browsers::default()
+      },
+    );
+
+    // Merging only applies to adjacent declarations: an intervening declaration could be
+    // overridden by the later shorthand, so the duplicate must be preserved.
+    prefix_test(
+      r#"
+        .foo {
+          -webkit-mask: var(--a);
+          mask-image: var(--b);
+          mask: var(--a);
+        }
+      "#,
+      indoc! { r#"
+        .foo {
+          -webkit-mask: var(--a);
+          -webkit-mask-image: var(--b);
+          mask-image: var(--b);
+          -webkit-mask: var(--a);
+          mask: var(--a);
+        }
+      "#},
+      Browsers {
+        chrome: Some(90 << 16),
+        ..Browsers::default()
+      },
+    );
+
+    // Different values do not merge.
+    prefix_test(
+      r#"
+        .foo {
+          -webkit-mask: var(--a);
+          mask: var(--b);
+        }
+      "#,
+      indoc! { r#"
+        .foo {
+          -webkit-mask: var(--a);
+          -webkit-mask: var(--b);
+          mask: var(--b);
+        }
+      "#},
+      Browsers {
+        chrome: Some(90 << 16),
+        ..Browsers::default()
+      },
+    );
+
     prefix_test(
       ".foo { mask: url(masks.svg#star) luminance }",
       indoc! { r#"

--- a/src/properties/custom.rs
+++ b/src/properties/custom.rs
@@ -165,6 +165,33 @@ impl<'i> UnparsedProperty<'i> {
     clone
   }
 
+  /// Merges the vendor prefixes of duplicate declarations. If the last declaration in
+  /// `declarations` is the same property as `self` with an identical value, merges the prefixes
+  /// of the two declarations into that declaration and returns `true`, meaning `self` was
+  /// absorbed and must not be appended. Returns `false` if the caller should append `self`.
+  ///
+  /// The prefix sets may also be identical, so exact duplicate declarations are absorbed. Only
+  /// the last declaration is considered: merging across an intervening declaration could change
+  /// the cascade (e.g. a longhand reset by a later shorthand), so callers must first flush any
+  /// buffered declarations that could affect cascade ordering.
+  pub(crate) fn merge_prefixes_into_last(&self, declarations: &mut [super::Property<'i>]) -> bool {
+    use crate::vendor_prefix::VendorPrefix;
+    if let Some(super::Property::Unparsed(last)) = declarations.last_mut() {
+      let prefixes = self.property_id.prefix();
+      let last_prefixes = last.property_id.prefix();
+      if !last_prefixes.is_empty()
+        && !prefixes.is_empty()
+        && last.property_id.with_prefix(VendorPrefix::empty())
+          == self.property_id.with_prefix(VendorPrefix::empty())
+        && last.value == self.value
+      {
+        last.property_id.add_prefix(prefixes);
+        return true;
+      }
+    }
+    false
+  }
+
   /// Returns a new UnparsedProperty with the same value and the given property id.
   pub fn with_property_id(&self, property_id: PropertyId<'i>) -> UnparsedProperty<'i> {
     UnparsedProperty {

--- a/src/properties/masking.rs
+++ b/src/properties/masking.rs
@@ -703,7 +703,11 @@ impl<'i> PropertyHandler<'i> for MaskHandler<'i> {
         self
           .flushed_properties
           .insert(MaskProperty::try_from(&val.property_id).unwrap());
-        dest.push(Property::Unparsed(unparsed));
+
+        // Merge adjacent authored prefix variants, e.g. `-webkit-mask` + `mask` pairs.
+        if !unparsed.merge_prefixes_into_last(dest) {
+          dest.push(Property::Unparsed(unparsed));
+        }
       }
       Property::MaskBorderSource(val) => property!(border_source, val, &VendorPrefix::None),
       Property::WebKitMaskBoxImageSource(val, _) => property!(border_source, val, &VendorPrefix::WebKit),


### PR DESCRIPTION
`-webkit-mask` is currently duplicated when a rule contains an authored prefix pair with a value it can't fully parse (e.g. containing `var()`):

```css
.foo {
  -webkit-mask: url(mask.svg) var(--offset);
  mask: url(mask.svg) var(--offset);
}
```

Resulting in:

```css
.foo {
  -webkit-mask: url(mask.svg) var(--offset);
  -webkit-mask: url(mask.svg) var(--offset);
  mask: url(mask.svg) var(--offset);
}
```


With targets that require prefixing `mask`,  `-webkit-mask` gets duplicated when the author already wrote one. Parsed values don't have this problem because the mask handler already accumulates prefixes for them. This is another case of #403 and https://github.com/parcel-bundler/lightningcss/issues/237

With this PR, if the previous declaration is the same property with an identical value, we merge the vendor prefixes into it instead of pushing a duplicate. The same merge is applied to generated `@supports` color fallbacks, which are registered per authored declaration and would otherwise keep the duplicate.

Only adjacent declarations are merged, since `mask` is a shorthand and merging across an intervening declaration (e.g. a `mask-image` that the later `mask` resets) could change the cascade. Merging also requires exact token equality, so identical duplicate declarations collapse too, which is cascade-neutral.

The logic lives in a small helper (`UnparsedProperty::merge_prefixes_into_last`) since the same bug exists in other handlers (transition, animation, transform, border-radius) — those are left for follow-ups to keep this focused, as is the `mask-border`/`-webkit-mask-box-image` pair, which needs property mapping rather than prefix normalization. The approach follows #850, which fixed the same kind of duplicate inside `transition-property` values, and doesn't overlap with #1259/#1284, which fix a sibling bug in the parsed `backdrop-filter` path.

Related to https://github.com/parcel-bundler/lightningcss/issues/969

