### PR TITLE
fix(supports): keep vendor prefixes when merging @supports conditions

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15376,6 +15376,42 @@ mod tests {
   }
 
   #[test]
+  fn test_supports_vendor_prefixes_preserved() {
+    // Issue #710: a prefixed feature query is load-bearing *because* it is
+    // prefixed, so un-prefixing one inverts what its author asked for.
+    // These only broke as an operand of `and` / `or`; a lone condition is
+    // returned straight from `parse` and never reaches the merge path.
+    minify_test(
+      "@supports (display: flex) and (-webkit-box-orient: vertical) { .a { color: red } }",
+      "@supports (display:flex) and ((-webkit-box-orient:vertical)){.a{color:red}}",
+    );
+    minify_test(
+      "@supports (display: flex) or (-moz-appearance: none) { .a { color: red } }",
+      "@supports (display:flex) or ((-moz-appearance:none)){.a{color:red}}",
+    );
+    minify_test(
+      "@supports (-webkit-backdrop-filter: blur(1px)) and (display: flex) { .a { color: red } }",
+      "@supports ((-webkit-backdrop-filter:blur(1px))) and (display:flex){.a{color:red}}",
+    );
+    // The original report: only the middle condition was being rewritten.
+    minify_test(
+      "@supports (display: -webkit-box) and (-webkit-box-orient: vertical) and (-webkit-line-clamp: 3) { .a { color: red } }",
+      "@supports (display:-webkit-box) and ((-webkit-box-orient:vertical)) and (-webkit-line-clamp:3){.a{color:red}}",
+    );
+    // A lone condition was already correct and must stay that way.
+    minify_test(
+      "@supports (-webkit-box-orient: vertical) { .a { color: red } }",
+      "@supports ((-webkit-box-orient:vertical)){.a{color:red}}",
+    );
+    // Merging equal declarations across prefixes still collapses into one
+    // condition carrying every prefix seen.
+    minify_test(
+      "@supports (-webkit-box-orient: vertical) or (-moz-box-orient: vertical) { .a { color: red } }",
+      "@supports ((-webkit-box-orient:vertical) or (-moz-box-orient:vertical)){.a{color:red}}",
+    );
+  }
+
+  #[test]
   fn test_counter_style() {
     test(
       r#"

--- a/src/rules/supports.rs
+++ b/src/rules/supports.rs
@@ -236,8 +236,15 @@ impl<'i> Parse<'i> for SupportsCondition<'i> {
 
         if let SupportsCondition::Declaration { property_id, value } = condition {
           // Merge multiple declarations with the same property id (minus prefix) and value together.
-          let property_id = property_id.with_prefix(VendorPrefix::None);
-          let key = (property_id.clone(), value.clone());
+          //
+          // The prefix is dropped for the lookup key only. It is what makes two
+          // conditions equivalent for merging, and it is also load-bearing in the
+          // output: `@supports (-webkit-box-orient: vertical)` asks a different
+          // question than the unprefixed property, which no browser implements.
+          // Shadowing `property_id` here dropped the prefix from the condition that
+          // got pushed, and made `add_prefix` below add `None` rather than the
+          // prefix actually seen. See #710.
+          let key = (property_id.with_prefix(VendorPrefix::None), value.clone());
           if let Some(index) = seen_declarations.get(&key) {
             if let SupportsCondition::Declaration {
               property_id: cur_property,


### PR DESCRIPTION
Fixes #710.

## The bug

`SupportsCondition::parse` merges operands that share a property id and value while
ignoring the prefix, so `(-webkit-x: v) or (-moz-x: v)` collapses into one condition
carrying both prefixes. It built the lookup key by shadowing `property_id` with its
unprefixed form:

```rust
let property_id = property_id.with_prefix(VendorPrefix::None);
let key = (property_id.clone(), value.clone());
```

Dropping the prefix is right for the key, since that is what makes two conditions
equivalent for merging. Binding it back over `property_id` lost the prefix for two
other purposes:

1. The `else` branch pushed the unprefixed id, so
   `(display: flex) and (-webkit-box-orient: vertical)` serialized as
   `(box-orient: vertical)`. No browser implements the unprefixed property, so the
   query stops matching.
2. `cur_property.add_prefix(property_id.prefix())` in the merge branch read the
   already stripped id, so it added `VendorPrefix::None` rather than the prefix
   actually seen.

The fix builds the key inline and leaves `property_id` alone, so both branches see
the real prefix. One line, plus a comment explaining why the prefix has to survive.

## Why only compound conditions

Worth recording, because it makes the bug look fixed if you reduce it wrong. A lone
condition never reaches this code: `conditions` is only populated once a second
operand parses, and a solo condition is returned as `in_parens` straight out of
`parse`. So `@supports (-webkit-box-orient: vertical)` was always correct, and only
`and` / `or` triggered it. That matches the report, where of the three conditions in
the original example only the middle one was rewritten.

The double parens some of these expectations carry are pre-existing `to_css`
behaviour: the `Declaration` arm wraps in an extra pair whenever the prefix set is
non-empty, since it may need to expand to `(a) or (b)`.

## Both failure directions

The issue and #341 describe the loud direction, where the rewritten query matches
nothing and styles never apply. There is a quieter one. Chromium implements
unprefixed `appearance`, so

```css
@supports (not selector(::-webkit-scrollbar)) or (-moz-appearance: none) { … }
```

is a Firefox-only arm in the source and matches in Chromium after minification. The
styles apply exactly where they were written to stay out, the source still reads
correct, and nothing warns.

## Tests

`test_supports_vendor_prefixes_preserved`, six cases: `and`, `or`, a prefixed first
operand, the original three-condition report, a lone condition as the control that
this path was already correct, and a cross-prefix merge that pins the
`add_prefix` half.

Reverting `src/rules/supports.rs` while keeping the test fails it on the first case,
`(display:flex) and (box-orient:vertical)` against the expected
`(display:flex) and ((-webkit-box-orient:vertical))`.

## Verification

```
cargo test        133 passed, 0 failed, across all 5 targets
cargo fmt         clean for both touched files
```

`cargo fmt --check` reports 4 pre-existing diffs on an unmodified checkout
(`src/bundler.rs` among them). Those are left alone rather than swept into this diff.

## AI usage disclosure

Drafted with Claude Code. There is no policy here requiring this note; it is the same
disclosure I put on an oxc PR that does require one, and it seems worth being
consistent about. The diagnosis and the fix were checked against the source rather
than guessed: the test was written first and confirmed failing, and the verification
numbers above were run rather than asserted.
