### PR TITLE
Fix gamut mapping binary search

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1831,26 +1831,26 @@ mod tests {
       .foo:not(:-webkit-any(:lang(ae), :lang(ar), :lang(arc), :lang(bcc), :lang(bqi), :lang(ckb), :lang(dv), :lang(fa), :lang(glk), :lang(he), :lang(ku), :lang(mzn), :lang(nqo), :lang(pnb), :lang(ps), :lang(sd), :lang(ug), :lang(ur), :lang(yi))) {
         border-left-color: #b32323;
         border-left-color: lab(40% 56.6 39);
-        border-right-color: #ee00be;
+        border-right-color: #f000c0;
         border-right-color: lch(50.998% 135.363 338);
       }
 
       .foo:not(:is(:lang(ae), :lang(ar), :lang(arc), :lang(bcc), :lang(bqi), :lang(ckb), :lang(dv), :lang(fa), :lang(glk), :lang(he), :lang(ku), :lang(mzn), :lang(nqo), :lang(pnb), :lang(ps), :lang(sd), :lang(ug), :lang(ur), :lang(yi))) {
         border-left-color: #b32323;
         border-left-color: lab(40% 56.6 39);
-        border-right-color: #ee00be;
+        border-right-color: #f000c0;
         border-right-color: lch(50.998% 135.363 338);
       }
 
       .foo:-webkit-any(:lang(ae), :lang(ar), :lang(arc), :lang(bcc), :lang(bqi), :lang(ckb), :lang(dv), :lang(fa), :lang(glk), :lang(he), :lang(ku), :lang(mzn), :lang(nqo), :lang(pnb), :lang(ps), :lang(sd), :lang(ug), :lang(ur), :lang(yi)) {
-        border-left-color: #ee00be;
+        border-left-color: #f000c0;
         border-left-color: lch(50.998% 135.363 338);
         border-right-color: #b32323;
         border-right-color: lab(40% 56.6 39);
       }
 
       .foo:is(:lang(ae), :lang(ar), :lang(arc), :lang(bcc), :lang(bqi), :lang(ckb), :lang(dv), :lang(fa), :lang(glk), :lang(he), :lang(ku), :lang(mzn), :lang(nqo), :lang(pnb), :lang(ps), :lang(sd), :lang(ug), :lang(ur), :lang(yi)) {
-        border-left-color: #ee00be;
+        border-left-color: #f000c0;
         border-left-color: lch(50.998% 135.363 338);
         border-right-color: #b32323;
         border-right-color: lab(40% 56.6 39);
@@ -1874,13 +1874,13 @@ mod tests {
         border-left-color: #b32323;
         border-left-color: color(display-p3 .643308 .192455 .167712);
         border-left-color: lab(40% 56.6 39);
-        border-right-color: #ee00be;
+        border-right-color: #f000c0;
         border-right-color: color(display-p3 .972962 -.362078 .804206);
         border-right-color: lch(50.998% 135.363 338);
       }
 
       .foo:is(:lang(ae), :lang(ar), :lang(arc), :lang(bcc), :lang(bqi), :lang(ckb), :lang(dv), :lang(fa), :lang(glk), :lang(he), :lang(ku), :lang(mzn), :lang(nqo), :lang(pnb), :lang(ps), :lang(sd), :lang(ug), :lang(ur), :lang(yi)) {
-        border-left-color: #ee00be;
+        border-left-color: #f000c0;
         border-left-color: color(display-p3 .972962 -.362078 .804206);
         border-left-color: lch(50.998% 135.363 338);
         border-right-color: #b32323;
@@ -2426,9 +2426,9 @@ mod tests {
     "#,
       indoc! {r#"
       .foo {
-        -webkit-border-image: -webkit-gradient(linear, 0 0, 0 100%, from(#ff0f0e), to(#7773ff)) 60;
-        -webkit-border-image: -webkit-linear-gradient(top, #ff0f0e, #7773ff) 60;
-        border-image: linear-gradient(#ff0f0e, #7773ff) 60;
+        -webkit-border-image: -webkit-gradient(linear, 0 0, 0 100%, from(#ff0b0c), to(#766eff)) 60;
+        -webkit-border-image: -webkit-linear-gradient(top, #ff0b0c, #766eff) 60;
+        border-image: linear-gradient(#ff0b0c, #766eff) 60;
         border-image: linear-gradient(lch(56.208% 136.76 46.312), lch(51% 135.366 301.364)) 60;
       }
     "#
@@ -2447,10 +2447,10 @@ mod tests {
     "#,
       indoc! {r#"
       .foo {
-        -webkit-border-image: -webkit-gradient(linear, 0 0, 0 100%, from(#ff0f0e), to(#7773ff)) 60;
-        -webkit-border-image: -webkit-linear-gradient(top, #ff0f0e, #7773ff) 60;
-        -moz-border-image: -moz-linear-gradient(top, #ff0f0e, #7773ff) 60;
-        border-image: linear-gradient(#ff0f0e, #7773ff) 60;
+        -webkit-border-image: -webkit-gradient(linear, 0 0, 0 100%, from(#ff0b0c), to(#766eff)) 60;
+        -webkit-border-image: -webkit-linear-gradient(top, #ff0b0c, #766eff) 60;
+        -moz-border-image: -moz-linear-gradient(top, #ff0b0c, #766eff) 60;
+        border-image: linear-gradient(#ff0b0c, #766eff) 60;
         border-image: linear-gradient(lch(56.208% 136.76 46.312), lch(51% 135.366 301.364)) 60;
       }
     "#
@@ -2470,9 +2470,9 @@ mod tests {
     "#,
       indoc! {r#"
       .foo {
-        border-image: -webkit-linear-gradient(top, #ff0f0e, #7773ff) 60;
-        border-image: -moz-linear-gradient(top, #ff0f0e, #7773ff) 60;
-        border-image: linear-gradient(#ff0f0e, #7773ff) 60;
+        border-image: -webkit-linear-gradient(top, #ff0b0c, #766eff) 60;
+        border-image: -moz-linear-gradient(top, #ff0b0c, #766eff) 60;
+        border-image: linear-gradient(#ff0b0c, #766eff) 60;
         border-image: linear-gradient(lch(56.208% 136.76 46.312), lch(51% 135.366 301.364)) 60;
       }
     "#
@@ -2492,8 +2492,8 @@ mod tests {
     "#,
       indoc! {r#"
       .foo {
-        border-image-source: -webkit-linear-gradient(top, #ff0f0e, #7773ff);
-        border-image-source: linear-gradient(#ff0f0e, #7773ff);
+        border-image-source: -webkit-linear-gradient(top, #ff0b0c, #766eff);
+        border-image-source: linear-gradient(#ff0b0c, #766eff);
         border-image-source: linear-gradient(lch(56.208% 136.76 46.312), lch(51% 135.366 301.364));
       }
     "#
@@ -2512,7 +2512,7 @@ mod tests {
     "#,
       indoc! {r#"
       .foo {
-        border-image: linear-gradient(#ff0f0e, #7773ff) var(--foo);
+        border-image: linear-gradient(#ff0b0c, #766eff) var(--foo);
       }
 
       @supports (color: lab(0% 0 0)) {
@@ -4716,7 +4716,7 @@ mod tests {
     "#,
       indoc! {r#"
       .foo {
-        background: #af5cae linear-gradient(#c65d07, #00807c);
+        background: #af5cae linear-gradient(#c65d07, #00817d);
         background: lab(51.5117% 43.3777 -29.0443) linear-gradient(lab(52.2319% 40.1449 59.9171), lab(47.7776% -34.2947 -7.65904));
       }
     "#
@@ -14041,7 +14041,7 @@ mod tests {
       ".foo { background: linear-gradient(lch(56.208% 136.76 46.312), lch(51% 135.366 301.364)) }",
       indoc! { r#"
         .foo {
-          background: linear-gradient(#ff0f0e, #7773ff);
+          background: linear-gradient(#ff0b0c, #766eff);
           background: linear-gradient(lch(56.208% 136.76 46.312), lch(51% 135.366 301.364));
         }
       "#},
@@ -14055,7 +14055,7 @@ mod tests {
       ".foo { background: linear-gradient(lch(56.208% 136.76 46.312), lch(51% 135.366 301.364)) }",
       indoc! { r#"
         .foo {
-          background: linear-gradient(#ff0f0e, #7773ff);
+          background: linear-gradient(#ff0b0c, #766eff);
           background: linear-gradient(color(display-p3 1 .0000153435 -.00000303562), color(display-p3 .440289 .28452 1.23485));
           background: linear-gradient(lch(56.208% 136.76 46.312), lch(51% 135.366 301.364));
         }
@@ -14071,8 +14071,8 @@ mod tests {
       ".foo { background: linear-gradient(lch(56.208% 136.76 46.312), lch(51% 135.366 301.364)) }",
       indoc! { r#"
         .foo {
-          background: -webkit-linear-gradient(top, #ff0f0e, #7773ff);
-          background: linear-gradient(#ff0f0e, #7773ff);
+          background: -webkit-linear-gradient(top, #ff0b0c, #766eff);
+          background: linear-gradient(#ff0b0c, #766eff);
           background: linear-gradient(lch(56.208% 136.76 46.312), lch(51% 135.366 301.364));
         }
       "#},
@@ -14086,9 +14086,9 @@ mod tests {
       ".foo { background: linear-gradient(lch(56.208% 136.76 46.312), lch(51% 135.366 301.364)) }",
       indoc! { r#"
         .foo {
-          background: -webkit-gradient(linear, 0 0, 0 100%, from(#ff0f0e), to(#7773ff));
-          background: -webkit-linear-gradient(top, #ff0f0e, #7773ff);
-          background: linear-gradient(#ff0f0e, #7773ff);
+          background: -webkit-gradient(linear, 0 0, 0 100%, from(#ff0b0c), to(#766eff));
+          background: -webkit-linear-gradient(top, #ff0b0c, #766eff);
+          background: linear-gradient(#ff0b0c, #766eff);
           background: linear-gradient(lch(56.208% 136.76 46.312), lch(51% 135.366 301.364));
         }
       "#},
@@ -14128,7 +14128,7 @@ mod tests {
       ".foo { background-image: linear-gradient(lch(56.208% 136.76 46.312), lch(51% 135.366 301.364)) }",
       indoc! { r#"
         .foo {
-          background-image: linear-gradient(#ff0f0e, #7773ff);
+          background-image: linear-gradient(#ff0b0c, #766eff);
           background-image: linear-gradient(lch(56.208% 136.76 46.312), lch(51% 135.366 301.364));
         }
       "#},
@@ -14142,7 +14142,7 @@ mod tests {
       ".foo { background-image: linear-gradient(lch(56.208% 136.76 46.312), lch(51% 135.366 301.364)) }",
       indoc! { r#"
         .foo {
-          background-image: linear-gradient(#ff0f0e, #7773ff);
+          background-image: linear-gradient(#ff0b0c, #766eff);
           background-image: linear-gradient(color(display-p3 1 .0000153435 -.00000303562), color(display-p3 .440289 .28452 1.23485));
           background-image: linear-gradient(lch(56.208% 136.76 46.312), lch(51% 135.366 301.364));
         }
@@ -14158,8 +14158,8 @@ mod tests {
       ".foo { background-image: linear-gradient(lch(56.208% 136.76 46.312), lch(51% 135.366 301.364)) }",
       indoc! { r#"
         .foo {
-          background-image: -webkit-linear-gradient(top, #ff0f0e, #7773ff);
-          background-image: linear-gradient(#ff0f0e, #7773ff);
+          background-image: -webkit-linear-gradient(top, #ff0b0c, #766eff);
+          background-image: linear-gradient(#ff0b0c, #766eff);
           background-image: linear-gradient(lch(56.208% 136.76 46.312), lch(51% 135.366 301.364));
         }
       "#},
@@ -14173,9 +14173,9 @@ mod tests {
       ".foo { background-image: linear-gradient(lch(56.208% 136.76 46.312), lch(51% 135.366 301.364)) }",
       indoc! { r#"
         .foo {
-          background-image: -webkit-gradient(linear, 0 0, 0 100%, from(#ff0f0e), to(#7773ff));
-          background-image: -webkit-linear-gradient(top, #ff0f0e, #7773ff);
-          background-image: linear-gradient(#ff0f0e, #7773ff);
+          background-image: -webkit-gradient(linear, 0 0, 0 100%, from(#ff0b0c), to(#766eff));
+          background-image: -webkit-linear-gradient(top, #ff0b0c, #766eff);
+          background-image: linear-gradient(#ff0b0c, #766eff);
           background-image: linear-gradient(lch(56.208% 136.76 46.312), lch(51% 135.366 301.364));
         }
       "#},
@@ -14761,7 +14761,7 @@ mod tests {
       indoc! {r#"@font-palette-values --Cooler {
       font-family: Handover Sans;
       base-palette: 3;
-      override-colors: 1 #2b0c09, 3 #ee00be;
+      override-colors: 1 #2b0c09, 3 #f000c0;
       override-colors: 1 #2b0c09, 3 lch(50.998% 135.363 338);
     }
     "#},
@@ -14779,7 +14779,7 @@ mod tests {
       indoc! {r#"@font-palette-values --Cooler {
       font-family: Handover Sans;
       base-palette: 3;
-      override-colors: 1 var(--foo), 3 #ee00be;
+      override-colors: 1 var(--foo), 3 #f000c0;
     }
 
     @supports (color: lab(0% 0 0)) {
@@ -16601,8 +16601,8 @@ mod tests {
     "#,
       indoc! {r#"
       .foo {
-        -webkit-text-decoration: underline #ee00be;
-        text-decoration: underline #ee00be;
+        -webkit-text-decoration: underline #f000c0;
+        text-decoration: underline #f000c0;
         -webkit-text-decoration: underline lch(50.998% 135.363 338);
         text-decoration: underline lch(50.998% 135.363 338);
       }
@@ -16622,9 +16622,9 @@ mod tests {
     "#,
       indoc! {r#"
       .foo {
-        -webkit-text-decoration-color: #ee00be;
-        -moz-text-decoration-color: #ee00be;
-        text-decoration-color: #ee00be;
+        -webkit-text-decoration-color: #f000c0;
+        -moz-text-decoration-color: #f000c0;
+        text-decoration-color: #f000c0;
         -webkit-text-decoration-color: lch(50.998% 135.363 338);
         -moz-text-decoration-color: lch(50.998% 135.363 338);
         text-decoration-color: lch(50.998% 135.363 338);
@@ -16645,7 +16645,7 @@ mod tests {
     "#,
       indoc! {r#"
       .foo {
-        text-decoration: #ee00be var(--style);
+        text-decoration: #f000c0 var(--style);
       }
 
       @supports (color: lab(0% 0 0)) {
@@ -16992,8 +16992,8 @@ mod tests {
     "#,
       indoc! {r#"
       .foo {
-        -webkit-text-emphasis: filled #ee00be;
-        text-emphasis: filled #ee00be;
+        -webkit-text-emphasis: filled #f000c0;
+        text-emphasis: filled #f000c0;
         -webkit-text-emphasis: filled lch(50.998% 135.363 338);
         text-emphasis: filled lch(50.998% 135.363 338);
       }
@@ -17013,8 +17013,8 @@ mod tests {
     "#,
       indoc! {r#"
       .foo {
-        -webkit-text-emphasis-color: #ee00be;
-        text-emphasis-color: #ee00be;
+        -webkit-text-emphasis-color: #f000c0;
+        text-emphasis-color: #f000c0;
         -webkit-text-emphasis-color: lch(50.998% 135.363 338);
         text-emphasis-color: lch(50.998% 135.363 338);
       }
@@ -17034,7 +17034,7 @@ mod tests {
     "#,
       indoc! {r#"
       .foo {
-        text-emphasis: #ee00be var(--style);
+        text-emphasis: #f000c0 var(--style);
       }
 
       @supports (color: lab(0% 0 0)) {
@@ -17841,7 +17841,7 @@ mod tests {
       ".foo { caret-color: lch(50.998% 135.363 338) }",
       indoc! { r#"
         .foo {
-          caret-color: #ee00be;
+          caret-color: #f000c0;
           caret-color: color(display-p3 .972962 -.362078 .804206);
           caret-color: lch(50.998% 135.363 338);
         }
@@ -17857,7 +17857,7 @@ mod tests {
       ".foo { caret: lch(50.998% 135.363 338) block }",
       indoc! { r#"
         .foo {
-          caret: #ee00be block;
+          caret: #f000c0 block;
           caret: color(display-p3 .972962 -.362078 .804206) block;
           caret: lch(50.998% 135.363 338) block;
         }
@@ -17873,7 +17873,7 @@ mod tests {
       ".foo { caret: lch(50.998% 135.363 338) var(--foo) }",
       indoc! { r#"
         .foo {
-          caret: #ee00be var(--foo);
+          caret: #f000c0 var(--foo);
         }
 
         @supports (color: lab(0% 0 0)) {
@@ -18002,9 +18002,9 @@ mod tests {
       ".foo { list-style-image: linear-gradient(lch(56.208% 136.76 46.312), lch(51% 135.366 301.364)) }",
       indoc! { r#"
         .foo {
-          list-style-image: -webkit-gradient(linear, 0 0, 0 100%, from(#ff0f0e), to(#7773ff));
-          list-style-image: -webkit-linear-gradient(top, #ff0f0e, #7773ff);
-          list-style-image: linear-gradient(#ff0f0e, #7773ff);
+          list-style-image: -webkit-gradient(linear, 0 0, 0 100%, from(#ff0b0c), to(#766eff));
+          list-style-image: -webkit-linear-gradient(top, #ff0b0c, #766eff);
+          list-style-image: linear-gradient(#ff0b0c, #766eff);
           list-style-image: linear-gradient(lch(56.208% 136.76 46.312), lch(51% 135.366 301.364));
         }
       "#},
@@ -18018,7 +18018,7 @@ mod tests {
       ".foo { list-style: \"★\" linear-gradient(lch(56.208% 136.76 46.312), lch(51% 135.366 301.364)) }",
       indoc! { r#"
         .foo {
-          list-style: linear-gradient(#ff0f0e, #7773ff) "★";
+          list-style: linear-gradient(#ff0b0c, #766eff) "★";
           list-style: linear-gradient(lch(56.208% 136.76 46.312), lch(51% 135.366 301.364)) "★";
         }
       "#},
@@ -18032,7 +18032,7 @@ mod tests {
       ".foo { list-style: var(--foo) linear-gradient(lch(56.208% 136.76 46.312), lch(51% 135.366 301.364)) }",
       indoc! { r#"
         .foo {
-          list-style: var(--foo) linear-gradient(#ff0f0e, #7773ff);
+          list-style: var(--foo) linear-gradient(#ff0b0c, #766eff);
         }
 
         @supports (color: lab(0% 0 0)) {
@@ -18877,7 +18877,7 @@ mod tests {
       ".foo { background-color: lch(50.998% 135.363 338) }",
       indoc! { r#"
         .foo {
-          background-color: #ee00be;
+          background-color: #f000c0;
           background-color: color(display-p3 .972962 -.362078 .804206);
           background-color: lch(50.998% 135.363 338);
         }
@@ -18893,7 +18893,7 @@ mod tests {
       ".foo { color: lch(50.998% 135.363 338) }",
       indoc! { r#"
         .foo {
-          color: #ee00be;
+          color: #f000c0;
           color: color(display-p3 .972962 -.362078 .804206);
           color: lch(50.998% 135.363 338);
         }
@@ -18901,6 +18901,48 @@ mod tests {
       Browsers {
         chrome: Some(90 << 16),
         safari: Some(14 << 16),
+        ..Browsers::default()
+      },
+    );
+
+    prefix_test(
+      ".foo { color: lab(98.2504% -7.697 88.7581) }",
+      indoc! { r#"
+        .foo {
+          color: #fffc44;
+          color: lab(98.2504% -7.697 88.7581);
+        }
+      "#},
+      Browsers {
+        chrome: Some(80 << 16),
+        ..Browsers::default()
+      },
+    );
+
+    prefix_test(
+      ".foo { color: color(prophoto-rgb 0.9784 0.9925 0.3037) }",
+      indoc! { r#"
+        .foo {
+          color: #ffff6d;
+          color: color(prophoto-rgb .9784 .9925 .3037);
+        }
+      "#},
+      Browsers {
+        chrome: Some(80 << 16),
+        ..Browsers::default()
+      },
+    );
+
+    prefix_test(
+      ".foo { color: lch(94.4698% 111.9227 117.6737deg) }",
+      indoc! { r#"
+        .foo {
+          color: #b0ff00;
+          color: lch(94.4698% 111.923 117.674);
+        }
+      "#},
+      Browsers {
+        chrome: Some(80 << 16),
         ..Browsers::default()
       },
     );
@@ -19479,7 +19521,7 @@ mod tests {
     test("rgb(from rgb(from rebeccapurple r g b) r g b)", "#639");
 
     // Testing non-sRGB origin colors to see gamut mapping.
-    test("rgb(from color(display-p3 0 1 0) r g b / alpha)", "#00f942"); // Naive clip based mapping would give rgb(0, 255, 0).
+    test("rgb(from color(display-p3 0 1 0) r g b / alpha)", "#00fb29"); // Naive clip based mapping would give rgb(0, 255, 0).
     test("rgb(from lab(100% 104.3 -50.9) r g b)", "#fff"); // Naive clip based mapping would give rgb(255, 150, 255).
     test("rgb(from lab(0% 104.3 -50.9) r g b)", "#2a0022"); // Naive clip based mapping would give rgb(90, 0, 76). NOTE: 0% lightness in Lab/LCH does not automatically correspond with sRGB black.
     test("rgb(from lch(100% 116 334) r g b)", "#fff"); // Naive clip based mapping would give rgb(255, 150, 255).
@@ -19641,7 +19683,7 @@ mod tests {
     test("hsl(from hsl(from rebeccapurple h s l) h s l)", "rgb(102, 51, 153)");
 
     // Testing non-sRGB origin colors to see gamut mapping.
-    test("hsl(from color(display-p3 0 1 0) h s l / alpha)", "rgb(0, 249, 66)"); // Naive clip based mapping would give rgb(0, 255, 0).
+    test("hsl(from color(display-p3 0 1 0) h s l / alpha)", "rgb(0, 251, 41)"); // Naive clip based mapping would give rgb(0, 255, 0).
     test("hsl(from lab(100% 104.3 -50.9) h s l)", "rgb(255, 255, 255)"); // Naive clip based mapping would give rgb(255, 150, 255).
     test("hsl(from lab(0% 104.3 -50.9) h s l)", "rgb(42, 0, 34)"); // Naive clip based mapping would give rgb(90, 0, 76). NOTE: 0% lightness in Lab/LCH does not automatically correspond with sRGB black,
     test("hsl(from lch(100% 116 334) h s l)", "rgb(255, 255, 255)"); // Naive clip based mapping would give rgb(255, 150, 255).
@@ -19788,7 +19830,7 @@ mod tests {
     test("hwb(from hwb(from rebeccapurple h w b) h w b)", "rgb(102, 51, 153)");
 
     // Testing non-sRGB origin colors to see gamut mapping.
-    test("hwb(from color(display-p3 0 1 0) h w b / alpha)", "rgb(0, 249, 66)"); // Naive clip based mapping would give rgb(0, 255, 0).
+    test("hwb(from color(display-p3 0 1 0) h w b / alpha)", "rgb(0, 251, 41)"); // Naive clip based mapping would give rgb(0, 255, 0).
     test("hwb(from lab(100% 104.3 -50.9) h w b)", "rgb(255, 255, 255)"); // Naive clip based mapping would give rgb(255, 150, 255).
     test("hwb(from lab(0% 104.3 -50.9) h w b)", "rgb(42, 0, 34)"); // Naive clip based mapping would give rgb(90, 0, 76). NOTE: 0% lightness in Lab/LCH does not automatically correspond with sRGB black,
     test("hwb(from lch(100% 116 334) h w b)", "rgb(255, 255, 255)"); // Naive clip based mapping would give rgb(255, 150, 255).
@@ -21261,7 +21303,7 @@ mod tests {
       ".foo { color: alpha(from color(display-p3 1 0 0) / 0.5) }",
       indoc! { r#"
         .foo {
-          color: #ff0f0e80;
+          color: #ff0b0c80;
           color: color(display-p3 1 0 0 / .5);
         }
       "#},
@@ -21635,7 +21677,7 @@ mod tests {
 
     minify_test(
       ".foo { color: color-mix(in hsl, color(display-p3 0 1 0) 100%, rgb(0, 0, 0) 0%) }",
-      &canonicalize("rgb(0, 249, 66)"),
+      &canonicalize("rgb(0, 251, 41)"),
     ); // Naive clip based mapping would give rgb(0, 255, 0).
     minify_test(
       ".foo { color: color-mix(in hsl, lab(100% 104.3 -50.9) 100%, rgb(0, 0, 0) 0%) }",
@@ -21836,7 +21878,7 @@ mod tests {
 
     minify_test(
       ".foo { color: color-mix(in hwb, color(display-p3 0 1 0) 100%, rgb(0, 0, 0) 0%) }",
-      &canonicalize("rgb(0, 249, 66)"),
+      &canonicalize("rgb(0, 251, 41)"),
     ); // Naive clip based mapping would give rgb(0, 255, 0).
     minify_test(
       ".foo { color: color-mix(in hwb, lab(100% 104.3 -50.9) 100%, rgb(0, 0, 0) 0%) }",
@@ -24175,7 +24217,7 @@ mod tests {
     "#,
       indoc! {r#"
       .foo {
-        --foo: #00f942;
+        --foo: #00fb29;
       }
 
       @supports (color: color(display-p3 0 0 0)) {
@@ -24238,7 +24280,7 @@ mod tests {
     "#,
       indoc! {r#"
       .foo {
-        --foo: #00f942;
+        --foo: #00fb29;
       }
 
       @supports (color: color(display-p3 0 0 0)) {
@@ -24262,7 +24304,7 @@ mod tests {
     "#,
       indoc! {r#"
       .foo {
-        --foo: #00f942;
+        --foo: #00fb29;
       }
 
       @supports (color: color(display-p3 0 0 0)) {
@@ -24355,7 +24397,7 @@ mod tests {
         }
 
         to {
-          --custom: #ee00be;
+          --custom: #f000c0;
         }
       }
 
@@ -24429,7 +24471,7 @@ mod tests {
         }
 
         to {
-          --custom: #ee00be;
+          --custom: #f000c0;
         }
       }
 
@@ -24544,7 +24586,7 @@ mod tests {
         }
 
         to {
-          --custom: #ee00be;
+          --custom: #f000c0;
           opacity: 1;
         }
       }
@@ -27837,7 +27879,7 @@ mod tests {
       ".foo { fill: lch(50.998% 135.363 338) }",
       indoc! { r#"
         .foo {
-          fill: #ee00be;
+          fill: #f000c0;
           fill: color(display-p3 .972962 -.362078 .804206);
           fill: lch(50.998% 135.363 338);
         }
@@ -27853,7 +27895,7 @@ mod tests {
       ".foo { stroke: lch(50.998% 135.363 338) }",
       indoc! { r#"
         .foo {
-          stroke: #ee00be;
+          stroke: #f000c0;
           stroke: color(display-p3 .972962 -.362078 .804206);
           stroke: lch(50.998% 135.363 338);
         }
@@ -27869,7 +27911,7 @@ mod tests {
       ".foo { fill: url(#foo) lch(50.998% 135.363 338) }",
       indoc! { r##"
         .foo {
-          fill: url("#foo") #ee00be;
+          fill: url("#foo") #f000c0;
           fill: url("#foo") color(display-p3 .972962 -.362078 .804206);
           fill: url("#foo") lch(50.998% 135.363 338);
         }
@@ -27885,7 +27927,7 @@ mod tests {
       ".foo { fill: var(--url) lch(50.998% 135.363 338) }",
       indoc! { r#"
         .foo {
-          fill: var(--url) #ee00be;
+          fill: var(--url) #f000c0;
         }
 
         @supports (color: lab(0% 0 0)) {
@@ -27925,10 +27967,10 @@ mod tests {
       ".foo { mask-image: linear-gradient(lch(56.208% 136.76 46.312), lch(51% 135.366 301.364)) }",
       indoc! { r#"
         .foo {
-          -webkit-mask-image: -webkit-gradient(linear, 0 0, 0 100%, from(#ff0f0e), to(#7773ff));
-          -webkit-mask-image: -webkit-linear-gradient(top, #ff0f0e, #7773ff);
-          -webkit-mask-image: linear-gradient(#ff0f0e, #7773ff);
-          mask-image: linear-gradient(#ff0f0e, #7773ff);
+          -webkit-mask-image: -webkit-gradient(linear, 0 0, 0 100%, from(#ff0b0c), to(#766eff));
+          -webkit-mask-image: -webkit-linear-gradient(top, #ff0b0c, #766eff);
+          -webkit-mask-image: linear-gradient(#ff0b0c, #766eff);
+          mask-image: linear-gradient(#ff0b0c, #766eff);
           -webkit-mask-image: linear-gradient(lch(56.208% 136.76 46.312), lch(51% 135.366 301.364));
           mask-image: linear-gradient(lch(56.208% 136.76 46.312), lch(51% 135.366 301.364));
         }
@@ -27943,8 +27985,8 @@ mod tests {
       ".foo { mask-image: linear-gradient(lch(56.208% 136.76 46.312), lch(51% 135.366 301.364)) }",
       indoc! { r#"
         .foo {
-          -webkit-mask-image: linear-gradient(#ff0f0e, #7773ff);
-          mask-image: linear-gradient(#ff0f0e, #7773ff);
+          -webkit-mask-image: linear-gradient(#ff0b0c, #766eff);
+          mask-image: linear-gradient(#ff0b0c, #766eff);
           -webkit-mask-image: linear-gradient(lch(56.208% 136.76 46.312), lch(51% 135.366 301.364));
           mask-image: linear-gradient(lch(56.208% 136.76 46.312), lch(51% 135.366 301.364));
         }
@@ -27987,10 +28029,10 @@ mod tests {
       ".foo { mask: linear-gradient(lch(56.208% 136.76 46.312), lch(51% 135.366 301.364)) 40px 20px }",
       indoc! { r#"
         .foo {
-          -webkit-mask: -webkit-gradient(linear, 0 0, 0 100%, from(#ff0f0e), to(#7773ff)) 40px 20px;
-          -webkit-mask: -webkit-linear-gradient(top, #ff0f0e, #7773ff) 40px 20px;
-          -webkit-mask: linear-gradient(#ff0f0e, #7773ff) 40px 20px;
-          mask: linear-gradient(#ff0f0e, #7773ff) 40px 20px;
+          -webkit-mask: -webkit-gradient(linear, 0 0, 0 100%, from(#ff0b0c), to(#766eff)) 40px 20px;
+          -webkit-mask: -webkit-linear-gradient(top, #ff0b0c, #766eff) 40px 20px;
+          -webkit-mask: linear-gradient(#ff0b0c, #766eff) 40px 20px;
+          mask: linear-gradient(#ff0b0c, #766eff) 40px 20px;
           -webkit-mask: linear-gradient(lch(56.208% 136.76 46.312), lch(51% 135.366 301.364)) 40px 20px;
           mask: linear-gradient(lch(56.208% 136.76 46.312), lch(51% 135.366 301.364)) 40px 20px;
         }
@@ -28005,8 +28047,8 @@ mod tests {
       ".foo { mask: -webkit-linear-gradient(lch(56.208% 136.76 46.312), lch(51% 135.366 301.364)) 40px 20px }",
       indoc! { r#"
         .foo {
-          -webkit-mask: -webkit-gradient(linear, 0 0, 0 100%, from(#ff0f0e), to(#7773ff)) 40px 20px;
-          -webkit-mask: -webkit-linear-gradient(#ff0f0e, #7773ff) 40px 20px;
+          -webkit-mask: -webkit-gradient(linear, 0 0, 0 100%, from(#ff0b0c), to(#766eff)) 40px 20px;
+          -webkit-mask: -webkit-linear-gradient(#ff0b0c, #766eff) 40px 20px;
         }
       "#},
       Browsers {
@@ -28019,8 +28061,8 @@ mod tests {
       ".foo { mask: linear-gradient(lch(56.208% 136.76 46.312), lch(51% 135.366 301.364)) 40px var(--foo) }",
       indoc! { r#"
         .foo {
-          -webkit-mask: linear-gradient(#ff0f0e, #7773ff) 40px var(--foo);
-          mask: linear-gradient(#ff0f0e, #7773ff) 40px var(--foo);
+          -webkit-mask: linear-gradient(#ff0b0c, #766eff) 40px var(--foo);
+          mask: linear-gradient(#ff0b0c, #766eff) 40px var(--foo);
         }
 
         @supports (color: lab(0% 0 0)) {
@@ -28129,10 +28171,10 @@ mod tests {
       "#,
       indoc! { r#"
         .foo {
-          -webkit-mask: linear-gradient(#ff0f0e, #7773ff) 25% 75% / cover no-repeat content-box padding-box;
+          -webkit-mask: linear-gradient(#ff0b0c, #766eff) 25% 75% / cover no-repeat content-box padding-box;
           -webkit-mask-composite: source-out;
           -webkit-mask-source-type: luminance;
-          mask: linear-gradient(#ff0f0e, #7773ff) 25% 75% / cover no-repeat content-box padding-box subtract luminance;
+          mask: linear-gradient(#ff0b0c, #766eff) 25% 75% / cover no-repeat content-box padding-box subtract luminance;
           -webkit-mask: linear-gradient(lch(56.208% 136.76 46.312), lch(51% 135.366 301.364)) 25% 75% / cover no-repeat content-box padding-box;
           -webkit-mask-composite: source-out;
           -webkit-mask-source-type: luminance;
@@ -28222,8 +28264,8 @@ mod tests {
       "#,
       indoc! { r#"
         .foo {
-          -webkit-mask-box-image: linear-gradient(#ff0f0e, #7773ff) 25 / 35px / 12px space;
-          mask-border: linear-gradient(#ff0f0e, #7773ff) 25 / 35px / 12px space luminance;
+          -webkit-mask-box-image: linear-gradient(#ff0b0c, #766eff) 25 / 35px / 12px space;
+          mask-border: linear-gradient(#ff0b0c, #766eff) 25 / 35px / 12px space luminance;
           -webkit-mask-box-image: linear-gradient(lch(56.208% 136.76 46.312), lch(51% 135.366 301.364)) 25 / 35px / 12px space;
           mask-border: linear-gradient(lch(56.208% 136.76 46.312), lch(51% 135.366 301.364)) 25 / 35px / 12px space luminance;
         }
@@ -28242,8 +28284,8 @@ mod tests {
       "#,
       indoc! { r#"
         .foo {
-          -webkit-mask-box-image-source: linear-gradient(#ff0f0e, #7773ff);
-          mask-border-source: linear-gradient(#ff0f0e, #7773ff);
+          -webkit-mask-box-image-source: linear-gradient(#ff0b0c, #766eff);
+          mask-border-source: linear-gradient(#ff0b0c, #766eff);
           -webkit-mask-box-image-source: linear-gradient(lch(56.208% 136.76 46.312), lch(51% 135.366 301.364));
           mask-border-source: linear-gradient(lch(56.208% 136.76 46.312), lch(51% 135.366 301.364));
         }
@@ -28342,8 +28384,8 @@ mod tests {
       "#,
       indoc! { r#"
         .foo {
-          -webkit-mask-box-image: linear-gradient(#ff0f0e, #7773ff) var(--foo);
-          mask-border: linear-gradient(#ff0f0e, #7773ff) var(--foo);
+          -webkit-mask-box-image: linear-gradient(#ff0b0c, #766eff) var(--foo);
+          mask-border: linear-gradient(#ff0b0c, #766eff) var(--foo);
         }
 
         @supports (color: lab(0% 0 0)) {
@@ -31038,7 +31080,7 @@ mod tests {
     "#,
       indoc! {r#"
       .foo {
-        color: env(--brand-color, #00f942);
+        color: env(--brand-color, #00fb29);
       }
 
       @supports (color: color(display-p3 0 0 0)) {

--- a/src/values/color.rs
+++ b/src/values/color.rs
@@ -3325,9 +3325,9 @@ where
   T: Into<OKLCH> + ColorGamut + Into<OKLAB> + From<OKLCH> + Copy,
 {
   const JND: f32 = 0.02;
-  const EPSILON: f32 = 0.00001;
+  const EPSILON: f32 = 0.0001;
 
-  // https://www.w3.org/TR/css-color-4/#binsearch
+  // https://www.w3.org/TR/css-color-4/#pseudo-binsearch
   let mut current: OKLCH = color.into();
 
   // If lightness is >= 100%, return pure white.
@@ -3354,27 +3354,37 @@ where
 
   let mut min = 0.0;
   let mut max = current.c;
+  let mut min_in_gamut = true;
+  let mut clipped = color.clip();
+  let mut delta_e = delta_eok(clipped, current);
+  if delta_e < JND {
+    return clipped;
+  }
 
   while (max - min) > EPSILON {
     let chroma = (min + max) / 2.0;
     current.c = chroma;
 
     let converted = T::from(current);
-    if converted.in_gamut() {
+    if min_in_gamut && converted.in_gamut() {
       min = chroma;
       continue;
     }
 
-    let clipped = converted.clip();
-    let delta_e = delta_eok(clipped, current);
+    clipped = converted.clip();
+    delta_e = delta_eok(clipped, current);
     if delta_e < JND {
-      return clipped;
+      if JND - delta_e < EPSILON {
+        break;
+      }
+      min_in_gamut = false;
+      min = chroma;
+    } else {
+      max = chroma;
     }
-
-    max = chroma;
   }
 
-  current.into()
+  clipped
 }
 
 fn parse_color_mix<'i, 't>(input: &mut Parser<'i, 't>) -> Result<CssColor, ParseError<'i, ParserError<'i>>> {


### PR DESCRIPTION
Fixes #1298.

The gamut mapping binary search returned as soon as it found a chroma under the JND. The spec keeps searching upward from that point and returns the largest chroma still under the JND. Because of the early return, sRGB fallbacks for wide gamut colors came out less saturated than the spec and colorjs.io produce.

This change follows the spec pseudocode: it clips the origin color once before the loop, carries the `min_inGamut` flag, and returns the last clipped color. The epsilon now matches the spec value and the spec link points to the current anchor.

The same search is implemented in [colordx](https://github.com/dkryaklin/colordx), where it matches colorjs.io on a large set of out of gamut samples. The loop here mirrors that math.

Test expectations that depended on the old behavior are updated, and the cases from the issue are added. All new values match colorjs.io with `method: "css"`.