### PR TITLE
Make animation-timeline reset-only in the animation shorthand

### DIFF
--- a/node/ast.d.ts
+++ b/node/ast.d.ts
@@ -8996,10 +8996,6 @@ export interface Animation {
    */
   playState: AnimationPlayState;
   /**
-   * The animation timeline.
-   */
-  timeline: AnimationTimeline;
-  /**
    * The easing function for the animation.
    */
   timingFunction: EasingFunction;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12290,45 +12290,53 @@ mod tests {
       ".foo { animation: foo 0s 3s infinite }",
       ".foo{animation:0s 3s infinite foo}",
     );
-    minify_test(".foo { animation: foo 3s --test }", ".foo{animation:3s foo --test}");
-    minify_test(".foo { animation: foo 3s scroll() }", ".foo{animation:3s foo scroll()}");
+    // animation-timeline is a reset-only component of the animation shorthand. It cannot be
+    // set there, so an invalid shorthand is preserved as authored rather than reinterpreted.
+    // https://drafts.csswg.org/scroll-animations/#animation-timeline
+    minify_test(".foo { animation: foo 3s --test }", ".foo{animation:foo 3s --test}");
+    minify_test(".foo { animation: foo 3s scroll() }", ".foo{animation:foo 3s scroll()}");
+    minify_test(".foo { animation: foo 3s auto }", ".foo{animation:foo 3s auto}");
+    minify_test(".foo { animation-timeline: --test }", ".foo{animation-timeline:--test}");
     minify_test(
-      ".foo { animation: foo 3s scroll(block) }",
-      ".foo{animation:3s foo scroll()}",
+      ".foo { animation-timeline: scroll() }",
+      ".foo{animation-timeline:scroll()}",
     );
     minify_test(
-      ".foo { animation: foo 3s scroll(root inline) }",
-      ".foo{animation:3s foo scroll(root inline)}",
+      ".foo { animation-timeline: scroll(block) }",
+      ".foo{animation-timeline:scroll()}",
     );
     minify_test(
-      ".foo { animation: foo 3s scroll(inline root) }",
-      ".foo{animation:3s foo scroll(root inline)}",
+      ".foo { animation-timeline: scroll(root inline) }",
+      ".foo{animation-timeline:scroll(root inline)}",
     );
     minify_test(
-      ".foo { animation: foo 3s scroll(inline nearest) }",
-      ".foo{animation:3s foo scroll(inline)}",
+      ".foo { animation-timeline: scroll(inline root) }",
+      ".foo{animation-timeline:scroll(root inline)}",
     );
     minify_test(
-      ".foo { animation: foo 3s view(block) }",
-      ".foo{animation:3s foo view()}",
+      ".foo { animation-timeline: scroll(inline nearest) }",
+      ".foo{animation-timeline:scroll(inline)}",
     );
     minify_test(
-      ".foo { animation: foo 3s view(inline) }",
-      ".foo{animation:3s foo view(inline)}",
+      ".foo { animation-timeline: view(block) }",
+      ".foo{animation-timeline:view()}",
     );
     minify_test(
-      ".foo { animation: foo 3s view(inline 10px 10px) }",
-      ".foo{animation:3s foo view(inline 10px)}",
+      ".foo { animation-timeline: view(inline) }",
+      ".foo{animation-timeline:view(inline)}",
     );
     minify_test(
-      ".foo { animation: foo 3s view(inline 10px 12px) }",
-      ".foo{animation:3s foo view(inline 10px 12px)}",
+      ".foo { animation-timeline: view(inline 10px 10px) }",
+      ".foo{animation-timeline:view(inline 10px)}",
     );
     minify_test(
-      ".foo { animation: foo 3s view(inline auto auto) }",
-      ".foo{animation:3s foo view(inline)}",
+      ".foo { animation-timeline: view(inline 10px 12px) }",
+      ".foo{animation-timeline:view(inline 10px 12px)}",
     );
-    minify_test(".foo { animation: foo 3s auto }", ".foo{animation:3s foo}");
+    minify_test(
+      ".foo { animation-timeline: view(inline auto auto) }",
+      ".foo{animation-timeline:view(inline)}",
+    );
     minify_test(".foo { animation-composition: add }", ".foo{animation-composition:add}");
     test(
       r#"
@@ -12441,7 +12449,8 @@ mod tests {
     "#,
       indoc! {r#"
       .foo {
-        animation: 90ms ease-in-out .1s 2 alternate forwards foo scroll();
+        animation: 90ms ease-in-out .1s 2 alternate forwards foo;
+        animation-timeline: scroll();
       }
     "#},
     );
@@ -12461,15 +12470,41 @@ mod tests {
     "#,
       indoc! {r#"
       .foo {
-        animation-name: foo;
-        animation-duration: 90ms;
-        animation-timing-function: ease-in-out;
-        animation-iteration-count: 2;
-        animation-direction: alternate;
-        animation-play-state: running;
-        animation-delay: .1s;
-        animation-fill-mode: forwards;
+        animation: 90ms ease-in-out .1s 2 alternate forwards foo;
         animation-timeline: scroll(), view();
+      }
+    "#},
+    );
+    // animation-timeline must never be folded into the shorthand, which would make
+    // the whole declaration invalid and drop the animation.
+    // https://github.com/parcel-bundler/lightningcss/issues/1283
+    test(
+      r#"
+      .foo {
+        animation: parallax 1ms linear both;
+        animation-timeline: view();
+        animation-range: exit 0% exit 100%;
+      }
+    "#,
+      indoc! {r#"
+      .foo {
+        animation: 1ms linear both parallax;
+        animation-timeline: view();
+        animation-range: exit;
+      }
+    "#},
+    );
+    // The shorthand still resets a timeline declared before it.
+    test(
+      r#"
+      .foo {
+        animation-timeline: view();
+        animation: bar 200ms;
+      }
+    "#,
+      indoc! {r#"
+      .foo {
+        animation: .2s bar;
       }
     "#},
     );
@@ -12584,7 +12619,8 @@ mod tests {
     prefix_test(
       r#"
       .foo {
-        animation: .2s ease-in-out bar scroll();
+        animation: .2s ease-in-out bar;
+        animation-timeline: scroll();
       }
     "#,
       indoc! {r#"
@@ -12601,12 +12637,14 @@ mod tests {
     prefix_test(
       r#"
       .foo {
-        animation: .2s ease-in-out bar scroll();
+        animation: .2s ease-in-out bar;
+        animation-timeline: scroll();
       }
     "#,
       indoc! {r#"
       .foo {
-        animation: .2s ease-in-out bar scroll();
+        animation: .2s ease-in-out bar;
+        animation-timeline: scroll();
       }
     "#},
       Browsers {
@@ -12614,10 +12652,13 @@ mod tests {
         ..Browsers::default()
       },
     );
+    // The prefixed shorthand has no timeline component either, so the longhand
+    // must stay outside of it.
     prefix_test(
       r#"
       .foo {
-        animation: .2s ease-in-out bar scroll();
+        animation: .2s ease-in-out bar;
+        animation-timeline: scroll();
       }
     "#,
       indoc! {r#"

--- a/src/properties/animation.rs
+++ b/src/properties/animation.rs
@@ -601,8 +601,6 @@ define_list_shorthand! {
     delay: AnimationDelay(Time, VendorPrefix),
     /// The animation fill mode.
     fill_mode: AnimationFillMode(AnimationFillMode, VendorPrefix),
-    /// The animation timeline.
-    timeline: AnimationTimeline(AnimationTimeline<'i>),
   }
 }
 
@@ -616,7 +614,6 @@ impl<'i> Parse<'i> for Animation<'i> {
     let mut play_state = None;
     let mut delay = None;
     let mut fill_mode = None;
-    let mut timeline = None;
 
     macro_rules! parse_prop {
       ($var: ident, $type: ident) => {
@@ -638,7 +635,6 @@ impl<'i> Parse<'i> for Animation<'i> {
       parse_prop!(fill_mode, AnimationFillMode);
       parse_prop!(play_state, AnimationPlayState);
       parse_prop!(name, AnimationName);
-      parse_prop!(timeline, AnimationTimeline);
       break;
     }
 
@@ -651,7 +647,6 @@ impl<'i> Parse<'i> for Animation<'i> {
       play_state: play_state.unwrap_or(AnimationPlayState::Running),
       delay: delay.unwrap_or(Time::Seconds(0.0)),
       fill_mode: fill_mode.unwrap_or(AnimationFillMode::None),
-      timeline: timeline.unwrap_or(AnimationTimeline::Auto),
     })
   }
 }
@@ -706,11 +701,6 @@ impl<'i> ToCss for Animation<'i> {
     // Eventually we could output a string here to avoid duplicating some properties above.
     // Chrome does not yet support strings, however.
     self.name.to_css(dest)?;
-
-    if self.name != AnimationName::None && self.timeline != AnimationTimeline::default() {
-      dest.write_char(' ')?;
-      self.timeline.to_css(dest)?;
-    }
 
     Ok(())
   }
@@ -820,8 +810,6 @@ impl<'i> PropertyHandler<'i> for AnimationHandler<'i> {
         let fill_modes = val.iter().map(|b| b.fill_mode.clone()).collect();
         maybe_flush!(fill_modes, &fill_modes, vp);
 
-        self.timelines = Some(val.iter().map(|b| b.timeline.clone()).collect());
-
         property!(names, &names, vp);
         property!(durations, &durations, vp);
         property!(timing_functions, &timing_functions, vp);
@@ -831,8 +819,10 @@ impl<'i> PropertyHandler<'i> for AnimationHandler<'i> {
         property!(delays, &delays, vp);
         property!(fill_modes, &fill_modes, vp);
 
-        // The animation shorthand resets animation-range
+        // The animation shorthand resets animation-timeline and animation-range,
+        // but cannot set them. They are reset-only components of the shorthand.
         // https://drafts.csswg.org/scroll-animations/#named-range-animation-declaration
+        self.timelines = None;
         self.range_starts = None;
         self.range_ends = None;
       }
@@ -863,6 +853,7 @@ impl<'i> PropertyHandler<'i> for AnimationHandler<'i> {
             }
           }
 
+          self.timelines = None;
           self.range_starts = None;
           self.range_ends = None;
         }
@@ -899,9 +890,10 @@ impl<'i> AnimationHandler<'i> {
     let mut play_states = std::mem::take(&mut self.play_states);
     let mut delays = std::mem::take(&mut self.delays);
     let mut fill_modes = std::mem::take(&mut self.fill_modes);
-    let mut timelines_value = std::mem::take(&mut self.timelines);
+    let timelines = std::mem::take(&mut self.timelines);
     let range_starts = std::mem::take(&mut self.range_starts);
     let range_ends = std::mem::take(&mut self.range_ends);
+    let mut pushed_shorthand = false;
 
     if let (
       Some((names, names_vp)),
@@ -932,15 +924,6 @@ impl<'i> AnimationHandler<'i> {
         & *play_states_vp
         & *delays_vp
         & *fill_modes_vp;
-      let mut timelines = if let Some(timelines) = &mut timelines_value {
-        Cow::Borrowed(timelines)
-      } else if !intersection.contains(VendorPrefix::None) {
-        // Prefixed animation shorthand does not support animation-timeline
-        Cow::Owned(std::iter::repeat(AnimationTimeline::Auto).take(len).collect())
-      } else {
-        Cow::Owned(SmallVec::new())
-      };
-
       if !intersection.is_empty()
         && durations.len() == len
         && timing_functions.len() == len
@@ -949,19 +932,7 @@ impl<'i> AnimationHandler<'i> {
         && play_states.len() == len
         && delays.len() == len
         && fill_modes.len() == len
-        && timelines.len() == len
       {
-        let timeline_property = if timelines.iter().any(|t| *t != AnimationTimeline::Auto)
-          && (intersection != VendorPrefix::None
-            || !context
-              .targets
-              .is_compatible(crate::compat::Feature::AnimationTimelineShorthand))
-        {
-          Some(Property::AnimationTimeline(timelines.clone().into_owned()))
-        } else {
-          None
-        };
-
         let animations = izip!(
           names.drain(..),
           durations.drain(..),
@@ -970,21 +941,10 @@ impl<'i> AnimationHandler<'i> {
           directions.drain(..),
           play_states.drain(..),
           delays.drain(..),
-          fill_modes.drain(..),
-          timelines.to_mut().drain(..)
+          fill_modes.drain(..)
         )
         .map(
-          |(
-            name,
-            duration,
-            timing_function,
-            iteration_count,
-            direction,
-            play_state,
-            delay,
-            fill_mode,
-            timeline,
-          )| {
+          |(name, duration, timing_function, iteration_count, direction, play_state, delay, fill_mode)| {
             Animation {
               name,
               duration,
@@ -994,17 +954,13 @@ impl<'i> AnimationHandler<'i> {
               play_state,
               delay,
               fill_mode,
-              timeline: if timeline_property.is_some() {
-                AnimationTimeline::Auto
-              } else {
-                timeline
-              },
             }
           },
         )
         .collect();
         let prefix = context.targets.prefixes(intersection, Feature::Animation);
         dest.push(Property::Animation(animations, prefix));
+        pushed_shorthand = true;
         names_vp.remove(intersection);
         durations_vp.remove(intersection);
         timing_functions_vp.remove(intersection);
@@ -1013,11 +969,6 @@ impl<'i> AnimationHandler<'i> {
         play_states_vp.remove(intersection);
         delays_vp.remove(intersection);
         fill_modes_vp.remove(intersection);
-
-        if let Some(p) = timeline_property {
-          dest.push(p);
-        }
-        timelines_value = None;
       }
     }
 
@@ -1041,8 +992,11 @@ impl<'i> AnimationHandler<'i> {
     prop!(delays, AnimationDelay);
     prop!(fill_modes, AnimationFillMode);
 
-    if let Some(val) = timelines_value {
-      dest.push(Property::AnimationTimeline(val));
+    if let Some(val) = timelines {
+      // A preceding animation shorthand already reset the timeline to auto.
+      if !(pushed_shorthand && val.iter().all(|t| *t == AnimationTimeline::Auto)) {
+        dest.push(Property::AnimationTimeline(val));
+      }
     }
 
     match (range_starts, range_ends) {


### PR DESCRIPTION
Fixes #1283

## Problem

`animation-timeline` is folded into the `animation` shorthand when both are set on the same rule:

```css
/* input */
.foo {
  animation: parallax 1ms linear both;
  animation-timeline: view();
}

/* output */
.foo {
  animation: 1ms linear both parallax view();
}
```

No engine accepts a timeline inside the shorthand, so the entire declaration is invalid and gets dropped. The animation silently stops running.

## Cause

`Feature::AnimationTimelineShorthand` is generated from the MDN BCD entry `css.properties.animation.animation-timeline_included`. That entry is marked **partial** for Chrome 115+, with the note:

> Support is currently reset-only. Including `animation` resets a previously-declared `animation-timeline` value to `auto`, but `animation-timeline` cannot be set via `animation`.

The partial flag was read as "settable", so `Animation` carried a `timeline` component that was parsed out of and written back into the shorthand.

`animation-range` is already modeled correctly as reset-only. This change brings `animation-timeline` in line with it.

## Changes

* Removed the `timeline` component from the `Animation` shorthand struct, its parse arm and its `to_css` output.
* `Property::Animation` (and the unparsed shorthand path, for `animation: var(--x)`) now clears any pending `animation-timeline`, preserving the reset semantics the spec requires.
* `flush` no longer requires `timelines.len() == len` to emit the shorthand, so a timeline list of a different length no longer blocks collapsing.
* When the shorthand is emitted and every timeline is `auto`, the redundant longhand is still dropped, since the shorthand already resets it.
* Regenerated `Animation` in `node/ast.d.ts`.

Invalid shorthand input such as `animation: foo 3s view()` now falls through to `Property::Unparsed` and is preserved as authored rather than reinterpreted.

## Notes

`Feature::AnimationTimelineShorthand` and its line in `scripts/build-prefixes.js` are now unused. I left both in place rather than hand editing generated `compat.rs`. Happy to remove them in a follow up, or here if you prefer.