### PR TITLE
Fix panic when generating color fallbacks for gradients using currentColor

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14211,6 +14211,20 @@ mod tests {
       },
     );
 
+    prefix_test(
+      ".foo { background-image: linear-gradient(oklch(0% 0 0), oklch(100% 0 0)), linear-gradient(currentcolor, currentcolor); }",
+      indoc! { r#"
+        .foo {
+          background-image: linear-gradient(#000, #fff), linear-gradient(currentColor, currentColor);
+          background-image: linear-gradient(lab(0% 0 0), lab(100% 0 0)), linear-gradient(currentColor, currentColor);
+        }
+      "#},
+      Browsers {
+        chrome: Some(90 << 16),
+        ..Browsers::default()
+      },
+    );
+
     // Test cases from https://github.com/postcss/autoprefixer/blob/541295c0e6dd348db2d3f52772b59cd403c59d29/test/cases/gradient.css
     prefix_test(
       r#"

--- a/src/values/color.rs
+++ b/src/values/color.rs
@@ -509,7 +509,7 @@ impl CssColor {
 
   /// Returns a fallback color for the given fallback type.
   pub fn get_fallback(&self, kind: ColorFallbackKind) -> CssColor {
-    if matches!(self, CssColor::RGBA(_)) {
+    if matches!(self, CssColor::CurrentColor | CssColor::RGBA(_) | CssColor::System(_)) {
       return self.clone();
     }
 


### PR DESCRIPTION
This PR aims to fix a crash when generating color fallbacks for CSS such as:

```css
.foo {
  background-image:
    linear-gradient(oklch(0% 0 0), oklch(100% 0 0)),
    linear-gradient(currentcolor, currentcolor);
}
```

When targeting a browser without `oklch()` support, Lightning CSS generates fallbacks for every gradient in the declaration. This caused it to attempt converting `currentColor` to RGB, P3, or Lab and panic.



Found the same issue in `text-shadow`. Making a separate PR for that.