### PR TITLE
Fix invalid selectors

### DIFF
--- a/node/test/transform.test.mjs
+++ b/node/test/transform.test.mjs
@@ -99,9 +99,6 @@ test('minification works as expected on older yet modern android versions', () =
 })
 
 test('throws on an invalid pseudo-element inside :has()', () => {
-  // Pseudo-elements are not valid within :has(), and :has() is a non-forgiving
-  // relative selector list, so the whole selector is invalid rather than
-  // producing an empty :has(). See https://github.com/parcel-bundler/lightningcss/issues/1239
   let error;
   try {
     transform({
@@ -118,9 +115,7 @@ test('throws on an invalid pseudo-element inside :has()', () => {
 
 test('throws on an empty or malformed :has()', () => {
   const invalid = {
-    // An empty :has() is invalid (non-forgiving relative selector list).
     'foo:has() { color: red }': 'Unexpected end of input',
-    // `slot="selection"` is not a valid selector (missing attribute brackets).
     'foo:has(slot="selection") { color: red }': `Unexpected token Delim('=')`,
   };
 
@@ -144,8 +139,6 @@ test('drops the rule and warns for an invalid :has() when error recovery is enab
     minify: true,
   });
 
-  // The invalid rule is dropped entirely (no invalid empty `:has()` is emitted),
-  // the valid rule is preserved, and a warning is surfaced.
   assert.equal(res.code.toString(), 'a{color:green}');
   assert.equal(res.warnings.length, 1);
   assert.equal(res.warnings[0].message, 'Invalid state');

--- a/node/test/transform.test.mjs
+++ b/node/test/transform.test.mjs
@@ -98,4 +98,57 @@ test('minification works as expected on older yet modern android versions', () =
   assert.equal(res.code.toString(), '.foo{color:#0000}');
 })
 
+test('throws on an invalid pseudo-element inside :has()', () => {
+  // Pseudo-elements are not valid within :has(), and :has() is a non-forgiving
+  // relative selector list, so the whole selector is invalid rather than
+  // producing an empty :has(). See https://github.com/parcel-bundler/lightningcss/issues/1239
+  let error;
+  try {
+    transform({
+      filename: 'test.css',
+      code: Buffer.from('video:not(:has(::backdrop)) { color: red }'),
+    });
+  } catch (err) {
+    error = err;
+  }
+
+  assert.ok(error, 'expected transform to throw');
+  assert.equal(error.message, 'Invalid state');
+});
+
+test('throws on an empty or malformed :has()', () => {
+  const invalid = {
+    // An empty :has() is invalid (non-forgiving relative selector list).
+    'foo:has() { color: red }': 'Unexpected end of input',
+    // `slot="selection"` is not a valid selector (missing attribute brackets).
+    'foo:has(slot="selection") { color: red }': `Unexpected token Delim('=')`,
+  };
+
+  for (let [code, message] of Object.entries(invalid)) {
+    let error;
+    try {
+      transform({ filename: 'test.css', code: Buffer.from(code) });
+    } catch (err) {
+      error = err;
+    }
+    assert.ok(error, `expected transform to throw for ${code}`);
+    assert.equal(error.message, message, `wrong message for ${code}`);
+  }
+});
+
+test('drops the rule and warns for an invalid :has() when error recovery is enabled', () => {
+  let res = transform({
+    filename: 'test.css',
+    code: Buffer.from('video:not(:has(::backdrop)) { color: red } a { color: green }'),
+    errorRecovery: true,
+    minify: true,
+  });
+
+  // The invalid rule is dropped entirely (no invalid empty `:has()` is emitted),
+  // the valid rule is preserved, and a warning is surfaced.
+  assert.equal(res.code.toString(), 'a{color:green}');
+  assert.equal(res.warnings.length, 1);
+  assert.equal(res.warnings[0].message, 'Invalid state');
+});
+
 test.run();

--- a/selectors/parser.rs
+++ b/selectors/parser.rs
@@ -2838,12 +2838,12 @@ where
   P: Parser<'i, Impl = Impl>,
   Impl: SelectorImpl<'i>,
 {
-  let mut child_state = *state;
+  let mut child_state = *state | SelectorParsingState::DISALLOW_PSEUDOS;
   let inner = SelectorList::parse_relative_with_state(
     parser,
     input,
     &mut child_state,
-    parser.is_and_where_error_recovery(),
+    ParseErrorRecovery::DiscardList,
     NestingRequirement::None,
   )?;
   if child_state.contains(SelectorParsingState::AFTER_NESTING) {
@@ -3929,6 +3929,15 @@ pub mod tests {
     assert!(parse("foo:where()").is_err());
     assert!(parse("foo:where(div, foo, .bar baz)").is_ok());
     assert!(parse("foo:where(::before)").is_err());
+
+    assert!(parse("foo:has(bar)").is_ok());
+    assert!(parse("foo:has(::before)").is_err());
+    assert!(parse("foo:not(:has(::before))").is_err());
+    assert!(parse("foo:has(bar, ::before)").is_err());
+    assert!(parse("foo:has()").is_err());
+    assert!(parse("foo:has(slot=\"selection\")").is_err());
+    assert!(parse("foo:has()").is_err());
+    assert!(parse(":has(slot=\"selection\")").is_err());
 
     assert!(parse("foo::details-content").is_ok());
     assert!(parse("foo::target-text").is_ok());

--- a/selectors/parser.rs
+++ b/selectors/parser.rs
@@ -3936,7 +3936,6 @@ pub mod tests {
     assert!(parse("foo:has(bar, ::before)").is_err());
     assert!(parse("foo:has()").is_err());
     assert!(parse("foo:has(slot=\"selection\")").is_err());
-    assert!(parse("foo:has()").is_err());
     assert!(parse(":has(slot=\"selection\")").is_err());
 
     assert!(parse("foo::details-content").is_ok());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6845,9 +6845,7 @@ mod tests {
       "video:not(:has(::backdrop)) {color:red}",
       ParserError::SelectorError(SelectorError::InvalidState),
     );
-    // An empty :has() is invalid (non-forgiving relative selector list).
     error_test("foo:has() {color:red}", ParserError::EndOfInput);
-    // `slot="selection"` is not a valid selector (missing attribute brackets).
     error_test(
       "foo:has(slot=\"selection\") {color:red}",
       ParserError::UnexpectedToken(Token::Delim('=')),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6837,6 +6837,21 @@ mod tests {
     minify_test(".x:has(.bar, #foo) {color:red}", ".x:has(.bar,#foo){color:red}");
     minify_test(".x:has(span + span) {color:red}", ".x:has(span+span){color:red}");
     minify_test("a:has(:visited) {color:red}", "a:has(:visited){color:red}");
+    error_test(
+      "a:has(::before) {color:red}",
+      ParserError::SelectorError(SelectorError::InvalidState),
+    );
+    error_test(
+      "video:not(:has(::backdrop)) {color:red}",
+      ParserError::SelectorError(SelectorError::InvalidState),
+    );
+    // An empty :has() is invalid (non-forgiving relative selector list).
+    error_test("foo:has() {color:red}", ParserError::EndOfInput);
+    // `slot="selection"` is not a valid selector (missing attribute brackets).
+    error_test(
+      "foo:has(slot=\"selection\") {color:red}",
+      ParserError::UnexpectedToken(Token::Delim('=')),
+    );
     for element in [
       "-webkit-scrollbar",
       "-webkit-scrollbar-button",


### PR DESCRIPTION
closes: https://github.com/parcel-bundler/lightningcss/issues/1239

unlike `:is` and `:where` which are forgiving selectors and can be empty, `:has` is not.

https://www.w3.org/TR/selectors-4/#forgiving-selector
https://www.w3.org/TR/selectors-4/#changes-2022-05 

The only thing I'm a little confused on is https://www.w3.org/TR/selectors-4/#has-allowed-pseudo-element says 
> Also, unless explicitly defined as a :has-allowed pseudo-element, [pseudo-elements](https://www.w3.org/TR/selectors-4/#pseudo-element) are not valid selectors within :has(). (This specification does not define any [:has-allowed pseudo-elements](https://www.w3.org/TR/selectors-4/#has-allowed-pseudo-element), but other specifications may do so.)

I'm not sure what the other specifications are which would define these. We could introduce support for this in the future though. Given that it was already removing the inside selector [in some scenarios](https://lightningcss.dev/playground/#%7B%22minify%22%3Afalse%2C%22customMedia%22%3Atrue%2C%22cssModules%22%3Afalse%2C%22analyzeDependencies%22%3Afalse%2C%22targets%22%3A%7B%22chrome%22%3A6225920%7D%2C%22include%22%3A0%2C%22exclude%22%3A0%2C%22source%22%3A%22a%3A%3Abefore%20%7B%5Cn%20%20content%3A%20'%3E'%5Cn%7D%5Cn%5Cna%3Ahas(%3A%3Abefore)%20%7B%5Cn%20%20color%3A%20green%3B%5Cn%7D%5Cn%5Cna%3Anot(%3Ahas(%3A%3Abefore))%20%7B%5Cn%20%20color%3A%20red%5Cn%7D%5Cn%22%2C%22visitorEnabled%22%3Afalse%2C%22visitor%22%3A%22%7B%5Cn%20%20Color(color)%20%7B%5Cn%20%20%20%20if%20(color.type%20%3D%3D%3D%20'rgb')%20%7B%5Cn%20%20%20%20%20%20color.g%20%3D%200%3B%5Cn%20%20%20%20%20%20return%20color%3B%5Cn%20%20%20%20%7D%5Cn%20%20%7D%5Cn%7D%22%2C%22unusedSymbols%22%3A%5B%5D%2C%22version%22%3A%22local%22%7D) I think this isn't introducing a regression for anyone trying to use an "other specification" allowed pseudo element.

This would've caught and prevented https://github.com/adobe/react-spectrum/issues/10468