### PR TITLE
Report CLI parse errors instead of panicking

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -186,41 +186,37 @@ pub fn main() -> Result<(), std::io::Error> {
 
       let mut stylesheet = if cli_args.bundle {
         let mut bundler = Bundler::new(&fs, source_map.as_mut(), options);
-        bundler.bundle(Path::new(&filename)).unwrap()
+        report_error(bundler.bundle(Path::new(&filename)))
       } else {
         if let Some(sm) = &mut source_map {
           sm.add_source(&filename);
           let _ = sm.set_source_content(0, &source);
         }
         options.filename = filename;
-        StyleSheet::parse(&source, options).unwrap()
+        report_error(StyleSheet::parse(&source, options))
       };
 
       let targets = if !cli_args.targets.is_empty() {
-        Browsers::from_browserslist(&cli_args.targets).unwrap()
+        report_error(Browsers::from_browserslist(&cli_args.targets))
       } else if cli_args.browserslist {
-        Browsers::load_browserslist().unwrap()
+        report_error(Browsers::load_browserslist())
       } else {
         None
       }
       .into();
 
-      stylesheet
-        .minify(MinifyOptions {
-          targets,
-          ..MinifyOptions::default()
-        })
-        .unwrap();
+      report_error(stylesheet.minify(MinifyOptions {
+        targets,
+        ..MinifyOptions::default()
+      }));
 
-      stylesheet
-        .to_css(PrinterOptions {
-          minify: cli_args.minify,
-          source_map: source_map.as_mut(),
-          project_root: Some(&project_root.to_string_lossy()),
-          targets,
-          ..PrinterOptions::default()
-        })
-        .unwrap()
+      report_error(stylesheet.to_css(PrinterOptions {
+        minify: cli_args.minify,
+        source_map: source_map.as_mut(),
+        project_root: Some(&project_root.to_string_lossy()),
+        targets,
+        ..PrinterOptions::default()
+      }))
     };
 
     let map = if let Some(ref mut source_map) = source_map {
@@ -291,6 +287,18 @@ pub fn main() -> Result<(), std::io::Error> {
   }
 
   Ok(())
+}
+
+// Print a parse/transform error and exit instead of panicking, so bad input
+// doesn't produce a backtrace and core dump.
+fn report_error<T, E: std::fmt::Display>(result: Result<T, E>) -> T {
+  match result {
+    Ok(value) => value,
+    Err(err) => {
+      eprintln!("{}", err);
+      std::process::exit(1);
+    }
+  }
 }
 
 fn infer_css_modules_filename(path: &Path) -> Result<String, std::io::Error> {

--- a/tests/cli_integration_tests.rs
+++ b/tests/cli_integration_tests.rs
@@ -792,6 +792,42 @@ fn browserslist_environment_from_browserslist_env() -> Result<(), Box<dyn std::e
 }
 
 #[test]
+/// A syntax error in the input should print a readable error and exit with a
+/// non-zero code, not panic with a backtrace. See #578.
+fn syntax_error_input_file() -> Result<(), Box<dyn std::error::Error>> {
+  let file = assert_fs::NamedTempFile::new("test.css")?;
+  file.write_str(
+    r#"
+      .cls {
+        asd
+      }
+    "#,
+  )?;
+
+  let mut cmd = Command::cargo_bin("lightningcss")?;
+  cmd.arg(file.path());
+  cmd
+    .assert()
+    .failure()
+    .stderr(predicate::str::contains("panicked").not())
+    .stderr(predicate::str::contains("end of input"));
+
+  Ok(())
+}
+
+#[test]
+/// An invalid `--targets` value should also fail cleanly rather than panic.
+fn invalid_targets_option() -> Result<(), Box<dyn std::error::Error>> {
+  let file = test_file()?;
+  let mut cmd = Command::cargo_bin("lightningcss")?;
+  cmd.arg(file.path());
+  cmd.arg("--targets").arg("not a real query");
+  cmd.assert().failure().stderr(predicate::str::contains("panicked").not());
+
+  Ok(())
+}
+
+#[test]
 fn next_66191() -> Result<(), Box<dyn std::error::Error>> {
   let infile = assert_fs::NamedTempFile::new("test.css")?;
   infile.write_str(


### PR DESCRIPTION
Fixes #578.

The CLI called `.unwrap()` on the parse, minify and print results, so any syntax error in the input crashed with a backtrace and core dump instead of a readable message. This adds a small `report_error` helper that prints the error to stderr and exits with code 1, matching how the css-modules pattern parsing already handles errors. Invalid `--targets`/browserslist values are covered too since they had the same problem.

Now `echo '.cls { asd }' | lightningcss /dev/stdin` prints `Unexpected end of input at ...:2:1` and exits 1.

Added a couple of CLI integration tests covering the bad-input and bad-targets cases.
