### PR TITLE
Fix #1303: ::search-text:current selector parsing

### DIFF
--- a/selectors/parser.rs
+++ b/selectors/parser.rs
@@ -45,6 +45,11 @@ pub trait PseudoElement<'i>: Sized + ToCss {
     false
   }
 
+  /// Whether this is the `::search-text` pseudo-element.
+  fn is_search_text(&self) -> bool {
+    false
+  }
+
   fn is_unknown(&self) -> bool {
     false
   }
@@ -62,6 +67,11 @@ pub trait NonTSPseudoClass<'i>: Sized + ToCss {
   ///
   /// https://drafts.csswg.org/selectors-4/#useraction-pseudos
   fn is_user_action_state(&self) -> bool;
+
+  /// Whether this pseudo-class is valid after `::search-text`.
+  fn is_valid_after_search_text(&self) -> bool {
+    false
+  }
 
   fn is_valid_before_webkit_scrollbar(&self) -> bool {
     true
@@ -137,6 +147,7 @@ bitflags! {
         const AFTER_WEBKIT_SCROLLBAR = 1 << 8;
         const AFTER_VIEW_TRANSITION = 1 << 9;
         const AFTER_UNKNOWN_PSEUDO_ELEMENT = 1 << 10;
+        const AFTER_SEARCH_TEXT = 1 << 11;
     }
 }
 
@@ -2791,6 +2802,9 @@ where
         if p.is_view_transition() {
           state.insert(SelectorParsingState::AFTER_VIEW_TRANSITION);
         }
+        if p.is_search_text() {
+          state.insert(SelectorParsingState::AFTER_SEARCH_TEXT);
+        }
         builder.push_simple_selector(Component::PseudoElement(p));
       }
     }
@@ -3127,7 +3141,12 @@ where
       return Err(location.new_custom_error(SelectorParseErrorKind::InvalidPseudoClassAfterWebKitScrollbar));
     }
   } else if state.intersects(SelectorParsingState::AFTER_PSEUDO_ELEMENT) {
-    if !pseudo_class.is_user_action_state() {
+    let is_valid = if state.intersects(SelectorParsingState::AFTER_SEARCH_TEXT) {
+      pseudo_class.is_valid_after_search_text()
+    } else {
+      pseudo_class.is_user_action_state()
+    };
+    if !is_valid {
       return Err(location.new_custom_error(SelectorParseErrorKind::InvalidPseudoClassAfterPseudoElement));
     }
   } else if !pseudo_class.is_valid_before_webkit_scrollbar() {
@@ -3932,9 +3951,6 @@ pub mod tests {
 
     assert!(parse("foo::details-content").is_ok());
     assert!(parse("foo::target-text").is_ok());
-    assert!(parse("foo::search-text").is_ok());
-    assert!(parse(":current::search-text").is_ok());
-
     assert!(parse("::highlight").is_err());
     assert!(parse("::highlight()").is_err());
     assert!(parse("::highlight(custom-highlight-name)").is_ok());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6674,6 +6674,33 @@ mod tests {
   }
 
   #[test]
+  fn test_search_text_selectors() {
+    minify_test("::search-text { color: red }", "::search-text{color:red}");
+    minify_test(
+      "::search-text:current { color: red }",
+      "::search-text:current{color:red}",
+    );
+    minify_test(
+      "::search-text:not(:current) { color: red }",
+      "::search-text:not(:current){color:red}",
+    );
+    minify_test(
+      ":current::search-text { color: red }",
+      ":current::search-text{color:red}",
+    );
+
+    for selector in [
+      "::search-text:hover",
+      "::search-text:current(*)",
+      "::search-text:past",
+      "::search-text:future",
+    ] {
+      let source = format!("{selector} {{ color: red }}");
+      assert!(StyleSheet::parse(&source, ParserOptions::default()).is_err());
+    }
+  }
+
+  #[test]
   fn test_selectors() {
     minify_test(":nth-col(2n) {width: 20px}", ":nth-col(2n){width:20px}");
     minify_test(":nth-col(10n-1) {width: 20px}", ":nth-col(10n-1){width:20px}");

--- a/src/selector.rs
+++ b/src/selector.rs
@@ -649,6 +649,10 @@ impl<'i> parcel_selectors::parser::NonTSPseudoClass<'i> for PseudoClass<'i> {
     )
   }
 
+  fn is_valid_after_search_text(&self) -> bool {
+    matches!(*self, PseudoClass::Current)
+  }
+
   fn is_valid_before_webkit_scrollbar(&self) -> bool {
     !matches!(*self, PseudoClass::WebKitScrollbar(..))
   }
@@ -1348,6 +1352,10 @@ impl<'i> parcel_selectors::parser::PseudoElement<'i> for PseudoElement<'i> {
         | PseudoElement::ViewTransitionNew { .. }
         | PseudoElement::ViewTransitionOld { .. }
     )
+  }
+
+  fn is_search_text(&self) -> bool {
+    matches!(*self, PseudoElement::SearchText)
   }
 
   fn is_unknown(&self) -> bool {


### PR DESCRIPTION
## Summary

- allow `:current` after the `::search-text` pseudo-element
- support the WPT-required `::search-text:not(:current)` form
- keep other states such as `:hover`, `:past`, and `:future` invalid after `::search-text`
- move the `::search-text` coverage into Lightning CSS parser/minifier tests

## Root cause

`::search-text` was registered as a pseudo-element, but selectors following a pseudo-element are validated by a generic guard that only accepts user-action pseudo-classes. Since `:current` is a time-dimensional pseudo-class, both `::search-text:current` and `::search-text:not(:current)` were rejected.

This adds a parser state for `::search-text` and restricts the allowed following pseudo-class to `:current`, matching the Web Platform Tests.

## Impact

Lightning CSS can parse and minify the valid selectors used to distinguish the active find-in-page match. Existing behavior for `:current::search-text` is preserved.

Fixes #1303.

## Checks

- `cargo test -p lightningcss` (Rust 1.96.0)
- `yarn build`
- `yarn test` (81 passed)
- native Node binding smoke test for both affected selectors
