### PR TITLE
Error on nested @property and @position-try rules

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14850,6 +14850,18 @@ mod tests {
       }"#,
       "@supports (anchor-name:--foo){@position-try --bar{top:anchor(bottom)}}",
     );
+
+    // Not allowed nested inside a style rule.
+    error_test(
+      r#"
+      .foo {
+        @position-try --bar {
+          top: anchor(bottom);
+        }
+      }
+    "#,
+      ParserError::AtRuleInvalid("position-try".into()),
+    );
   }
 
   #[test]
@@ -30146,6 +30158,42 @@ mod tests {
         }
     "#},
     );
+
+    // @property must appear at the top level of a stylesheet. Nested inside a
+    // style rule it is invalid and should error, just like other rules that are
+    // not allowed in a style rule (e.g. @keyframes).
+    error_test(
+      r#"
+      .foo {
+        @property --angle {
+          syntax: '<angle>';
+          inherits: false;
+          initial-value: 0deg;
+        }
+
+        color: red;
+      }
+    "#,
+      ParserError::AtRuleInvalid("property".into()),
+    );
+
+    // With error recovery enabled the same input produces a warning instead of
+    // failing the whole parse.
+    let warnings = error_recovery_test(
+      r#"
+      .foo {
+        @property --angle {
+          syntax: '<angle>';
+          inherits: false;
+          initial-value: 0deg;
+        }
+
+        color: red;
+      }
+    "#,
+    );
+    assert_eq!(warnings.len(), 1);
+    assert_eq!(warnings[0].kind, ParserError::AtRuleInvalid("property".into()));
   }
 
   #[test]

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -730,12 +730,12 @@ impl<'a, 'b, 'i, T: crate::traits::AtRuleParser<'i>> AtRuleParser<'i> for Nested
 
       "property" => {
         let name = DashedIdent::parse(input)?;
-        return Ok(AtRulePrelude::Property(name))
+        AtRulePrelude::Property(name)
       },
 
       "position-try" => {
         let name = DashedIdent::parse(input)?;
-        return Ok(AtRulePrelude::PositionTry(name))
+        AtRulePrelude::PositionTry(name)
       },
 
       _ => parse_custom_at_rule_prelude(&name, input, self.options, self.at_rule_parser)?


### PR DESCRIPTION
`@property` must appear at the top level of a stylesheet, but when it was nested inside a style rule the prelude parser returned early and skipped the check that rejects at-rules which aren't allowed in a style rule. So a nested `@property` was silently kept instead of erroring the way `@keyframes` does, and when the nesting was left in place (e.g. targeting Chrome >= 120 where nesting is preserved) the output was invalid CSS.

This lets `@property` fall through to the same `allowed_in_style_rule()` check as the other top-level-only rules, so nesting one in a style rule now errors, or warns when `error_recovery` is enabled. `@position-try` had the same early return, so it gets the same treatment.

Fixes: https://github.com/parcel-bundler/lightningcss/issues/962
