### PR TITLE
Supports `:host-context` pseudo-class

### DIFF
--- a/selectors/builder.rs
+++ b/selectors/builder.rs
@@ -314,6 +314,11 @@ where
           *specificity += Specificity::from(selector.specificity());
         }
       }
+      Component::HostContext(ref selector) => {
+        specificity.class_like_selectors += 1;
+        // See: https://github.com/w3c/csswg-drafts/issues/1915
+        *specificity += Specificity::from(selector.specificity());
+      }
       Component::ID(..) => {
         specificity.id_selectors += 1;
       }

--- a/selectors/matching.rs
+++ b/selectors/matching.rs
@@ -770,6 +770,23 @@ where
             .nest(|context| matches_complex_selector(selector.iter(), element, context, flags_setter))
         })
     }
+    Component::HostContext(ref selector) => {
+      context.shared.shadow_host().map_or(false, |host| host == element.opaque()) && {
+        let mut current = Some(element.clone());
+        let mut matched = false;
+        while let Some(candidate) = current {
+          if context
+            .shared
+            .nest(|context| matches_complex_selector(selector.iter(), &candidate, context, flags_setter))
+          {
+            matched = true;
+            break;
+          }
+          current = candidate.parent_element();
+        }
+        matched
+      }
+    }
     Component::Scope => match context.shared.scope_element {
       Some(ref scope_element) => element.opaque() == *scope_element,
       None => element.is_root(),

--- a/selectors/parser.rs
+++ b/selectors/parser.rs
@@ -1027,7 +1027,7 @@ impl<'a, 'i, Impl: 'a + SelectorImpl<'i>> SelectorIter<'a, 'i, Impl> {
   #[inline]
   pub(crate) fn is_featureless_host_selector(&mut self) -> bool {
     self.selector_length() > 0
-      && self.all(|component| matches!(*component, Component::Host(..)))
+      && self.all(|component| matches!(*component, Component::Host(..) | Component::HostContext(..)))
       && self.next_sequence().is_none()
   }
 
@@ -1451,6 +1451,16 @@ pub enum Component<'i, Impl: SelectorImpl<'i>> {
   ///
   /// See https://github.com/w3c/csswg-drafts/issues/2158
   Host(Option<Selector<'i, Impl>>),
+  /// The `:host-context` pseudo-class:
+  ///
+  /// https://drafts.csswg.org/css-scoping/#host-selector
+  ///
+  /// NOTE(emilio): This should support a list of selectors, but as of this
+  /// writing no other browser does, and that allows them to put
+  /// :host-context() in the rule hash, so we do that too.
+  ///
+  /// See https://github.com/w3c/csswg-drafts/issues/2158
+  HostContext(Selector<'i, Impl>),
   /// The `:where` pseudo-class.
   ///
   /// https://drafts.csswg.org/selectors/#zero-matches
@@ -1540,6 +1550,7 @@ where
       Component::Slotted(c) => Component::Slotted(c.into_owned()),
       Component::Part(c) => Component::Part(c.into_owned()),
       Component::Host(c) => Component::Host(c.into_owned()),
+      Component::HostContext(c) => Component::HostContext(c.into_owned()),
       Component::Where(c) => Component::Where(c.into_owned()),
       Component::Is(c) => Component::Is(c.into_owned()),
       Component::Any(a, b) => Component::Any(a.into_owned(), b.into_owned()),
@@ -1620,7 +1631,7 @@ impl<'i, Impl: SelectorImpl<'i>> Component<'i, Impl> {
           return false;
         }
       }
-      Host(Some(ref selector)) => {
+      Host(Some(ref selector)) | HostContext(ref selector) => {
         if !selector.visit(visitor) {
           return false;
         }
@@ -2011,6 +2022,11 @@ impl<'i, Impl: SelectorImpl<'i>> ToCss for Component<'i, Impl> {
           dest.write_char(')')?;
         }
         Ok(())
+      }
+      HostContext(ref selector) => {
+        dest.write_str(":host-context(")?;
+        selector.to_css(dest)?;
+        dest.write_char(')')
       }
       Nth(ref nth_data) => {
         nth_data.write_start(dest, nth_data.is_function())?;
@@ -2752,7 +2768,10 @@ where
         //     (Similar quotes for :where() / :not())
         //
         let ignore_default_ns = state.intersects(SelectorParsingState::SKIP_DEFAULT_NAMESPACE)
-          || matches!(result, SimpleSelectorParseResult::SimpleSelector(Component::Host(..)));
+          || matches!(
+            result,
+            SimpleSelectorParseResult::SimpleSelector(Component::Host(..) | Component::HostContext(..))
+          );
         if !ignore_default_ns {
           builder.push_simple_selector(Component::DefaultNamespace(url));
         }
@@ -2878,6 +2897,12 @@ where
           }
           return Ok(Component::Host(Some(parse_inner_compound_selector(parser, input, state)?)));
       },
+        "host-context" => {
+          if !state.allows_tree_structural_pseudo_classes() {
+            return Err(input.new_custom_error(SelectorParseErrorKind::InvalidState));
+          }
+          return Ok(Component::HostContext(parse_inner_compound_selector(parser, input, state)?));
+        },
       "not" => {
           return parse_negation(parser, input, state)
       },
@@ -3341,6 +3366,10 @@ pub mod tests {
     }
 
     fn parse_part(&self) -> bool {
+      true
+    }
+
+    fn parse_host(&self) -> bool {
       true
     }
 
@@ -3918,6 +3947,13 @@ pub mod tests {
     assert!(parse("::part(foo bar)").is_ok());
     assert!(parse("::part(foo):hover").is_ok());
     assert!(parse("::part(foo) + bar").is_err());
+
+    assert!(parse(":host").is_ok());
+    assert!(parse(":host(.foo)").is_ok());
+    assert!(parse(":host-context()").is_err());
+    assert!(parse(":host-context(.foo)").is_ok());
+    assert!(parse(":host-context(.foo, .bar)").is_err());
+    assert!(parse(":host-context(div > .foo)").is_err());
 
     assert!(parse("div ::slotted(div)").is_ok());
     assert!(parse("div + slot::slotted(div)").is_ok());

--- a/selectors/serialization.rs
+++ b/selectors/serialization.rs
@@ -149,6 +149,16 @@ enum TSPseudoClass<'s, Impl: SelectorImpl<'s>, VendorPrefix> {
     )]
     selectors: Option<Selector<'s, Impl>>,
   },
+  HostContext {
+    #[serde(
+      borrow,
+      bound(
+        serialize = "Impl::NonTSPseudoClass: serde::Serialize, Impl::PseudoElement: serde::Serialize, Impl::VendorPrefix: serde::Serialize",
+        deserialize = "Impl::NonTSPseudoClass: serde::Deserialize<'de>, Impl::PseudoElement: serde::Deserialize<'de>, Impl::VendorPrefix: serde::Deserialize<'de>"
+      )
+    )]
+    selectors: Selector<'s, Impl>,
+  },
   Where {
     #[serde(
       borrow,
@@ -371,6 +381,9 @@ where
       Component::NthOf(nth) => serialize_nth(nth.nth_data(), Some(nth.clone_selectors())),
       Component::Host(s) => {
         SerializedComponent::PseudoClass(SerializedPseudoClass::TS(TSPseudoClass::Host { selectors: s.clone() }))
+      }
+      Component::HostContext(s) => {
+        SerializedComponent::PseudoClass(SerializedPseudoClass::TS(TSPseudoClass::HostContext { selectors: s.clone() }))
       }
       Component::Where(s) => {
         SerializedComponent::PseudoClass(SerializedPseudoClass::TS(TSPseudoClass::Where { selectors: s.clone() }))

--- a/src/selector.rs
+++ b/src/selector.rs
@@ -1712,6 +1712,11 @@ where
       }
       Ok(())
     }
