### PR TITLE
Fix parsing of pseudo-elements and pseudo-classes after ::details-content

### DIFF
--- a/selectors/parser.rs
+++ b/selectors/parser.rs
@@ -48,6 +48,16 @@ pub trait PseudoElement<'i>: Sized + ToCss {
   fn is_unknown(&self) -> bool {
     false
   }
+
+  /// Whether this pseudo-element is element-backed.
+  ///
+  /// Element-backed pseudo-elements (such as `::details-content`) behave like
+  /// a type selector: pseudo-classes and other pseudo-elements may follow them.
+  ///
+  /// https://drafts.csswg.org/css-pseudo-4/#element-like
+  fn is_element_backed(&self) -> bool {
+    false
+  }
 }
 
 /// A trait that represents a pseudo-class.
@@ -122,8 +132,15 @@ bitflags! {
         /// as well.
         const AFTER_NON_STATEFUL_PSEUDO_ELEMENT = 1 << 4;
 
+        /// Whether we've parsed an element-backed pseudo-element (as in,
+        /// `::details-content`), which accepts tree-abiding pseudo-elements
+        /// and pseudo-classes after it.
+        ///
+        /// https://drafts.csswg.org/css-pseudo-4/#element-like
+        const AFTER_ELEMENT_BACKED_PSEUDO_ELEMENT = 1 << 11;
+
         /// Whether we are after any of the pseudo-like things.
-        const AFTER_PSEUDO = Self::AFTER_PART.bits() | Self::AFTER_SLOTTED.bits() | Self::AFTER_PSEUDO_ELEMENT.bits();
+        const AFTER_PSEUDO = Self::AFTER_PART.bits() | Self::AFTER_SLOTTED.bits() | Self::AFTER_PSEUDO_ELEMENT.bits() | Self::AFTER_ELEMENT_BACKED_PSEUDO_ELEMENT.bits();
 
         /// Whether we explicitly disallow combinators.
         const DISALLOW_COMBINATORS = 1 << 5;
@@ -163,7 +180,11 @@ impl SelectorParsingState {
   // state, and so on.
   #[inline]
   fn allows_custom_functional_pseudo_classes(self) -> bool {
-    !self.intersects(Self::AFTER_PSEUDO)
+    // Functional pseudo-classes are allowed after ::part and element-backed
+    // pseudo-elements, but not after ::slotted() or non-element-backed
+    // pseudo-elements.
+    // https://drafts.csswg.org/css-pseudo-4/#element-like
+    !self.intersects(Self::AFTER_SLOTTED | Self::AFTER_PSEUDO_ELEMENT)
   }
 
   #[inline]
@@ -2776,7 +2797,10 @@ where
         builder.push_simple_selector(Component::Slotted(selector));
       }
       SimpleSelectorParseResult::PseudoElement(p) => {
-        if !p.is_unknown() {
+        if p.is_element_backed() {
+          state.insert(SelectorParsingState::AFTER_ELEMENT_BACKED_PSEUDO_ELEMENT);
+          builder.push_combinator(Combinator::PseudoElement);
+        } else if !p.is_unknown() {
           state.insert(SelectorParsingState::AFTER_PSEUDO_ELEMENT);
           builder.push_combinator(Combinator::PseudoElement);
         } else {
@@ -3157,6 +3181,7 @@ pub mod tests {
   pub enum PseudoElement {
     Before,
     After,
+    DetailsContent,
   }
 
   impl<'i> parser::PseudoElement<'i> for PseudoElement {
@@ -3168,6 +3193,10 @@ pub mod tests {
 
     fn valid_after_slotted(&self) -> bool {
       true
+    }
+
+    fn is_element_backed(&self) -> bool {
+      matches!(*self, PseudoElement::DetailsContent)
     }
   }
 
@@ -3210,6 +3239,7 @@ pub mod tests {
       match *self {
         PseudoElement::Before => dest.write_str("::before"),
         PseudoElement::After => dest.write_str("::after"),
+        PseudoElement::DetailsContent => dest.write_str("::details-content"),
       }
     }
   }
@@ -3380,6 +3410,7 @@ pub mod tests {
       match_ignore_ascii_case! { &name,
           "before" => return Ok(PseudoElement::Before),
           "after" => return Ok(PseudoElement::After),
+          "details-content" => return Ok(PseudoElement::DetailsContent),
           _ => {}
       }
       Err(location.new_custom_error(SelectorParseErrorKind::UnsupportedPseudoElement(name)))
@@ -3984,6 +4015,28 @@ pub mod tests {
     assert_eq!(iter.next(), Some(&Component::PseudoElement(PseudoElement::Before)));
     assert_eq!(iter.next(), None);
     assert_eq!(iter.next_sequence(), Some(Combinator::PseudoElement));
+    assert_eq!(iter.next(), None);
+    assert_eq!(iter.next_sequence(), None);
+  }
+
+  #[test]
+  fn test_pseudo_on_element_backed_pseudo() {
+    let selector = &parse("::details-content::before").unwrap().0[0];
+    let mut iter = selector.iter();
+    assert_eq!(
+      iter.next(),
+      Some(&Component::PseudoElement(PseudoElement::Before))
+    );
+    assert_eq!(iter.next(), None);
+    let combinator = iter.next_sequence();
+    assert_eq!(combinator, Some(Combinator::PseudoElement));
+    assert_eq!(
+      iter.next(),
+      Some(&Component::PseudoElement(PseudoElement::DetailsContent))
+    );
+    assert_eq!(iter.next(), None);
+    let combinator = iter.next_sequence();
+    assert_eq!(combinator, Some(Combinator::PseudoElement));
     assert_eq!(iter.next(), None);
     assert_eq!(iter.next_sequence(), None);
   }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6822,6 +6822,19 @@ mod tests {
       "custom-element::part(foo) {color:red}",
       "custom-element::part(foo){color:red}",
     );
+    // https://github.com/parcel-bundler/lightningcss/issues/1244
+    minify_test("::details-content::before {color:red}", "::details-content:before{color:red}");
+    minify_test("::details-content::after {color:red}", "::details-content:after{color:red}");
+    minify_test("::details-content::marker {color:red}", "::details-content::marker{color:red}");
+    minify_test(
+      "details::details-content::before {color:red}",
+      "details::details-content:before{color:red}",
+    );
+    // https://github.com/parcel-bundler/lightningcss/issues/1244
+    error_test(
+      "::details-content::part(foo) {color:red}",
+      ParserError::SelectorError(SelectorError::InvalidState),
+    );
     minify_test(".sm\\:text-5xl { font-size: 3rem }", ".sm\\:text-5xl{font-size:3rem}");
     minify_test("a:has(> img) {color:red}", "a:has(>img){color:red}");
     minify_test("dt:has(+ dt) {color:red}", "dt:has(+dt){color:red}");

--- a/src/selector.rs
+++ b/src/selector.rs
@@ -1356,6 +1356,10 @@ impl<'i> parcel_selectors::parser::PseudoElement<'i> for PseudoElement<'i> {
       PseudoElement::Custom { .. } | PseudoElement::CustomFunction { .. },
     )
   }
+
+  fn is_element_backed(&self) -> bool {
+    matches!(*self, PseudoElement::DetailsContent)
+  }
 }
 
 impl<'i> PseudoElement<'i> {


### PR DESCRIPTION
Fixes #1244

## Problem

Selectors chaining pseudo-elements off `::details-content` fail to parse:

```css
::details-content::before { color: red }   /* error: Invalid state */
details::details-content::after { content: '' }
```

## Root cause

`::details-content` is an [element-backed pseudo-element](https://drafts.csswg.org/css-pseudo-4/#element-like): it behaves like a type selector, so other pseudo-elements and pseudo-classes may follow it. The parser did not model this distinction, and treated every known pseudo-element the same way as `::before` (which cannot be followed by further pseudo-elements).

## Changes

The relationship between pseudo-elements is now modeled comprehensively, mirroring the current upstream [`selectors`](https://github.com/servo/stylo/blob/main/selectors/parser.rs) parser in servo/stylo (where Firefox implements `::details-content`) and the Chromium change that allowed almost all pseudo-elements after `::part()` (crrev.com/c/5823774):

- Rename the parsing state to `AFTER_NON_ELEMENT_BACKED_PSEUDO`, add `AFTER_BEFORE_OR_AFTER_PSEUDO`, and add `PseudoElement::{parses_as_element_backed, is_before_or_after, valid_after_before_or_after}` trait methods, matching upstream naming.
- Element-backed pseudo-elements now parse exactly like `::part()`: all pseudo-classes (including functional ones like `:lang()`) and all other pseudo-elements may follow them, and they may also follow `::part()` itself, e.g. `::part(foo)::details-content::before`. `::part()`, `::slotted()`, combinators and type/class/id selectors remain errors after them.
- `::before`/`::after` accept a single following pseudo-element, restricted to a `valid_after_before_or_after()` allowlist that currently only contains `::marker` (per [css-pseudo-4](https://drafts.csswg.org/css-pseudo-4/#marker-pseudo)), so `::before::marker` and `::details-content::before::marker` parse while e.g. `::before::before`, `::marker::marker` and `::before::details-content` are still errors.
- lightningcss also marks `::picker()` as element-backed, matching Gecko (stylo's `pseudo_elements.toml`). The view-transition pseudo-elements are deliberately left out: css-view-transitions only allows `:only-child` after them.
- A bare element-backed pseudo-element now also sets the `HAS_PSEUDO` selector flag, so such selectors are excluded from the `:is()` lowering in `rules/mod.rs` (where pseudo-elements are not allowed).

Now all of these parse:

```css
::details-content::before { color: red }
::details-content::after { content: '' }
::details-content::marker { color: red }
::details-content::before::marker { color: red }
details::details-content::before { color: red }
details::details-content:lang(en)::before { content: '' }
::part(foo)::details-content::before { color: red }
::part(foo)::marker { color: red }
::picker(select)::before { color: red }
```

while these remain errors (matching browsers):

```css
::details-content div { color: red }          /* error */
::details-content.foo { color: red }          /* error */
::details-content::part(x) { color: red }     /* error */
::details-content::slotted(div) { color: red } /* error */
::details-content::before::after { color: red } /* error */
::before::before { color: red }               /* error */
::marker::marker { color: red }               /* error */
::view-transition-group(foo)::before { color: red } /* error */
```

## Tests

- selectors: `test_pseudo_on_element_backed_pseudo`, plus new `test_pseudo_duplicate_before_after_or_marker`, `test_pseudo_after_before_or_after` and `test_pseudo_after_part` (mirroring upstream), and `test_parsing` now covers the chains above.
- lightningcss: minify tests for `::details-content::before/after/marker`, `::before::marker`, `::details-content::before::marker`, `details::details-content::before`, `::part(foo)::details-content::before` and `::picker(select)::before`, plus error tests for `::details-content::part(foo)`, `::details-content::slotted(div)`, `::details-content::before::before`, `::details-content::before::selection`, `::before::details-content`, `::marker::marker` and `::part(foo)::part(bar)`.
- Also fixes the pre-existing `test_parsing` failures in the selectors crate (the `DummyParser` was missing `::target-text`, `::search-text`, `:current`, `::highlight()`, `::picker()`, `::picker-icon`, `::checkmark`, `::grammar-error` and `::spelling-error`), so that suite is fully green.
