### PR TITLE
Fix place-self/place-items collapsing non-equal values

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5301,6 +5301,69 @@ mod tests {
       },
     );
 
+    // justify-self: auto is not equivalent to a self-position align-self, so the
+    // shorthand must keep both values. https://github.com/parcel-bundler/lightningcss/issues/1182
+    test(
+      r#"
+      .foo {
+        align-self: self-start;
+        justify-self: auto;
+      }
+    "#,
+      indoc! {r#"
+      .foo {
+        place-self: self-start auto;
+      }
+    "#
+      },
+    );
+
+    test(
+      r#"
+      .foo {
+        align-self: auto;
+        justify-self: auto;
+      }
+    "#,
+      indoc! {r#"
+      .foo {
+        place-self: auto;
+      }
+    "#
+      },
+    );
+
+    // Likewise, justify-self: stretch only collapses when align-self is stretch.
+    test(
+      r#"
+      .foo {
+        align-self: normal;
+        justify-self: stretch;
+      }
+    "#,
+      indoc! {r#"
+      .foo {
+        place-self: normal stretch;
+      }
+    "#
+      },
+    );
+
+    test(
+      r#"
+      .foo {
+        align-self: stretch;
+        justify-self: stretch;
+      }
+    "#,
+      indoc! {r#"
+      .foo {
+        place-self: stretch;
+      }
+    "#
+      },
+    );
+
     test(
       r#"
       .foo {
@@ -5311,6 +5374,38 @@ mod tests {
       indoc! {r#"
       .foo {
         place-items: center;
+      }
+    "#
+      },
+    );
+
+    // place-items has the same rule: justify-items: stretch only collapses when
+    // align-items is stretch.
+    test(
+      r#"
+      .foo {
+        align-items: normal;
+        justify-items: stretch;
+      }
+    "#,
+      indoc! {r#"
+      .foo {
+        place-items: normal stretch;
+      }
+    "#
+      },
+    );
+
+    test(
+      r#"
+      .foo {
+        align-items: stretch;
+        justify-items: stretch;
+      }
+    "#,
+      indoc! {r#"
+      .foo {
+        place-items: stretch;
       }
     "#
       },

--- a/src/properties/align.rs
+++ b/src/properties/align.rs
@@ -506,9 +506,9 @@ impl ToCss for PlaceSelf {
   {
     self.align.to_css(dest)?;
     let is_equal = match &self.justify {
-      JustifySelf::Auto => true,
+      JustifySelf::Auto => self.align == AlignSelf::Auto,
       JustifySelf::Normal => self.align == AlignSelf::Normal,
-      JustifySelf::Stretch => self.align == AlignSelf::Normal,
+      JustifySelf::Stretch => self.align == AlignSelf::Stretch,
       JustifySelf::BaselinePosition(p) if matches!(&self.align, AlignSelf::BaselinePosition(p2) if p == p2) => {
         true
       }
@@ -776,7 +776,7 @@ impl ToCss for PlaceItems {
     self.align.to_css(dest)?;
     let is_equal = match &self.justify {
       JustifyItems::Normal => self.align == AlignItems::Normal,
-      JustifyItems::Stretch => self.align == AlignItems::Normal,
+      JustifyItems::Stretch => self.align == AlignItems::Stretch,
       JustifyItems::BaselinePosition(p) if matches!(&self.align, AlignItems::BaselinePosition(p2) if p == p2) => {
         true
       }


### PR DESCRIPTION
Fixes #1182.

The `place-self`/`place-items` serializers omit the second value (collapsing `place-self: X Y` to `place-self: X`) when they consider it equal to the first. Since the single-value form sets both longhands to `X`, that's only valid when the two are actually equal. Three arms of that check were wrong:

- `place-self` with `justify-self: auto` always collapsed, so `align-self: self-start; justify-self: auto` minified to `place-self: self-start` — silently changing `justify-self` to `self-start` (the reported bug).
- `place-self` with `justify-self: stretch` compared against `align-self: normal` instead of `stretch`.
- `place-items` had the same `stretch`-vs-`normal` mistake.

Each now compares against the matching align value, so the shorthands round-trip. Added regression tests for all three.

Used AI assistance on this; I reviewed and tested it.
