### PR TITLE
fix(supports): keep the vendor prefix on a feature query inside and/or

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15078,6 +15078,28 @@ mod tests {
 
   #[test]
   fn test_supports_rule() {
+    // A vendor-prefixed feature query must keep its prefix when it is an OPERAND
+    // of `and` / `or`, not only when it stands alone. The merge pass bound the
+    // unprefixed id over `property_id` and then stored THAT, so a condition
+    // matching nothing already seen was pushed stripped: `-webkit-box-orient`
+    // became `box-orient`, which no browser implements, silently disabling the
+    // whole block. Regression test for #710.
+    //
+    // These carry no `Browsers` targets on purpose. Every existing assertion for
+    // this merge sets them, and the prefixing pass then re-adds what was lost,
+    // which is why the bug survived the tests that shipped with the feature.
+    minify_test(
+      "@supports (display: flex) and (-webkit-box-orient: vertical) { .a { color: red } }",
+      "@supports (display:flex) and ((-webkit-box-orient:vertical)){.a{color:red}}",
+    );
+    minify_test(
+      "@supports (display: flex) or (-moz-appearance: none) { .a { color: red } }",
+      "@supports (display:flex) or ((-moz-appearance:none)){.a{color:red}}",
+    );
+    minify_test(
+      "@supports (display: -webkit-box) and (-webkit-box-orient: vertical) and (-webkit-line-clamp: 3) { .a { color: red } }",
+      "@supports (display:-webkit-box) and ((-webkit-box-orient:vertical)) and (-webkit-line-clamp:3){.a{color:red}}",
+    );
     test(
       r#"
       @supports (foo: bar) {

--- a/src/rules/supports.rs
+++ b/src/rules/supports.rs
@@ -236,8 +236,12 @@ impl<'i> Parse<'i> for SupportsCondition<'i> {
 
         if let SupportsCondition::Declaration { property_id, value } = condition {
           // Merge multiple declarations with the same property id (minus prefix) and value together.
-          let property_id = property_id.with_prefix(VendorPrefix::None);
-          let key = (property_id.clone(), value.clone());
+          // The unprefixed id is the MATCH KEY only. Binding it over `property_id` also changed
+          // what got stored and what prefix got merged in, so a condition that matched nothing was
+          // pushed with its prefix stripped -- turning `(-webkit-box-orient: vertical)` into
+          // `(box-orient: vertical)`, which no browser implements.
+          let unprefixed = property_id.with_prefix(VendorPrefix::None);
+          let key = (unprefixed, value.clone());
           if let Some(index) = seen_declarations.get(&key) {
             if let SupportsCondition::Declaration {
               property_id: cur_property,


### PR DESCRIPTION
Fixes #710.

The `@supports` merge pass binds the unprefixed id **over** `property_id`, and then uses that binding for two more things: what it stores, and which prefix it merges in.

```rust
let property_id = property_id.with_prefix(VendorPrefix::None);   // shadows
let key = (property_id.clone(), value.clone());
if let Some(index) = seen_declarations.get(&key) {
    cur_property.add_prefix(property_id.prefix());               // always VendorPrefix::None
} else {
    seen_declarations.insert(key, conditions.len());
    conditions.push(SupportsCondition::Declaration { property_id, value });   // stored stripped
}
```

So a condition matching nothing already seen is pushed with its prefix gone, and `(-webkit-box-orient: vertical)` becomes `(box-orient: vertical)` — which [no browser implements](https://developer.mozilla.org/en-US/docs/Web/CSS/box-orient#browser_compatibility), so the block it guards silently never applies.

Using a separate binding for the match key fixes both symptoms. The unprefixed id is the **key** only; the condition keeps the prefix it was written with, and the merge branch adds the real prefix instead of `None`.

## Why it reads as an inconsistency rather than a plain regression

A prefixed query survives when it stands **alone**, because that path pushes `in_parens` untouched. It is only stripped as an operand of `and` / `or`. Measured on 1.33.0 before this change:

| condition | alone | inside `(display:flex) or …` |
|---|---|---|
| `(-webkit-box-orient:vertical)` | preserved | `(box-orient:vertical)` |
| `(-webkit-backdrop-filter:blur(1px))` | preserved | `(backdrop-filter:blur(1px))` |
| `(-moz-appearance:none)` | preserved | `(appearance:none)` |

Worth knowing for anyone triaging this: reducing a report to a single condition to check whether it still reproduces answers **no** on a build that is still broken.

## Why the existing tests did not catch it

Every assertion added with the merge feature in 6bd2761 sets `Browsers` targets, and the prefixing pass then re-adds what the merge dropped. The regression tests here deliberately set none, and they use `minify_test` rather than `prefix_test` for that reason.

## Verification

Before and after, same input, `minify: true`, no targets:

```
BEFORE   @supports (display:flex) and (box-orient:vertical){a{color:red}}
AFTER    @supports (display:flex) and ((-webkit-box-orient:vertical)){a{color:red}}
```

- 120/120 lib tests pass, including the merge assertions from 6bd2761
- the three added tests **fail without the fix**, printing the stripped form, and pass with it
- `cargo fmt` leaves both changed files untouched (it does reformat `bundler.rs`, `selector.rs` and an unrelated `lib.rs` line under current rustfmt; those are deliberately not included here)