+    Component::HostContext(selector) => {
+      dest.write_str(":host-context(")?;
+      selector.to_css(dest)?;
+      dest.write_char(')')
+    }
     Component::Slotted(ref selector) => {
       dest.write_str("::slotted(")?;
       selector.to_css(dest)?;
@@ -1931,7 +1936,9 @@ pub(crate) fn is_compatible(selectors: &[Selector], targets: Targets) -> bool {
           continue;
         }
 
-        Component::Scope | Component::Host(_) | Component::Slotted(_) => Feature::Shadowdomv1,
+        Component::Scope | Component::Host(_) | Component::HostContext(_) | Component::Slotted(_) => {
+          Feature::Shadowdomv1
+        }
 
         Component::Part(_) => Feature::PartPseudo,
 
@@ -2275,6 +2282,7 @@ pub(crate) fn is_pure_css_modules_selector(selector: &Selector) -> bool {
     Component::NthOf(nth) => nth.selectors().iter().any(is_pure_css_modules_selector),
     Component::Slotted(s) => is_pure_css_modules_selector(&s),
     Component::Host(s) => s.as_ref().map(is_pure_css_modules_selector).unwrap_or(false),
+    Component::HostContext(s) => is_pure_css_modules_selector(s),
     Component::NonTSPseudoClass(pc) => match pc {
       PseudoClass::Local { selector } => is_pure_css_modules_selector(&*selector),
       _ => false,


### PR DESCRIPTION
## Summary

Adds support for the `:host-context()` pseudo-class when parsing CSS selectors.

## Motivation

Ionic uses `:host-context()` in its component styles. When Lightning CSS is used as the CSS transformer in Vite, parsing fails with:

```text
[vite:css][lightningcss] 'host-context' is not recognized as a valid pseudo-class. Did you mean '::host-context' (pseudo-element) or is this a typo?
```

This prevents Lightning CSS from processing Ionic's generated CSS.

**P.S.** I'm not a Rust developer I'm primarily a front-end developer. This is my first contribution to a Rust project, so I hope my implementation is useful. If there's anything you'd like me to improve or implement differently, I'd be happy to update the PR.