### PR TITLE
Add NonNegative wrapper for numeric values

### DIFF
--- a/src/bundler.rs
+++ b/src/bundler.rs
@@ -106,10 +106,7 @@ pub enum ResolveResult {
   /// An external URL.
   External(String),
   /// A file path.
-  #[cfg_attr(
-    any(feature = "serde", feature = "nodejs"),
-    serde(untagged)
-  )]
+  #[cfg_attr(any(feature = "serde", feature = "nodejs"), serde(untagged))]
   File(PathBuf),
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,6 +78,56 @@ mod tests {
   }
 
   #[track_caller]
+  fn non_negative_test<'i, T: crate::traits::ParseNumeric<'i> + ToCss>(source: &'i str, expected: Option<&str>) {
+    use crate::values::number::NonNegative;
+
+    let result = NonNegative::<T>::parse_string(source);
+    match expected {
+      Some(expected) => {
+        let value = result.unwrap();
+        assert_eq!(
+          value.to_css_string(PrinterOptions::default()).unwrap(),
+          expected,
+          "{}",
+          source
+        );
+      }
+      None => assert!(result.is_err(), "expected {} to be invalid", source),
+    }
+  }
+
+  // Invalid known properties are preserved as unparsed declarations for browser validation.
+  #[track_caller]
+  fn property_range_test(names: &[&str], cases: &[(&str, Option<&str>)]) {
+    for name in names {
+      for (source, expected) in cases {
+        let value = Property::parse_string((*name).into(), source, ParserOptions::default()).unwrap();
+        if let Some(expected) = expected {
+          assert!(
+            !matches!(value, Property::Unparsed(_) | Property::Custom(_)),
+            "{name}: {source}"
+          );
+          assert_eq!(
+            value
+              .value_to_css_string(PrinterOptions {
+                minify: true,
+                ..PrinterOptions::default()
+              })
+              .unwrap(),
+            *expected,
+            "{name}: {source}"
+          );
+        } else {
+          assert!(
+            matches!(value, Property::Unparsed(_)),
+            "expected {name}: {source} to be invalid, got {value:?}"
+          );
+        }
+      }
+    }
+  }
+
+  #[track_caller]
   fn test_with_options<'i>(source: &'i str, expected: &'i str, options: ParserOptions<'i>) {
     let mut stylesheet = match StyleSheet::parse(&source, options) {
       Ok(stylesheet) => stylesheet,
@@ -436,6 +486,15 @@ mod tests {
 
   #[test]
   pub fn test_border_spacing() {
+    property_range_test(
+      &["border-spacing"],
+      &[
+        ("-1px", None),
+        ("calc(1px - 2px)", Some("0")),
+        ("calc(-1px + 2px)", Some("1px")),
+        ("1px -1px", None),
+      ],
+    );
     minify_test(
       r#"
       .foo {
@@ -503,6 +562,65 @@ mod tests {
 
   #[test]
   pub fn test_math_fn() {
+    use crate::values::angle::Angle;
+    use crate::values::length::Length;
+    use crate::values::number::{CSSInteger, CSSNumber};
+    use crate::values::percentage::{NumberOrPercentage, Percentage};
+
+    for source in ["-1", "-0.5"] {
+      non_negative_test::<CSSNumber>(source, None);
+      assert!(CSSNumber::parse_string(source).is_ok());
+    }
+    for (source, expected) in [
+      ("0", "0"),
+      ("-0", "0"),
+      ("calc(-5)", "0"),
+      ("calc(-5 + 10)", "5"),
+      ("calc(-5 * -2)", "10"),
+      ("min(-5, 10)", "0"),
+      ("max(-5, -10)", "0"),
+      ("clamp(-10, -5, -1)", "0"),
+      ("calc(min(-5, -10) + 20)", "10"),
+    ] {
+      non_negative_test::<CSSNumber>(source, Some(expected));
+      non_negative_test::<NumberOrPercentage>(source, Some(expected));
+    }
+    non_negative_test::<CSSInteger>("-1", None);
+    non_negative_test::<CSSInteger>("0", Some("0"));
+    non_negative_test::<CSSInteger>("2147483647", Some("2147483647"));
+    non_negative_test::<CSSInteger>("1.5", None);
+    for (source, expected) in [
+      ("-5%", None),
+      ("-0%", Some("-0%")),
+      ("calc(-5%)", Some("0%")),
+      ("calc(-5% + 10%)", Some("5%")),
+      ("min(-5%, 10%)", Some("0%")),
+      ("calc(min(-5%, -10%) + 20%)", Some("10%")),
+    ] {
+      non_negative_test::<Percentage>(source, expected);
+      non_negative_test::<NumberOrPercentage>(source, expected);
+    }
+    non_negative_test::<Percentage>("calc(1)", None);
+    non_negative_test::<Percentage>("calc(1px)", None);
+    assert_eq!(Percentage::parse_string("calc(-5%)").unwrap().0, -0.05);
+    for (source, expected) in [
+      ("-5deg", None),
+      ("calc(-5deg)", Some("0deg")),
+      ("calc(-5deg + 10deg)", Some("5deg")),
+      ("min(-5deg, 10deg)", Some("0deg")),
+      ("calc(1)", None),
+    ] {
+      non_negative_test::<Angle>(source, expected);
+    }
+    for (source, expected) in [
+      ("min(-5px, 10px)", "0"),
+      ("max(-5px, -10px)", "0"),
+      ("clamp(-10px, -5px, -1px)", "0"),
+      ("calc(min(-5px, -10px) + 20px)", "10px"),
+    ] {
+      non_negative_test::<Length>(source, Some(expected));
+    }
+
     // max()
     minify_test(
       r#"
@@ -619,6 +737,14 @@ mod tests {
 
   #[test]
   pub fn test_border() {
+    property_range_test(
+      &["border-width", "border-left-width", "outline-width"],
+      &[
+        ("-1px", None),
+        ("calc(1px - 2px)", Some("0")),
+        ("calc(-1px + 2px)", Some("1px")),
+      ],
+    );
     test(
       r#"
       .foo {
@@ -2175,6 +2301,45 @@ mod tests {
 
   #[test]
   pub fn test_border_image() {
+    property_range_test(
+      &[
+        "border-image-outset",
+        "mask-border-outset",
+        "-webkit-mask-box-image-outset",
+      ],
+      &[
+        ("-1px", None),
+        ("calc(1px - 2px)", Some("0")),
+        ("calc(-1px + 2px)", Some("1px")),
+        ("-1", None),
+        ("calc(1 - 2)", Some("0")),
+        ("calc(-1 + 2)", Some("1")),
+      ],
+    );
+    property_range_test(
+      &["border-image-width", "mask-border-width"],
+      &[
+        ("-1px", None),
+        ("calc(1px - 2px)", Some("0")),
+        ("calc(-1px + 2px)", Some("1px")),
+        ("-1%", None),
+        ("calc(1em - 2px)", Some("calc(1em - 2px)")),
+        ("calc(-1%)", Some("calc(-1%)")),
+        ("-1", None),
+        ("calc(1 - 2)", Some("0")),
+        ("calc(-1 + 2)", Some("1")),
+        ("auto", Some("auto")),
+      ],
+    );
+    property_range_test(
+      &["border-image-slice", "mask-border-slice"],
+      &[
+        ("-1", None),
+        ("calc(1 - 2)", Some("0")),
+        ("calc(-1 + 2)", Some("1")),
+        ("-1%", None),
+      ],
+    );
     test(
       r#"
       .foo {
@@ -2651,6 +2816,17 @@ mod tests {
 
   #[test]
   pub fn test_border_radius() {
+    property_range_test(
+      &["border-radius", "border-top-left-radius", "border-start-start-radius"],
+      &[
+        ("-1px", None),
+        ("calc(1px - 2px)", Some("0")),
+        ("calc(-1px + 2px)", Some("1px")),
+        ("-1%", None),
+        ("calc(1em - 2px)", Some("calc(1em - 2px)")),
+        ("calc(-1%)", Some("calc(-1%)")),
+      ],
+    );
     test(
       r#"
       .foo {
@@ -3252,6 +3428,7 @@ mod tests {
 
   #[test]
   pub fn test_margin() {
+    property_range_test(&["margin", "inset", "scroll-margin"], &[("-1px", Some("-1px"))]);
     test(
       r#"
       .foo {
@@ -3538,6 +3715,37 @@ mod tests {
 
   #[test]
   fn test_length() {
+    use crate::values::length::{Length, LengthOrNumber, LengthPercentage, LengthPercentageOrAuto, LengthValue};
+    use crate::values::number::NonNegative;
+
+    for source in ["-1px", "-1em", "-1vw", "-1"] {
+      non_negative_test::<LengthValue>(source, None);
+      non_negative_test::<Length>(source, None);
+      non_negative_test::<LengthPercentage>(source, None);
+      non_negative_test::<LengthPercentageOrAuto>(source, None);
+      non_negative_test::<LengthOrNumber>(source, None);
+      assert!(Length::parse_string(source).is_ok());
+    }
+    for source in ["0", "-0", "-0px"] {
+      non_negative_test::<LengthValue>(source, Some("0"));
+      non_negative_test::<Length>(source, Some("0"));
+    }
+    non_negative_test::<LengthValue>("2em", Some("2em"));
+    non_negative_test::<LengthPercentage>("-1%", None);
+    non_negative_test::<LengthPercentage>("10%", Some("10%"));
+    non_negative_test::<LengthPercentageOrAuto>("auto", Some("auto"));
+    non_negative_test::<LengthPercentageOrAuto>("-1%", None);
+    non_negative_test::<LengthOrNumber>("2", Some("2"));
+    non_negative_test::<LengthOrNumber>("2px", Some("2px"));
+    non_negative_test::<LengthOrNumber>("calc(-2)", Some("0"));
+    non_negative_test::<LengthOrNumber>("calc(-2px)", Some("0"));
+
+    // Backtracking a rejected range must leave the input available to another parser.
+    let mut input = cssparser::ParserInput::new("-1px");
+    let mut parser = cssparser::Parser::new(&mut input);
+    assert!(parser.try_parse(NonNegative::<Length>::parse).is_err());
+    assert_eq!(Length::parse(&mut parser).unwrap(), Length::px(-1.0));
+
     for prop in &[
       "margin-right",
       "margin",
@@ -3655,6 +3863,25 @@ mod tests {
 
   #[test]
   pub fn test_padding() {
+    property_range_test(
+      &[
+        "padding",
+        "padding-inline",
+        "padding-block",
+        "padding-top",
+        "padding-inline-start",
+      ],
+      &[
+        ("-1px", None),
+        ("calc(1px - 2px)", Some("0")),
+        ("calc(-1px + 2px)", Some("1px")),
+        ("-1%", None),
+        ("calc(1em - 2px)", Some("calc(1em - 2px)")),
+        ("calc(-1%)", Some("calc(-1%)")),
+        ("auto", None),
+        ("1px -1px", None),
+      ],
+    );
     test(
       r#"
       .foo {
@@ -3923,6 +4150,18 @@ mod tests {
 
   #[test]
   fn test_scroll_padding() {
+    property_range_test(
+      &["scroll-padding", "scroll-padding-inline", "scroll-padding-top"],
+      &[
+        ("-1px", None),
+        ("calc(1px - 2px)", Some("0")),
+        ("calc(-1px + 2px)", Some("1px")),
+        ("-1%", None),
+        ("calc(1em - 2px)", Some("calc(1em - 2px)")),
+        ("calc(-1%)", Some("calc(-1%)")),
+        ("auto", Some("auto")),
+      ],
+    );
     prefix_test(
       r#"
       .foo {
@@ -3944,6 +4183,45 @@ mod tests {
 
   #[test]
   fn test_size() {
+    minify_test(".foo { width: 10px; width: -1px }", ".foo{width:10px;width:-1px}");
+    property_range_test(
+      &["aspect-ratio"],
+      &[
+        ("-1 / 2", None),
+        ("1 / -2", None),
+        ("calc(-1) / 2", Some("0/2")),
+        ("0 / 0", Some("0/0")),
+      ],
+    );
+    property_range_test(
+      &["width", "max-height"],
+      &[
+        ("fit-content(-1px)", None),
+        ("fit-content(calc(-1px))", Some("fit-content(0)")),
+      ],
+    );
+    property_range_test(
+      &[
+        "width",
+        "height",
+        "min-width",
+        "max-width",
+        "min-height",
+        "max-height",
+        "block-size",
+        "inline-size",
+        "min-block-size",
+        "max-inline-size",
+      ],
+      &[
+        ("-1px", None),
+        ("calc(1px - 2px)", Some("0")),
+        ("calc(-1px + 2px)", Some("1px")),
+        ("-1%", None),
+        ("calc(1em - 2px)", Some("calc(1em - 2px)")),
+        ("calc(-1%)", Some("calc(-1%)")),
+      ],
+    );
     prefix_test(
       r#"
       .foo {
@@ -4275,6 +4553,19 @@ mod tests {
 
   #[test]
   pub fn test_background() {
+    property_range_test(
+      &["background-size", "mask-size"],
+      &[
+        ("-1px", None),
+        ("calc(1px - 2px)", Some("0")),
+        ("calc(-1px + 2px)", Some("1px")),
+        ("-1%", None),
+        ("calc(1em - 2px)", Some("calc(1em - 2px)")),
+        ("calc(-1%)", Some("calc(-1%)")),
+        ("auto", Some("auto")),
+        ("1px -1px", None),
+      ],
+    );
     test(
       r#"
       .foo {
@@ -4946,6 +5237,28 @@ mod tests {
 
   #[test]
   pub fn test_flex() {
+    property_range_test(&["flex"], &[("-1", None), ("1 -1", None), ("1 1 -1px", None)]);
+    property_range_test(
+      &["flex-basis", "-ms-flex-preferred-size"],
+      &[
+        ("-1px", None),
+        ("calc(1px - 2px)", Some("0")),
+        ("calc(-1px + 2px)", Some("1px")),
+        ("-1%", None),
+        ("calc(1em - 2px)", Some("calc(1em - 2px)")),
+        ("calc(-1%)", Some("calc(-1%)")),
+      ],
+    );
+    property_range_test(
+      &[
+        "flex-grow",
+        "flex-shrink",
+        "-webkit-box-flex",
+        "-ms-flex-positive",
+        "-ms-flex-negative",
+      ],
+      &[("-1", None), ("calc(1 - 2)", Some("0")), ("calc(-1 + 2)", Some("1"))],
+    );
     test(
       r#"
       .foo {
@@ -6207,6 +6520,22 @@ mod tests {
 
   #[test]
   fn test_font() {
+    property_range_test(&["font-stretch"], &[("-1%", None), ("calc(-1%)", Some("0%"))]);
+    property_range_test(
+      &["line-height"],
+      &[("-1", None), ("calc(1 - 2)", Some("0")), ("calc(-1 + 2)", Some("1"))],
+    );
+    property_range_test(
+      &["font-size", "line-height"],
+      &[
+        ("-1px", None),
+        ("calc(1px - 2px)", Some("0")),
+        ("calc(-1px + 2px)", Some("1px")),
+        ("-1%", None),
+        ("calc(1em - 2px)", Some("calc(1em - 2px)")),
+        ("calc(-1%)", Some("calc(-1%)")),
+      ],
+    );
     test(
       r#"
       .foo {
@@ -8061,6 +8390,47 @@ mod tests {
 
   #[test]
   fn test_calc() {
+    use crate::values::length::{Length, LengthPercentage, LengthPercentageOrAuto};
+    use crate::values::number::NonNegative;
+
+    for (source, expected) in [
+      ("calc(-5px)", "0"),
+      ("calc(5px - 10px)", "0"),
+      ("calc(-5px + 10px)", "5px"),
+      ("calc(-5px * -2)", "10px"),
+      ("calc(calc(-5px) + 10px)", "5px"),
+      ("calc(-1em)", "0"),
+      ("calc(1in - 100px)", "0"),
+      ("calc(1em - 10px)", "calc(1em - 10px)"),
+      ("min(-1em, -10px)", "min(-1em, -10px)"),
+    ] {
+      non_negative_test::<Length>(source, Some(expected));
+      non_negative_test::<LengthPercentage>(source, Some(expected));
+      non_negative_test::<LengthPercentageOrAuto>(source, Some(expected));
+    }
+    assert_eq!(Length::parse_string("calc(-5px)").unwrap(), Length::px(-5.0));
+    for source in ["calc(0)", "calc(-5)", "calc(1s)"] {
+      non_negative_test::<Length>(source, None);
+      non_negative_test::<LengthPercentage>(source, None);
+    }
+    for (source, expected) in [
+      ("calc(5%)", "5%"),
+      ("calc(0%)", "0%"),
+      ("calc(-5% + 10%)", "5%"),
+      ("calc(5% - 5%)", "0%"),
+      ("calc(100px - (100px - 100%))", "100%"),
+    ] {
+      non_negative_test::<LengthPercentage>(source, Some(expected));
+      non_negative_test::<LengthPercentageOrAuto>(source, Some(expected));
+    }
+    // Negative percentages and unresolved calculations retain their math boundary.
+    for source in ["calc(-5%)", "calc(100% - 10px)"] {
+      non_negative_test::<LengthPercentage>(source, Some(source));
+      let value = NonNegative::<LengthPercentage>::parse_string(source).unwrap();
+      let css = value.to_css_string(PrinterOptions::default()).unwrap();
+      assert_eq!(NonNegative::<LengthPercentage>::parse_string(&css).unwrap(), value);
+    }
+
     minify_test(".foo { width: calc(20px * 2) }", ".foo{width:40px}");
     minify_test(".foo { font-size: calc(100vw / 35) }", ".foo{font-size:2.85714vw}");
     minify_test(".foo { width: calc(20px * 2 * 3) }", ".foo{width:120px}");
@@ -8130,10 +8500,7 @@ mod tests {
       ".foo{width:calc(50vw - 6px)}",
     );
     minify_test(".foo { width: calc(1px + 1) }", ".foo{width:calc(1px + 1)}");
-    minify_test(
-      ".foo { width: calc( (1em - calc( 10px + 1em)) / 2) }",
-      ".foo{width:-5px}",
-    );
+    minify_test(".foo { width: calc( (1em - calc( 10px + 1em)) / 2) }", ".foo{width:0}");
     minify_test(
       ".foo { width: calc((100px - 1em) + (-50px + 1em)) }",
       ".foo{width:50px}",
@@ -8368,7 +8735,7 @@ mod tests {
     minify_test(".foo { margin: round(nearest, -23px, 5px) }", ".foo{margin:-25px}");
     minify_test(".foo { margin: calc(10px * round(22, 5)) }", ".foo{margin:200px}");
     minify_test(".foo { width: rem(18px, 5px) }", ".foo{width:3px}");
-    minify_test(".foo { width: rem(-18px, 5px) }", ".foo{width:-3px}");
+    minify_test(".foo { width: rem(-18px, 5px) }", ".foo{width:0}");
     minify_test(".foo { width: rem(18px, 5vw) }", ".foo{width:rem(18px,5vw)}");
     minify_test(".foo { rotate: rem(-140deg, -90deg) }", ".foo{rotate:-50deg}");
     minify_test(".foo { rotate: rem(140deg, -90deg) }", ".foo{rotate:50deg}");
@@ -8516,7 +8883,7 @@ mod tests {
     minify_test(".foo { width: abs(-1px)", ".foo{width:1px}");
     minify_test(".foo { width: abs(1%)", ".foo{width:abs(1%)}"); // spec says percentages must be against resolved value
 
-    minify_test(".foo { width: calc(10px * sign(-1vw)", ".foo{width:-10px}");
+    minify_test(".foo { width: calc(10px * sign(-1vw)", ".foo{width:0}");
     minify_test(
       ".foo { width: calc(10px * sign(1%)",
       ".foo{width:calc(10px * sign(1%))}",
@@ -8525,6 +8892,15 @@ mod tests {
 
   #[test]
   fn test_box_shadow() {
+    property_range_test(
+      &["box-shadow"],
+      &[
+        ("1px 2px -3px", None),
+        ("1px 2px -3px 4px", None),
+        ("1px 2px 0 -4px", Some("1px 2px 0 -4px")),
+        ("1px 2px calc(-3px)", Some("1px 2px")),
+      ],
+    );
     minify_test(
       ".foo { box-shadow: 64px 64px 12px 40px rgba(0,0,0,0.4) }",
       ".foo{box-shadow:64px 64px 12px 40px #0006}",
@@ -11358,6 +11734,32 @@ mod tests {
 
   #[test]
   fn test_transitions() {
+    property_range_test(&["transition-delay"], &[("-1s", Some("-1s"))]);
+    property_range_test(
+      &["transition"],
+      &[("opacity -1s", None), ("opacity 1s -1s", Some("opacity 1s -1s"))],
+    );
+    property_range_test(
+      &["transition-duration"],
+      &[("-1s", None), ("calc(1s - 2s)", Some("0s"))],
+    );
+    use crate::values::time::Time;
+
+    for (source, expected) in [
+      ("-1s", None),
+      ("-1ms", None),
+      ("0s", Some("0s")),
+      ("calc(-1s)", Some("0s")),
+      ("calc(500ms - 1s)", Some("0s")),
+      ("calc(-1s + 1500ms)", Some(".5s")),
+      ("calc(min(-1s, -2s) + 3s)", Some("1s")),
+      ("calc(1px)", None),
+      ("calc(1)", None),
+    ] {
+      non_negative_test::<Time>(source, expected);
+    }
+    assert!(Time::parse_string("-1s").is_ok());
+
     minify_test(".foo { transition-duration: 500ms }", ".foo{transition-duration:.5s}");
     minify_test(".foo { transition-duration: .5s }", ".foo{transition-duration:.5s}");
     minify_test(".foo { transition-duration: 99ms }", ".foo{transition-duration:99ms}");
@@ -12118,6 +12520,20 @@ mod tests {
 
   #[test]
   fn test_animation() {
+    property_range_test(&["animation-delay"], &[("-1s", Some("-1s"))]);
+    property_range_test(
+      &["animation"],
+      &[
+        ("test -1s", None),
+        ("test 1s -1s", Some("1s -1s test")),
+        ("test 1s -1", None),
+      ],
+    );
+    property_range_test(
+      &["animation-iteration-count"],
+      &[("-1", None), ("calc(1 - 2)", Some("0")), ("calc(-1 + 2)", Some("1"))],
+    );
+    property_range_test(&["animation-duration"], &[("-1s", None), ("calc(-1s)", Some("0s"))]);
     minify_test(".foo { animation-name: test }", ".foo{animation-name:test}");
     minify_test(".foo { animation-name: \"test\" }", ".foo{animation-name:test}");
     minify_test(".foo { animation-name: foo, bar }", ".foo{animation-name:foo,bar}");
@@ -12879,6 +13295,22 @@ mod tests {
 
   #[test]
   fn test_transform() {
+    property_range_test(
+      &["transform"],
+      &[
+        ("perspective(-1px)", None),
+        ("perspective(calc(-1px))", Some("perspective(0)")),
+        ("translateX(-1px)", Some("translate(-1px)")),
+      ],
+    );
+    property_range_test(
+      &["perspective"],
+      &[
+        ("-1px", None),
+        ("calc(1px - 2px)", Some("0")),
+        ("calc(-1px + 2px)", Some("1px")),
+      ],
+    );
     test(
       ".foo { transform: perspective(500px)translate3d(10px, 0, 20px)rotateY(30deg) }",
       indoc! {r#"
@@ -13366,6 +13798,14 @@ mod tests {
 
   #[test]
   pub fn test_gradients() {
+    property_range_test(&["clip-path"], &[("circle(-1px)", None), ("ellipse(1px -2%)", None)]);
+    property_range_test(
+      &["background-image"],
+      &[
+        ("radial-gradient(-1px, red, blue)", None),
+        ("radial-gradient(1px -2%, red, blue)", None),
+      ],
+    );
     minify_test(
       ".foo { background: linear-gradient(yellow, blue) }",
       ".foo{background:linear-gradient(#ff0,#00f)}",
@@ -15838,6 +16278,17 @@ mod tests {
 
   #[test]
   fn test_tab_size() {
+    property_range_test(
+      &["tab-size"],
+      &[
+        ("-1px", None),
+        ("calc(1px - 2px)", Some("0")),
+        ("calc(-1px + 2px)", Some("1px")),
+        ("-1", None),
+        ("calc(1 - 2)", Some("0")),
+        ("calc(-1 + 2)", Some("1")),
+      ],
+    );
     minify_test(".foo { tab-size: 8 }", ".foo{tab-size:8}");
     minify_test(".foo { tab-size: 4px }", ".foo{tab-size:4px}");
     minify_test(".foo { -moz-tab-size: 4px }", ".foo{-moz-tab-size:4px}");
@@ -16192,6 +16643,7 @@ mod tests {
 
   #[test]
   fn test_text_size_adjust() {
+    property_range_test(&["text-size-adjust"], &[("-1%", None), ("calc(-1%)", Some("0%"))]);
     minify_test(".foo { text-size-adjust: none }", ".foo{text-size-adjust:none}");
     minify_test(".foo { text-size-adjust: auto }", ".foo{text-size-adjust:auto}");
     minify_test(".foo { text-size-adjust: 80% }", ".foo{text-size-adjust:80%}");
@@ -17073,6 +17525,15 @@ mod tests {
 
   #[test]
   fn test_text_shadow() {
+    property_range_test(
+      &["text-shadow"],
+      &[
+        ("1px 2px -3px", None),
+        ("1px 2px 0 -4px", None),
+        ("-1px -2px", Some("-1px -2px")),
+        ("1px 2px calc(-3px)", Some("1px 2px")),
+      ],
+    );
     minify_test(
       ".foo { text-shadow: 1px 1px 2px yellow; }",
       ".foo{text-shadow:1px 1px 2px #ff0}",
@@ -19439,10 +19900,7 @@ mod tests {
     );
 
     // Test in image()
-    minify_test(
-      ".foo { mask: image(alpha(from red / 1))}",
-      ".foo{mask:image(red)}",
-    );
+    minify_test(".foo { mask: image(alpha(from red / 1))}", ".foo{mask:image(red)}");
 
     // Test in linear-gradient()
     minify_test(
@@ -22752,6 +23210,32 @@ mod tests {
 
   #[test]
   fn test_grid() {
+    property_range_test(
+      &["gap", "row-gap", "column-gap"],
+      &[
+        ("-1px", None),
+        ("calc(1px - 2px)", Some("0")),
+        ("calc(-1px + 2px)", Some("1px")),
+        ("-1%", None),
+        ("calc(1em - 2px)", Some("calc(1em - 2px)")),
+        ("calc(-1%)", Some("calc(-1%)")),
+      ],
+    );
+    property_range_test(
+      &["grid-template-columns", "grid-auto-rows"],
+      &[
+        ("-1px", None),
+        ("calc(1px - 2px)", Some("0")),
+        ("calc(-1px + 2px)", Some("1px")),
+        ("-1%", None),
+        ("calc(1em - 2px)", Some("calc(1em - 2px)")),
+        ("calc(-1%)", Some("calc(-1%)")),
+        ("-1fr", None),
+        ("-0fr", Some("-0fr")),
+        ("minmax(-1px, 1fr)", None),
+        ("fit-content(-1px)", None),
+      ],
+    );
     minify_test(
       ".foo { grid-template-columns: [first nav-start]  150px [main-start] 1fr [last]; }",
       ".foo{grid-template-columns:[first nav-start]150px[main-start]1fr[last]}",
@@ -27613,6 +28097,29 @@ mod tests {
 
   #[test]
   fn test_svg() {
+    property_range_test(
+      &["stroke-dasharray"],
+      &[
+        ("-1px", None),
+        ("-1%", None),
+        ("calc(-1px)", Some("0")),
+        ("calc(-1px + 2px)", Some("1")),
+        ("calc(-1%)", Some("calc(-1%)")),
+      ],
+    );
+    property_range_test(&["stroke-dashoffset"], &[("-1px", Some("-1px"))]);
+    property_range_test(&["stroke-dasharray"], &[("1px -2px", None)]);
+    property_range_test(
+      &["stroke-width"],
+      &[
+        ("-1px", None),
+        ("calc(1px - 2px)", Some("0")),
+        ("calc(-1px + 2px)", Some("1px")),
+        ("-1%", None),
+        ("calc(1em - 2px)", Some("calc(1em - 2px)")),
+        ("calc(-1%)", Some("calc(-1%)")),
+      ],
+    );
     use crate::properties::svg;
 
     minify_test(".foo { fill: yellow; }", ".foo{fill:#ff0}");
@@ -28462,6 +28969,22 @@ mod tests {
 
   #[test]
   fn test_filter() {
+    property_range_test(
+      &["filter", "backdrop-filter"],
+      &[
+        ("brightness(-1)", None),
+        ("contrast(-1)", None),
+        ("grayscale(-1)", None),
+        ("invert(-1)", None),
+        ("opacity(-1)", None),
+        ("saturate(-1)", None),
+        ("sepia(-1)", None),
+        ("blur(-1px)", None),
+        ("blur(calc(-1px))", Some("blur()")),
+        ("drop-shadow(1px 2px -3px)", None),
+        ("hue-rotate(-1deg)", Some("hue-rotate(-1deg)")),
+      ],
+    );
     minify_test(
       ".foo { filter: url('filters.svg#filter-id'); }",
       ".foo{filter:url(filters.svg#filter-id)}",
@@ -30930,6 +31453,15 @@ mod tests {
 
   #[test]
   fn test_resolution() {
+    use crate::values::resolution::Resolution;
+
+    for source in ["-1dpi", "-1dpcm", "-1dppx", "-1x"] {
+      non_negative_test::<Resolution>(source, None);
+      assert!(Resolution::parse_string(source).is_ok());
+    }
+    non_negative_test::<Resolution>("0dpi", Some("0dpi"));
+    non_negative_test::<Resolution>("10dpcm", Some("10dpcm"));
+
     prefix_test(
       r#"
       @media (resolution: 1dppx) {

--- a/src/properties/align.rs
+++ b/src/properties/align.rs
@@ -11,6 +11,7 @@ use crate::prefixes::{is_flex_2009, Feature};
 use crate::printer::Printer;
 use crate::traits::{FromStandard, Parse, PropertyHandler, Shorthand, ToCss};
 use crate::values::length::LengthPercentage;
+use crate::values::number::NonNegative;
 use crate::vendor_prefix::VendorPrefix;
 #[cfg(feature = "visitor")]
 use crate::visitor::Visit;
@@ -810,7 +811,7 @@ pub enum GapValue {
   /// Equal to `1em` for multi-column containers, and zero otherwise.
   Normal,
   /// An explicit length.
-  LengthPercentage(LengthPercentage),
+  LengthPercentage(NonNegative<LengthPercentage>),
 }
 
 define_shorthand! {

--- a/src/properties/animation.rs
+++ b/src/properties/animation.rs
@@ -11,7 +11,7 @@ use crate::printer::Printer;
 use crate::properties::{Property, PropertyId, TokenOrValue, VendorPrefix};
 use crate::traits::{Parse, PropertyHandler, Shorthand, ToCss, Zero};
 use crate::values::ident::DashedIdent;
-use crate::values::number::CSSNumber;
+use crate::values::number::{CSSNumber, NonNegative};
 use crate::values::percentage::Percentage;
 use crate::values::size::Size2D;
 use crate::values::string::CSSString;
@@ -100,14 +100,14 @@ pub type AnimationNameList<'i> = SmallVec<[AnimationName<'i>; 1]>;
 #[cfg_attr(feature = "into_owned", derive(static_self::IntoOwned))]
 pub enum AnimationIterationCount {
   /// The animation will repeat the specified number of times.
-  Number(CSSNumber),
+  Number(NonNegative<CSSNumber>),
   /// The animation will repeat forever.
   Infinite,
 }
 
 impl Default for AnimationIterationCount {
   fn default() -> Self {
-    AnimationIterationCount::Number(1.0)
+    AnimationIterationCount::Number(NonNegative(1.0))
   }
 }
 
@@ -588,7 +588,7 @@ define_list_shorthand! {
     #[cfg_attr(feature = "serde", serde(borrow))]
     name: AnimationName(AnimationName<'i>, VendorPrefix),
     /// The animation duration.
-    duration: AnimationDuration(Time, VendorPrefix),
+    duration: AnimationDuration(NonNegative<Time>, VendorPrefix),
     /// The easing function for the animation.
     timing_function: AnimationTimingFunction(EasingFunction, VendorPrefix),
     /// The number of times the animation will run.
@@ -619,9 +619,9 @@ impl<'i> Parse<'i> for Animation<'i> {
     let mut timeline = None;
 
     macro_rules! parse_prop {
-      ($var: ident, $type: ident) => {
+      ($var: ident, $type: ty) => {
         if $var.is_none() {
-          if let Ok(value) = input.try_parse($type::parse) {
+          if let Ok(value) = input.try_parse(<$type>::parse) {
             $var = Some(value);
             continue;
           }
@@ -630,9 +630,12 @@ impl<'i> Parse<'i> for Animation<'i> {
     }
 
     loop {
-      parse_prop!(duration, Time);
+      parse_prop!(duration, NonNegative<Time>);
       parse_prop!(timing_function, EasingFunction);
-      parse_prop!(delay, Time);
+      // The first time must be a duration, even if it is invalid.
+      if duration.is_some() {
+        parse_prop!(delay, Time);
+      }
       parse_prop!(iteration_count, AnimationIterationCount);
       parse_prop!(direction, AnimationDirection);
       parse_prop!(fill_mode, AnimationFillMode);
@@ -644,9 +647,9 @@ impl<'i> Parse<'i> for Animation<'i> {
 
     Ok(Animation {
       name: name.unwrap_or(AnimationName::None),
-      duration: duration.unwrap_or(Time::Seconds(0.0)),
+      duration: duration.unwrap_or(NonNegative(Time::Seconds(0.0))),
       timing_function: timing_function.unwrap_or(EasingFunction::Ease),
-      iteration_count: iteration_count.unwrap_or(AnimationIterationCount::Number(1.0)),
+      iteration_count: iteration_count.unwrap_or(AnimationIterationCount::Number(NonNegative(1.0))),
       direction: direction.unwrap_or(AnimationDirection::Normal),
       play_state: play_state.unwrap_or(AnimationPlayState::Running),
       delay: delay.unwrap_or(Time::Seconds(0.0)),
@@ -722,7 +725,7 @@ pub type AnimationList<'i> = SmallVec<[Animation<'i>; 1]>;
 #[derive(Default)]
 pub(crate) struct AnimationHandler<'i> {
   names: Option<(SmallVec<[AnimationName<'i>; 1]>, VendorPrefix)>,
-  durations: Option<(SmallVec<[Time; 1]>, VendorPrefix)>,
+  durations: Option<(SmallVec<[NonNegative<Time>; 1]>, VendorPrefix)>,
   timing_functions: Option<(SmallVec<[EasingFunction; 1]>, VendorPrefix)>,
   iteration_counts: Option<(SmallVec<[AnimationIterationCount; 1]>, VendorPrefix)>,
   directions: Option<(SmallVec<[AnimationDirection; 1]>, VendorPrefix)>,

--- a/src/properties/background.rs
+++ b/src/properties/background.rs
@@ -11,6 +11,7 @@ use crate::targets::{Browsers, Targets};
 use crate::traits::{FallbackValues, IsCompatible, Parse, PropertyHandler, Shorthand, ToCss};
 use crate::values::color::ColorFallbackKind;
 use crate::values::image::ImageFallback;
+use crate::values::number::NonNegative;
 use crate::values::{color::CssColor, image::Image, length::LengthPercentageOrAuto, position::*};
 #[cfg(feature = "visitor")]
 use crate::visitor::Visit;
@@ -32,9 +33,9 @@ pub enum BackgroundSize {
   /// An explicit background size.
   Explicit {
     /// The width of the background.
-    width: LengthPercentageOrAuto,
+    width: NonNegative<LengthPercentageOrAuto>,
     /// The height of the background.
-    height: LengthPercentageOrAuto,
+    height: NonNegative<LengthPercentageOrAuto>,
   },
   /// The `cover` keyword. Scales the background image to cover both the width and height of the element.
   Cover,
@@ -45,18 +46,18 @@ pub enum BackgroundSize {
 impl Default for BackgroundSize {
   fn default() -> BackgroundSize {
     BackgroundSize::Explicit {
-      width: LengthPercentageOrAuto::Auto,
-      height: LengthPercentageOrAuto::Auto,
+      width: NonNegative(LengthPercentageOrAuto::Auto),
+      height: NonNegative(LengthPercentageOrAuto::Auto),
     }
   }
 }
 
 impl<'i> Parse<'i> for BackgroundSize {
   fn parse<'t>(input: &mut Parser<'i, 't>) -> Result<Self, ParseError<'i, ParserError<'i>>> {
-    if let Ok(width) = input.try_parse(LengthPercentageOrAuto::parse) {
+    if let Ok(width) = input.try_parse(NonNegative::<LengthPercentageOrAuto>::parse) {
       let height = input
-        .try_parse(LengthPercentageOrAuto::parse)
-        .unwrap_or(LengthPercentageOrAuto::Auto);
+        .try_parse(NonNegative::<LengthPercentageOrAuto>::parse)
+        .unwrap_or(NonNegative(LengthPercentageOrAuto::Auto));
       return Ok(BackgroundSize::Explicit { width, height });
     }
 
@@ -84,7 +85,7 @@ impl ToCss for BackgroundSize {
       Contain => dest.write_str("contain"),
       Explicit { width, height } => {
         width.to_css(dest)?;
-        if *height != LengthPercentageOrAuto::Auto {
+        if *height != NonNegative(LengthPercentageOrAuto::Auto) {
           dest.write_str(" ")?;
           height.to_css(dest)?;
         }

--- a/src/properties/border.rs
+++ b/src/properties/border.rs
@@ -16,6 +16,7 @@ use crate::targets::Targets;
 use crate::traits::{FallbackValues, IsCompatible, Parse, PropertyHandler, Shorthand, ToCss};
 use crate::values::color::{ColorFallbackKind, CssColor};
 use crate::values::length::*;
+use crate::values::number::NonNegative;
 use crate::values::rect::Rect;
 use crate::values::size::Size2D;
 #[cfg(feature = "visitor")]
@@ -40,7 +41,7 @@ pub enum BorderSideWidth {
   /// A UA defined `thick` value.
   Thick,
   /// An explicit width.
-  Length(Length),
+  Length(NonNegative<Length>),
 }
 
 impl Default for BorderSideWidth {

--- a/src/properties/border_image.rs
+++ b/src/properties/border_image.rs
@@ -10,6 +10,7 @@ use crate::targets::{Browsers, Targets};
 use crate::traits::{IsCompatible, Parse, PropertyHandler, Shorthand, ToCss};
 use crate::values::image::Image;
 use crate::values::number::CSSNumber;
+use crate::values::number::NonNegative;
 use crate::values::rect::Rect;
 #[cfg(feature = "visitor")]
 use crate::visitor::Visit;
@@ -113,16 +114,16 @@ impl IsCompatible for BorderImageRepeat {
 #[cfg_attr(feature = "into_owned", derive(static_self::IntoOwned))]
 pub enum BorderImageSideWidth {
   /// A number representing a multiple of the border width.
-  Number(CSSNumber),
+  Number(NonNegative<CSSNumber>),
   /// An explicit length or percentage.
-  LengthPercentage(LengthPercentage),
+  LengthPercentage(NonNegative<LengthPercentage>),
   /// The `auto` keyword, representing the natural width of the image slice.
   Auto,
 }
 
 impl Default for BorderImageSideWidth {
   fn default() -> BorderImageSideWidth {
-    BorderImageSideWidth::Number(1.0)
+    BorderImageSideWidth::Number(NonNegative(1.0))
   }
 }
 
@@ -143,7 +144,7 @@ impl IsCompatible for BorderImageSideWidth {
 #[cfg_attr(feature = "into_owned", derive(static_self::IntoOwned))]
 pub struct BorderImageSlice {
   /// The offsets from the edges of the image.
-  pub offsets: Rect<NumberOrPercentage>,
+  pub offsets: Rect<NonNegative<NumberOrPercentage>>,
   /// Whether the middle of the border image should be preserved.
   pub fill: bool,
 }
@@ -151,7 +152,7 @@ pub struct BorderImageSlice {
 impl Default for BorderImageSlice {
   fn default() -> BorderImageSlice {
     BorderImageSlice {
-      offsets: Rect::all(NumberOrPercentage::Percentage(Percentage(1.0))),
+      offsets: Rect::all(NonNegative(NumberOrPercentage::Percentage(Percentage(1.0)))),
       fill: false,
     }
   }
@@ -199,7 +200,7 @@ define_shorthand! {
     /// The width of the border image.
     width: BorderImageWidth(Rect<BorderImageSideWidth>),
     /// The amount that the image extends beyond the border box.
-    outset: BorderImageOutset(Rect<LengthOrNumber>),
+    outset: BorderImageOutset(Rect<NonNegative<LengthOrNumber>>),
     /// How the border image is scaled and tiled.
     repeat: BorderImageRepeat(BorderImageRepeat),
   }
@@ -222,7 +223,7 @@ impl<'i> BorderImage<'i> {
     let mut source: Option<Image> = None;
     let mut slice: Option<BorderImageSlice> = None;
     let mut width: Option<Rect<BorderImageSideWidth>> = None;
-    let mut outset: Option<Rect<LengthOrNumber>> = None;
+    let mut outset: Option<Rect<NonNegative<LengthOrNumber>>> = None;
     let mut repeat: Option<BorderImageRepeat> = None;
     loop {
       if slice.is_none() {
@@ -283,7 +284,7 @@ impl<'i> BorderImage<'i> {
         source: source.unwrap_or_default(),
         slice: slice.unwrap_or_default(),
         width: width.unwrap_or(Rect::all(BorderImageSideWidth::default())),
-        outset: outset.unwrap_or(Rect::all(LengthOrNumber::default())),
+        outset: outset.unwrap_or(Rect::all(NonNegative(LengthOrNumber::default()))),
         repeat: repeat.unwrap_or_default(),
       })
     } else {
@@ -295,7 +296,7 @@ impl<'i> BorderImage<'i> {
     source: &Image<'i>,
     slice: &BorderImageSlice,
     width: &Rect<BorderImageSideWidth>,
-    outset: &Rect<LengthOrNumber>,
+    outset: &Rect<NonNegative<LengthOrNumber>>,
     repeat: &BorderImageRepeat,
     dest: &mut Printer<W>,
   ) -> Result<(), PrinterError>
@@ -307,7 +308,7 @@ impl<'i> BorderImage<'i> {
     }
     let has_slice = *slice != BorderImageSlice::default();
     let has_width = *width != Rect::all(BorderImageSideWidth::default());
-    let has_outset = *outset != Rect::all(LengthOrNumber::Number(0.0));
+    let has_outset = *outset != Rect::all(NonNegative(LengthOrNumber::Number(0.0)));
     if has_slice || has_width || has_outset {
       dest.write_str(" ")?;
       slice.to_css(dest)?;
@@ -370,7 +371,7 @@ pub(crate) struct BorderImageHandler<'i> {
   source: Option<Image<'i>>,
   slice: Option<BorderImageSlice>,
   width: Option<Rect<BorderImageSideWidth>>,
-  outset: Option<Rect<LengthOrNumber>>,
+  outset: Option<Rect<NonNegative<LengthOrNumber>>>,
   repeat: Option<BorderImageRepeat>,
   vendor_prefix: VendorPrefix,
   flushed_properties: BorderImageProperty,

--- a/src/properties/border_radius.rs
+++ b/src/properties/border_radius.rs
@@ -11,6 +11,7 @@ use crate::printer::Printer;
 use crate::properties::{Property, PropertyId, VendorPrefix};
 use crate::traits::{IsCompatible, Parse, PropertyHandler, Shorthand, ToCss, Zero};
 use crate::values::length::*;
+use crate::values::number::NonNegative;
 use crate::values::rect::Rect;
 use crate::values::size::Size2D;
 #[cfg(feature = "visitor")]
@@ -21,19 +22,22 @@ define_shorthand! {
   /// A value for the [border-radius](https://www.w3.org/TR/css-backgrounds-3/#border-radius) property.
   pub struct BorderRadius(VendorPrefix) {
     /// The x and y radius values for the top left corner.
-    top_left: BorderTopLeftRadius(Size2D<LengthPercentage>, VendorPrefix),
+    top_left: BorderTopLeftRadius(Size2D<NonNegative<LengthPercentage>>, VendorPrefix),
     /// The x and y radius values for the top right corner.
-    top_right: BorderTopRightRadius(Size2D<LengthPercentage>, VendorPrefix),
+    top_right: BorderTopRightRadius(Size2D<NonNegative<LengthPercentage>>, VendorPrefix),
     /// The x and y radius values for the bottom right corner.
-    bottom_right: BorderBottomRightRadius(Size2D<LengthPercentage>, VendorPrefix),
+    bottom_right: BorderBottomRightRadius(Size2D<NonNegative<LengthPercentage>>, VendorPrefix),
     /// The x and y radius values for the bottom left corner.
-    bottom_left: BorderBottomLeftRadius(Size2D<LengthPercentage>, VendorPrefix),
+    bottom_left: BorderBottomLeftRadius(Size2D<NonNegative<LengthPercentage>>, VendorPrefix),
   }
 }
 
 impl Default for BorderRadius {
   fn default() -> BorderRadius {
-    let zero = Size2D(LengthPercentage::zero(), LengthPercentage::zero());
+    let zero = Size2D(
+      NonNegative::<LengthPercentage>::zero(),
+      NonNegative::<LengthPercentage>::zero(),
+    );
     BorderRadius {
       top_left: zero.clone(),
       top_right: zero.clone(),
@@ -45,7 +49,7 @@ impl Default for BorderRadius {
 
 impl<'i> Parse<'i> for BorderRadius {
   fn parse<'t>(input: &mut Parser<'i, 't>) -> Result<Self, ParseError<'i, ParserError<'i>>> {
-    let widths: Rect<LengthPercentage> = Rect::parse(input)?;
+    let widths: Rect<NonNegative<LengthPercentage>> = Rect::parse(input)?;
     let heights = if input.try_parse(|input| input.expect_delim('/')).is_ok() {
       Rect::parse(input)?
     } else {
@@ -91,10 +95,10 @@ impl ToCss for BorderRadius {
 
 #[derive(Default, Debug)]
 pub(crate) struct BorderRadiusHandler<'i> {
-  top_left: Option<(Size2D<LengthPercentage>, VendorPrefix)>,
-  top_right: Option<(Size2D<LengthPercentage>, VendorPrefix)>,
-  bottom_right: Option<(Size2D<LengthPercentage>, VendorPrefix)>,
-  bottom_left: Option<(Size2D<LengthPercentage>, VendorPrefix)>,
+  top_left: Option<(Size2D<NonNegative<LengthPercentage>>, VendorPrefix)>,
+  top_right: Option<(Size2D<NonNegative<LengthPercentage>>, VendorPrefix)>,
+  bottom_right: Option<(Size2D<NonNegative<LengthPercentage>>, VendorPrefix)>,
+  bottom_left: Option<(Size2D<NonNegative<LengthPercentage>>, VendorPrefix)>,
   start_start: Option<Property<'i>>,
   start_end: Option<Property<'i>>,
   end_end: Option<Property<'i>>,

--- a/src/properties/box_shadow.rs
+++ b/src/properties/box_shadow.rs
@@ -11,6 +11,7 @@ use crate::targets::Browsers;
 use crate::traits::{IsCompatible, Parse, PropertyHandler, ToCss, Zero};
 use crate::values::color::{ColorFallbackKind, CssColor};
 use crate::values::length::Length;
+use crate::values::number::NonNegative;
 use crate::vendor_prefix::VendorPrefix;
 #[cfg(feature = "visitor")]
 use crate::visitor::Visit;
@@ -35,7 +36,7 @@ pub struct BoxShadow {
   /// The y offset of the shadow.
   pub y_offset: Length,
   /// The blur radius of the shadow.
-  pub blur: Length,
+  pub blur: NonNegative<Length>,
   /// The spread distance of the shadow.
   pub spread: Length,
   /// Whether the shadow is inset within the box.
@@ -60,9 +61,14 @@ impl<'i> Parse<'i> for BoxShadow {
         let value = input.try_parse::<_, _, ParseError<ParserError<'i>>>(|input| {
           let horizontal = Length::parse(input)?;
           let vertical = Length::parse(input)?;
-          let blur = input.try_parse(Length::parse).unwrap_or(Length::zero());
-          let spread = input.try_parse(Length::parse).unwrap_or(Length::zero());
-          Ok((horizontal, vertical, blur, spread))
+          let blur = input.try_parse(NonNegative::<Length>::parse).ok();
+          // A rejected blur radius must not be reinterpreted as a spread.
+          let spread = if blur.is_some() {
+            input.try_parse(Length::parse).unwrap_or(Length::zero())
+          } else {
+            Length::zero()
+          };
+          Ok((horizontal, vertical, blur.unwrap_or(NonNegative::zero()), spread))
         });
 
         if let Ok(value) = value {
@@ -106,7 +112,7 @@ impl ToCss for BoxShadow {
     dest.write_char(' ')?;
     self.y_offset.to_css(dest)?;
 
-    if self.blur != Length::zero() || self.spread != Length::zero() {
+    if self.blur != NonNegative::zero() || self.spread != Length::zero() {
       dest.write_char(' ')?;
       self.blur.to_css(dest)?;
 

--- a/src/properties/effects.rs
+++ b/src/properties/effects.rs
@@ -6,6 +6,7 @@ use crate::printer::Printer;
 use crate::targets::{Browsers, Targets};
 use crate::traits::{FallbackValues, IsCompatible, Parse, ToCss, Zero};
 use crate::values::color::ColorFallbackKind;
+use crate::values::number::NonNegative;
 use crate::values::{angle::Angle, color::CssColor, length::Length, percentage::NumberOrPercentage, url::Url};
 #[cfg(feature = "visitor")]
 use crate::visitor::Visit;
@@ -24,23 +25,23 @@ use smallvec::SmallVec;
 #[cfg_attr(feature = "jsonschema", derive(schemars::JsonSchema))]
 pub enum Filter<'i> {
   /// A `blur()` filter.
-  Blur(Length),
+  Blur(NonNegative<Length>),
   /// A `brightness()` filter.
-  Brightness(NumberOrPercentage),
+  Brightness(NonNegative<NumberOrPercentage>),
   /// A `contrast()` filter.
-  Contrast(NumberOrPercentage),
+  Contrast(NonNegative<NumberOrPercentage>),
   /// A `grayscale()` filter.
-  Grayscale(NumberOrPercentage),
+  Grayscale(NonNegative<NumberOrPercentage>),
   /// A `hue-rotate()` filter.
   HueRotate(Angle),
   /// An `invert()` filter.
-  Invert(NumberOrPercentage),
+  Invert(NonNegative<NumberOrPercentage>),
   /// An `opacity()` filter.
-  Opacity(NumberOrPercentage),
+  Opacity(NonNegative<NumberOrPercentage>),
   /// A `saturate()` filter.
-  Saturate(NumberOrPercentage),
+  Saturate(NonNegative<NumberOrPercentage>),
   /// A `sepia()` filter.
-  Sepia(NumberOrPercentage),
+  Sepia(NonNegative<NumberOrPercentage>),
   /// A `drop-shadow()` filter.
   DropShadow(DropShadow),
   /// A `url()` reference to an SVG filter.
@@ -59,22 +60,22 @@ impl<'i> Parse<'i> for Filter<'i> {
     match_ignore_ascii_case! { &function,
       "blur" => {
         input.parse_nested_block(|input| {
-          Ok(Filter::Blur(input.try_parse(Length::parse).unwrap_or(Length::zero())))
+          Ok(Filter::Blur(input.try_parse(NonNegative::<Length>::parse).unwrap_or(NonNegative::zero())))
         })
       },
       "brightness" => {
         input.parse_nested_block(|input| {
-          Ok(Filter::Brightness(input.try_parse(NumberOrPercentage::parse).unwrap_or(NumberOrPercentage::Number(1.0))))
+          Ok(Filter::Brightness(input.try_parse(NonNegative::<NumberOrPercentage>::parse).unwrap_or(NonNegative(NumberOrPercentage::Number(1.0)))))
         })
       },
       "contrast" => {
         input.parse_nested_block(|input| {
-          Ok(Filter::Contrast(input.try_parse(NumberOrPercentage::parse).unwrap_or(NumberOrPercentage::Number(1.0))))
+          Ok(Filter::Contrast(input.try_parse(NonNegative::<NumberOrPercentage>::parse).unwrap_or(NonNegative(NumberOrPercentage::Number(1.0)))))
         })
       },
       "grayscale" => {
         input.parse_nested_block(|input| {
-          Ok(Filter::Grayscale(input.try_parse(NumberOrPercentage::parse).unwrap_or(NumberOrPercentage::Number(1.0))))
+          Ok(Filter::Grayscale(input.try_parse(NonNegative::<NumberOrPercentage>::parse).unwrap_or(NonNegative(NumberOrPercentage::Number(1.0)))))
         })
       },
       "hue-rotate" => {
@@ -85,22 +86,22 @@ impl<'i> Parse<'i> for Filter<'i> {
       },
       "invert" => {
         input.parse_nested_block(|input| {
-          Ok(Filter::Invert(input.try_parse(NumberOrPercentage::parse).unwrap_or(NumberOrPercentage::Number(1.0))))
+          Ok(Filter::Invert(input.try_parse(NonNegative::<NumberOrPercentage>::parse).unwrap_or(NonNegative(NumberOrPercentage::Number(1.0)))))
         })
       },
       "opacity" => {
         input.parse_nested_block(|input| {
-          Ok(Filter::Opacity(input.try_parse(NumberOrPercentage::parse).unwrap_or(NumberOrPercentage::Number(1.0))))
+          Ok(Filter::Opacity(input.try_parse(NonNegative::<NumberOrPercentage>::parse).unwrap_or(NonNegative(NumberOrPercentage::Number(1.0)))))
         })
       },
       "saturate" => {
         input.parse_nested_block(|input| {
-          Ok(Filter::Saturate(input.try_parse(NumberOrPercentage::parse).unwrap_or(NumberOrPercentage::Number(1.0))))
+          Ok(Filter::Saturate(input.try_parse(NonNegative::<NumberOrPercentage>::parse).unwrap_or(NonNegative(NumberOrPercentage::Number(1.0)))))
         })
       },
       "sepia" => {
         input.parse_nested_block(|input| {
-          Ok(Filter::Sepia(input.try_parse(NumberOrPercentage::parse).unwrap_or(NumberOrPercentage::Number(1.0))))
+          Ok(Filter::Sepia(input.try_parse(NonNegative::<NumberOrPercentage>::parse).unwrap_or(NonNegative(NumberOrPercentage::Number(1.0)))))
         })
       },
       "drop-shadow" => {
@@ -123,14 +124,14 @@ impl<'i> ToCss for Filter<'i> {
     match self {
       Filter::Blur(val) => {
         dest.write_str("blur(")?;
-        if *val != Length::zero() {
+        if *val != NonNegative::zero() {
           val.to_css(dest)?;
         }
         dest.write_char(')')
       }
       Filter::Brightness(val) => {
         dest.write_str("brightness(")?;
-        let v: f32 = val.into();
+        let v: f32 = (&val.0).into();
         if v != 1.0 {
           val.to_css(dest)?;
         }
@@ -138,7 +139,7 @@ impl<'i> ToCss for Filter<'i> {
       }
       Filter::Contrast(val) => {
         dest.write_str("contrast(")?;
-        let v: f32 = val.into();
+        let v: f32 = (&val.0).into();
         if v != 1.0 {
           val.to_css(dest)?;
         }
@@ -146,7 +147,7 @@ impl<'i> ToCss for Filter<'i> {
       }
       Filter::Grayscale(val) => {
         dest.write_str("grayscale(")?;
-        let v: f32 = val.into();
+        let v: f32 = (&val.0).into();
         if v != 1.0 {
           val.to_css(dest)?;
         }
@@ -161,7 +162,7 @@ impl<'i> ToCss for Filter<'i> {
       }
       Filter::Invert(val) => {
         dest.write_str("invert(")?;
-        let v: f32 = val.into();
+        let v: f32 = (&val.0).into();
         if v != 1.0 {
           val.to_css(dest)?;
         }
@@ -169,7 +170,7 @@ impl<'i> ToCss for Filter<'i> {
       }
       Filter::Opacity(val) => {
         dest.write_str("opacity(")?;
-        let v: f32 = val.into();
+        let v: f32 = (&val.0).into();
         if v != 1.0 {
           val.to_css(dest)?;
         }
@@ -177,7 +178,7 @@ impl<'i> ToCss for Filter<'i> {
       }
       Filter::Saturate(val) => {
         dest.write_str("saturate(")?;
-        let v: f32 = val.into();
+        let v: f32 = (&val.0).into();
         if v != 1.0 {
           val.to_css(dest)?;
         }
@@ -185,7 +186,7 @@ impl<'i> ToCss for Filter<'i> {
       }
       Filter::Sepia(val) => {
         dest.write_str("sepia(")?;
-        let v: f32 = val.into();
+        let v: f32 = (&val.0).into();
         if v != 1.0 {
           val.to_css(dest)?;
         }
@@ -234,7 +235,7 @@ pub struct DropShadow {
   /// The y offset of the drop shadow.
   pub y_offset: Length,
   /// The blur radius of the drop shadow.
-  pub blur: Length,
+  pub blur: NonNegative<Length>,
 }
 
 impl<'i> Parse<'i> for DropShadow {
@@ -247,7 +248,7 @@ impl<'i> Parse<'i> for DropShadow {
         let value = input.try_parse::<_, _, ParseError<ParserError<'i>>>(|input| {
           let horizontal = Length::parse(input)?;
           let vertical = Length::parse(input)?;
-          let blur = input.try_parse(Length::parse).unwrap_or(Length::zero());
+          let blur = input.try_parse(NonNegative::<Length>::parse).unwrap_or(NonNegative::zero());
           Ok((horizontal, vertical, blur))
         });
 
@@ -286,7 +287,7 @@ impl ToCss for DropShadow {
     dest.write_char(' ')?;
     self.y_offset.to_css(dest)?;
 
-    if self.blur != Length::zero() {
+    if self.blur != NonNegative::zero() {
       dest.write_char(' ')?;
       self.blur.to_css(dest)?;
     }

--- a/src/properties/flex.rs
+++ b/src/properties/flex.rs
@@ -11,7 +11,7 @@ use crate::macros::*;
 use crate::prefixes::{is_flex_2009, Feature};
 use crate::printer::Printer;
 use crate::traits::{FromStandard, Parse, PropertyHandler, Shorthand, ToCss, Zero};
-use crate::values::number::{CSSInteger, CSSNumber};
+use crate::values::number::{CSSInteger, CSSNumber, NonNegative};
 use crate::values::{
   length::{LengthPercentage, LengthPercentageOrAuto},
   percentage::Percentage,
@@ -128,11 +128,11 @@ define_shorthand! {
 /// A value for the [flex](https://www.w3.org/TR/2018/CR-css-flexbox-1-20181119/#flex-property) shorthand property.
   pub struct Flex(VendorPrefix) {
     /// The flex grow factor.
-    grow: FlexGrow(CSSNumber, VendorPrefix),
+    grow: FlexGrow(NonNegative<CSSNumber>, VendorPrefix),
     /// The flex shrink factor.
-    shrink: FlexShrink(CSSNumber, VendorPrefix),
+    shrink: FlexShrink(NonNegative<CSSNumber>, VendorPrefix),
     /// The flex basis.
-    basis: FlexBasis(LengthPercentageOrAuto, VendorPrefix),
+    basis: FlexBasis(NonNegative<LengthPercentageOrAuto>, VendorPrefix),
   }
 }
 
@@ -140,9 +140,9 @@ impl<'i> Parse<'i> for Flex {
   fn parse<'t>(input: &mut Parser<'i, 't>) -> Result<Self, ParseError<'i, ParserError<'i>>> {
     if input.try_parse(|input| input.expect_ident_matching("none")).is_ok() {
       return Ok(Flex {
-        grow: 0.0,
-        shrink: 0.0,
-        basis: LengthPercentageOrAuto::Auto,
+        grow: NonNegative(0.0),
+        shrink: NonNegative(0.0),
+        basis: NonNegative(LengthPercentageOrAuto::Auto),
       });
     }
 
@@ -152,15 +152,15 @@ impl<'i> Parse<'i> for Flex {
 
     loop {
       if grow.is_none() {
-        if let Ok(val) = input.try_parse(CSSNumber::parse) {
+        if let Ok(val) = input.try_parse(NonNegative::<CSSNumber>::parse) {
           grow = Some(val);
-          shrink = input.try_parse(CSSNumber::parse).ok();
+          shrink = input.try_parse(NonNegative::<CSSNumber>::parse).ok();
           continue;
         }
       }
 
       if basis.is_none() {
-        if let Ok(val) = input.try_parse(LengthPercentageOrAuto::parse) {
+        if let Ok(val) = input.try_parse(NonNegative::<LengthPercentageOrAuto>::parse) {
           basis = Some(val);
           continue;
         }
@@ -170,10 +170,10 @@ impl<'i> Parse<'i> for Flex {
     }
 
     Ok(Flex {
-      grow: grow.unwrap_or(1.0),
-      shrink: shrink.unwrap_or(1.0),
-      basis: basis.unwrap_or(LengthPercentageOrAuto::LengthPercentage(LengthPercentage::Percentage(
-        Percentage(0.0),
+      grow: grow.unwrap_or(NonNegative(1.0)),
+      shrink: shrink.unwrap_or(NonNegative(1.0)),
+      basis: basis.unwrap_or(NonNegative(LengthPercentageOrAuto::LengthPercentage(
+        LengthPercentage::Percentage(Percentage(0.0)),
       ))),
     })
   }
@@ -184,7 +184,7 @@ impl ToCss for Flex {
   where
     W: std::fmt::Write,
   {
-    if self.grow == 0.0 && self.shrink == 0.0 && self.basis == LengthPercentageOrAuto::Auto {
+    if self.grow.0 == 0.0 && self.shrink.0 == 0.0 && self.basis.0 == LengthPercentageOrAuto::Auto {
       dest.write_str("none")?;
       return Ok(());
     }
@@ -198,7 +198,7 @@ impl ToCss for Flex {
 
     // If the basis is unitless 0, we must write all three components to disambiguate.
     // If the basis is 0%, we can omit the basis.
-    let basis_kind = match &self.basis {
+    let basis_kind = match &self.basis.0 {
       LengthPercentageOrAuto::LengthPercentage(lp) => match lp {
         LengthPercentage::Dimension(l) if l.is_zero() => ZeroKind::Length,
         LengthPercentage::Percentage(p) if p.is_zero() => ZeroKind::Percentage,
@@ -207,16 +207,16 @@ impl ToCss for Flex {
       _ => ZeroKind::NonZero,
     };
 
-    if self.grow != 1.0 || self.shrink != 1.0 || basis_kind != ZeroKind::NonZero {
+    if self.grow.0 != 1.0 || self.shrink.0 != 1.0 || basis_kind != ZeroKind::NonZero {
       self.grow.to_css(dest)?;
-      if self.shrink != 1.0 || basis_kind == ZeroKind::Length {
+      if self.shrink.0 != 1.0 || basis_kind == ZeroKind::Length {
         dest.write_str(" ")?;
         self.shrink.to_css(dest)?;
       }
     }
 
     if basis_kind != ZeroKind::Percentage {
-      if self.grow != 1.0 || self.shrink != 1.0 || basis_kind == ZeroKind::Length {
+      if self.grow.0 != 1.0 || self.shrink.0 != 1.0 || basis_kind == ZeroKind::Length {
         dest.write_str(" ")?;
       }
       self.basis.to_css(dest)?;
@@ -477,13 +477,13 @@ pub(crate) struct FlexHandler {
   box_direction: Option<(BoxDirection, VendorPrefix)>,
   wrap: Option<(FlexWrap, VendorPrefix)>,
   box_lines: Option<(BoxLines, VendorPrefix)>,
-  grow: Option<(CSSNumber, VendorPrefix)>,
-  box_flex: Option<(CSSNumber, VendorPrefix)>,
-  flex_positive: Option<(CSSNumber, VendorPrefix)>,
-  shrink: Option<(CSSNumber, VendorPrefix)>,
-  flex_negative: Option<(CSSNumber, VendorPrefix)>,
-  basis: Option<(LengthPercentageOrAuto, VendorPrefix)>,
-  preferred_size: Option<(LengthPercentageOrAuto, VendorPrefix)>,
+  grow: Option<(NonNegative<CSSNumber>, VendorPrefix)>,
+  box_flex: Option<(NonNegative<CSSNumber>, VendorPrefix)>,
+  flex_positive: Option<(NonNegative<CSSNumber>, VendorPrefix)>,
+  shrink: Option<(NonNegative<CSSNumber>, VendorPrefix)>,
+  flex_negative: Option<(NonNegative<CSSNumber>, VendorPrefix)>,
+  basis: Option<(NonNegative<LengthPercentageOrAuto>, VendorPrefix)>,
+  preferred_size: Option<(NonNegative<LengthPercentageOrAuto>, VendorPrefix)>,
   order: Option<(CSSInteger, VendorPrefix)>,
   box_ordinal_group: Option<(BoxOrdinalGroup, VendorPrefix)>,
   flex_order: Option<(CSSInteger, VendorPrefix)>,

--- a/src/properties/font.rs
+++ b/src/properties/font.rs
@@ -12,7 +12,7 @@ use crate::printer::Printer;
 use crate::targets::should_compile;
 use crate::traits::{IsCompatible, Parse, PropertyHandler, Shorthand, ToCss};
 use crate::values::length::LengthValue;
-use crate::values::number::CSSNumber;
+use crate::values::number::{CSSNumber, NonNegative};
 use crate::values::string::CowArcStr;
 use crate::values::{angle::Angle, length::LengthPercentage, percentage::Percentage};
 #[cfg(feature = "visitor")]
@@ -158,7 +158,7 @@ enum_property! {
 #[cfg_attr(feature = "into_owned", derive(static_self::IntoOwned))]
 pub enum FontSize {
   /// An explicit size.
-  Length(LengthPercentage),
+  Length(NonNegative<LengthPercentage>),
   /// An absolute font size keyword.
   Absolute(AbsoluteFontSize),
   /// A relative font size keyword.
@@ -168,7 +168,7 @@ pub enum FontSize {
 impl IsCompatible for FontSize {
   fn is_compatible(&self, browsers: crate::targets::Browsers) -> bool {
     match self {
-      FontSize::Length(LengthPercentage::Dimension(LengthValue::Rem(..))) => {
+      FontSize::Length(NonNegative(LengthPercentage::Dimension(LengthValue::Rem(..)))) => {
         Feature::FontSizeRem.is_compatible(browsers)
       }
       FontSize::Length(l) => l.is_compatible(browsers),
@@ -243,7 +243,7 @@ pub enum FontStretch {
   /// A font stretch keyword.
   Keyword(FontStretchKeyword),
   /// A percentage.
-  Percentage(Percentage),
+  Percentage(NonNegative<Percentage>),
 }
 
 impl Default for FontStretch {
@@ -255,7 +255,7 @@ impl Default for FontStretch {
 impl Into<Percentage> for &FontStretch {
   fn into(self) -> Percentage {
     match self {
-      FontStretch::Percentage(val) => val.clone(),
+      FontStretch::Percentage(val) => val.0.clone(),
       FontStretch::Keyword(keyword) => keyword.into(),
     }
   }
@@ -597,9 +597,9 @@ pub enum LineHeight {
   /// The UA sets the line height based on the font.
   Normal,
   /// A multiple of the element's font size.
-  Number(CSSNumber),
+  Number(NonNegative<CSSNumber>),
   /// An explicit height.
-  Length(LengthPercentage),
+  Length(NonNegative<LengthPercentage>),
 }
 
 impl Default for LineHeight {

--- a/src/properties/grid.rs
+++ b/src/properties/grid.rs
@@ -11,7 +11,7 @@ use crate::properties::{Property, PropertyId};
 use crate::traits::{Parse, PropertyHandler, Shorthand, ToCss};
 use crate::values::ident::CustomIdent;
 use crate::values::length::serialize_dimension;
-use crate::values::number::{CSSInteger, CSSNumber};
+use crate::values::number::{CSSInteger, CSSNumber, NonNegative};
 use crate::values::{ident::CustomIdentList, length::LengthPercentage};
 #[cfg(feature = "visitor")]
 use crate::visitor::Visit;
@@ -107,8 +107,8 @@ pub enum TrackSize {
     max: TrackBreadth,
   },
   /// The `fit-content()` function.
-  #[cfg_attr(feature = "serde", serde(with = "ValueWrapper::<LengthPercentage>"))]
-  FitContent(LengthPercentage),
+  #[cfg_attr(feature = "serde", serde(with = "ValueWrapper::<NonNegative<LengthPercentage>>"))]
+  FitContent(NonNegative<LengthPercentage>),
 }
 
 impl Default for TrackSize {
@@ -140,9 +140,9 @@ pub struct TrackSizeList(pub SmallVec<[TrackSize; 1]>);
 #[cfg_attr(feature = "into_owned", derive(static_self::IntoOwned))]
 pub enum TrackBreadth {
   /// An explicit length.
-  Length(LengthPercentage),
+  Length(NonNegative<LengthPercentage>),
   /// A flex factor.
-  Flex(CSSNumber),
+  Flex(NonNegative<CSSNumber>),
   /// The `min-content` keyword.
   MinContent,
   /// The `max-content` keyword.
@@ -214,7 +214,7 @@ impl<'i> Parse<'i> for TrackSize {
     }
 
     input.expect_function_matching("fit-content")?;
-    let len = input.parse_nested_block(LengthPercentage::parse)?;
+    let len = input.parse_nested_block(NonNegative::<LengthPercentage>::parse)?;
     Ok(TrackSize::FitContent(len))
   }
 }
@@ -253,7 +253,7 @@ impl TrackBreadth {
     input: &mut Parser<'i, 't>,
     allow_flex: bool,
   ) -> Result<Self, ParseError<'i, ParserError<'i>>> {
-    if let Ok(len) = input.try_parse(LengthPercentage::parse) {
+    if let Ok(len) = input.try_parse(NonNegative::<LengthPercentage>::parse) {
       return Ok(TrackBreadth::Length(len));
     }
 
@@ -275,11 +275,13 @@ impl TrackBreadth {
     }
   }
 
-  fn parse_flex<'i, 't>(input: &mut Parser<'i, 't>) -> Result<CSSNumber, ParseError<'i, ParserError<'i>>> {
+  fn parse_flex<'i, 't>(
+    input: &mut Parser<'i, 't>,
+  ) -> Result<NonNegative<CSSNumber>, ParseError<'i, ParserError<'i>>> {
     let location = input.current_source_location();
     match *input.next()? {
-      Token::Dimension { value, ref unit, .. } if unit.eq_ignore_ascii_case("fr") && value.is_sign_positive() => {
-        Ok(value)
+      Token::Dimension { value, ref unit, .. } if unit.eq_ignore_ascii_case("fr") && value >= 0.0 => {
+        Ok(NonNegative(value))
       }
       ref t => Err(location.new_unexpected_token_error(t.clone())),
     }
@@ -296,7 +298,7 @@ impl ToCss for TrackBreadth {
       TrackBreadth::MinContent => dest.write_str("min-content"),
       TrackBreadth::MaxContent => dest.write_str("max-content"),
       TrackBreadth::Length(len) => len.to_css(dest),
-      TrackBreadth::Flex(flex) => serialize_dimension(*flex, "fr", dest),
+      TrackBreadth::Flex(flex) => serialize_dimension(flex.0, "fr", dest),
     }
   }
 }

--- a/src/properties/margin_padding.rs
+++ b/src/properties/margin_padding.rs
@@ -7,7 +7,12 @@ use crate::macros::{define_shorthand, rect_shorthand, size_shorthand};
 use crate::printer::Printer;
 use crate::properties::{Property, PropertyId};
 use crate::traits::{IsCompatible, Parse, PropertyHandler, Shorthand, ToCss};
-use crate::values::{length::LengthPercentageOrAuto, rect::Rect, size::Size2D};
+use crate::values::number::NonNegative;
+use crate::values::{
+  length::{LengthPercentage, LengthPercentageOrAuto},
+  rect::Rect,
+  size::Size2D,
+};
 #[cfg(feature = "visitor")]
 use crate::visitor::Visit;
 use cssparser::*;
@@ -24,7 +29,7 @@ rect_shorthand! {
 
 rect_shorthand! {
   /// A value for the [padding](https://drafts.csswg.org/css-box-4/#propdef-padding) shorthand property.
-  pub struct Padding<LengthPercentageOrAuto> {
+  pub struct Padding<NonNegative<LengthPercentage>> {
     PaddingTop,
     PaddingRight,
     PaddingBottom,
@@ -44,7 +49,7 @@ rect_shorthand! {
 
 rect_shorthand! {
   /// A value for the [scroll-padding](https://drafts.csswg.org/css-scroll-snap/#scroll-padding) shorthand property.
-  pub struct ScrollPadding<LengthPercentageOrAuto> {
+  pub struct ScrollPadding<NonNegative<LengthPercentageOrAuto>> {
     ScrollPaddingTop,
     ScrollPaddingRight,
     ScrollPaddingBottom,
@@ -84,7 +89,7 @@ size_shorthand! {
 
 size_shorthand! {
   /// A value for the [padding-block](https://drafts.csswg.org/css-logical/#propdef-padding-block) shorthand property.
-  pub struct PaddingBlock<LengthPercentageOrAuto> {
+  pub struct PaddingBlock<NonNegative<LengthPercentage>> {
      /// The block start value.
     block_start: PaddingBlockStart,
     /// The block end value.
@@ -94,7 +99,7 @@ size_shorthand! {
 
 size_shorthand! {
   /// A value for the [padding-inline](https://drafts.csswg.org/css-logical/#propdef-padding-inline) shorthand property.
-  pub struct PaddingInline<LengthPercentageOrAuto> {
+  pub struct PaddingInline<NonNegative<LengthPercentage>> {
     /// The inline start value.
     inline_start: PaddingInlineStart,
     /// The inline end value.
@@ -124,7 +129,7 @@ size_shorthand! {
 
 size_shorthand! {
   /// A value for the [scroll-padding-block](https://drafts.csswg.org/css-scroll-snap/#propdef-scroll-padding-block) shorthand property.
-  pub struct ScrollPaddingBlock<LengthPercentageOrAuto> {
+  pub struct ScrollPaddingBlock<NonNegative<LengthPercentageOrAuto>> {
      /// The block start value.
     block_start: ScrollPaddingBlockStart,
     /// The block end value.
@@ -134,7 +139,7 @@ size_shorthand! {
 
 size_shorthand! {
   /// A value for the [scroll-padding-inline](https://drafts.csswg.org/css-scroll-snap/#propdef-scroll-padding-inline) shorthand property.
-  pub struct ScrollPaddingInline<LengthPercentageOrAuto> {
+  pub struct ScrollPaddingInline<NonNegative<LengthPercentageOrAuto>> {
     /// The inline start value.
     inline_start: ScrollPaddingInlineStart,
     /// The inline end value.
@@ -163,13 +168,13 @@ size_shorthand! {
 }
 
 macro_rules! side_handler {
-  ($name: ident, $top: ident, $bottom: ident, $left: ident, $right: ident, $block_start: ident, $block_end: ident, $inline_start: ident, $inline_end: ident, $shorthand: ident, $block_shorthand: ident, $inline_shorthand: ident, $shorthand_category: ident $(, $feature: ident, $shorthand_feature: ident)?) => {
+  ($name: ident, $value: ty, $top: ident, $bottom: ident, $left: ident, $right: ident, $block_start: ident, $block_end: ident, $inline_start: ident, $inline_end: ident, $shorthand: ident, $block_shorthand: ident, $inline_shorthand: ident, $shorthand_category: ident $(, $feature: ident, $shorthand_feature: ident)?) => {
     #[derive(Debug, Default)]
     pub(crate) struct $name<'i> {
-      top: Option<LengthPercentageOrAuto>,
-      bottom: Option<LengthPercentageOrAuto>,
-      left: Option<LengthPercentageOrAuto>,
-      right: Option<LengthPercentageOrAuto>,
+      top: Option<$value>,
+      bottom: Option<$value>,
+      left: Option<$value>,
+      right: Option<$value>,
       block_start: Option<Property<'i>>,
       block_end: Option<Property<'i>>,
       inline_start: Option<Property<'i>>,
@@ -411,6 +416,7 @@ macro_rules! side_handler {
 
 side_handler!(
   MarginHandler,
+  LengthPercentageOrAuto,
   MarginTop,
   MarginBottom,
   MarginLeft,
@@ -429,6 +435,7 @@ side_handler!(
 
 side_handler!(
   PaddingHandler,
+  NonNegative<LengthPercentage>,
   PaddingTop,
   PaddingBottom,
   PaddingLeft,
@@ -447,6 +454,7 @@ side_handler!(
 
 side_handler!(
   ScrollMarginHandler,
+  LengthPercentageOrAuto,
   ScrollMarginTop,
   ScrollMarginBottom,
   ScrollMarginLeft,
@@ -463,6 +471,7 @@ side_handler!(
 
 side_handler!(
   ScrollPaddingHandler,
+  NonNegative<LengthPercentageOrAuto>,
   ScrollPaddingTop,
   ScrollPaddingBottom,
   ScrollPaddingLeft,
@@ -479,6 +488,7 @@ side_handler!(
 
 side_handler!(
   InsetHandler,
+  LengthPercentageOrAuto,
   Top,
   Bottom,
   Left,

--- a/src/properties/masking.rs
+++ b/src/properties/masking.rs
@@ -14,6 +14,7 @@ use crate::targets::{Browsers, Targets};
 use crate::traits::{FallbackValues, IsCompatible, Parse, PropertyHandler, Shorthand, ToCss};
 use crate::values::image::ImageFallback;
 use crate::values::length::LengthOrNumber;
+use crate::values::number::NonNegative;
 use crate::values::rect::Rect;
 use crate::values::{image::Image, position::Position, shape::BasicShape, url::Url};
 use crate::vendor_prefix::VendorPrefix;
@@ -478,7 +479,7 @@ define_shorthand! {
     /// The width of the mask image.
     width: MaskBorderWidth(Rect<BorderImageSideWidth>),
     /// The amount that the image extends beyond the border box.
-    outset: MaskBorderOutset(Rect<LengthOrNumber>),
+    outset: MaskBorderOutset(Rect<NonNegative<LengthOrNumber>>),
     /// How the mask image is scaled and tiled.
     repeat: MaskBorderRepeat(BorderImageRepeat),
     /// How the mask image is interpreted.
@@ -589,7 +590,7 @@ pub(crate) struct MaskHandler<'i> {
   border_mode: Option<MaskBorderMode>,
   border_slice: Option<(BorderImageSlice, VendorPrefix)>,
   border_width: Option<(Rect<BorderImageSideWidth>, VendorPrefix)>,
-  border_outset: Option<(Rect<LengthOrNumber>, VendorPrefix)>,
+  border_outset: Option<(Rect<NonNegative<LengthOrNumber>>, VendorPrefix)>,
   border_repeat: Option<(BorderImageRepeat, VendorPrefix)>,
   flushed_properties: MaskProperty,
   has_any: bool,

--- a/src/properties/mod.rs
+++ b/src/properties/mod.rs
@@ -27,7 +27,7 @@
 //! use smallvec::smallvec;
 //! use lightningcss::{
 //!   properties::{Property, PropertyId, background::*},
-//!   values::{url::Url, image::Image, color::{CssColor, RGBA}, position::*, length::*},
+//!   values::{number::NonNegative, url::Url, image::Image, color::{CssColor, RGBA}, position::*, length::*},
 //!   stylesheet::{ParserOptions, PrinterOptions},
 //!   dependencies::Location,
 //! };
@@ -60,8 +60,8 @@
 //!       y: BackgroundRepeatKeyword::Repeat,
 //!     },
 //!     size: BackgroundSize::Explicit {
-//!       width: LengthPercentageOrAuto::LengthPercentage(LengthPercentage::px(50.0)),
-//!       height: LengthPercentageOrAuto::LengthPercentage(LengthPercentage::px(100.0)),
+//!       width: NonNegative(LengthPercentageOrAuto::LengthPercentage(LengthPercentage::px(50.0))),
+//!       height: NonNegative(LengthPercentageOrAuto::LengthPercentage(LengthPercentage::px(100.0))),
 //!     },
 //!     attachment: BackgroundAttachment::Fixed,
 //!     origin: BackgroundOrigin::PaddingBox,
@@ -129,7 +129,7 @@ use crate::prefixes::Feature;
 use crate::printer::{Printer, PrinterOptions};
 use crate::targets::Targets;
 use crate::traits::{Parse, ParseWithOptions, Shorthand, ToCss};
-use crate::values::number::{CSSInteger, CSSNumber};
+use crate::values::number::{CSSInteger, CSSNumber, NonNegative};
 use crate::values::string::CowArcStr;
 use crate::values::{
   alpha::*, color::*, easing::EasingFunction, ident::DashedIdentReference, ident::NoneOrCustomIdentList, image::*,
@@ -1252,7 +1252,7 @@ define_properties! {
   "inset-inline": InsetInline(InsetInline) shorthand: true,
   "inset": Inset(Inset) shorthand: true,
 
-  "border-spacing": BorderSpacing(Size2D<Length>),
+  "border-spacing": BorderSpacing(Size2D<NonNegative<Length>>),
 
   "border-top-color": BorderTopColor(CssColor) [logical_group: BorderColor, category: Physical],
   "border-bottom-color": BorderBottomColor(CssColor) [logical_group: BorderColor, category: Physical],
@@ -1281,18 +1281,18 @@ define_properties! {
   "border-inline-start-width": BorderInlineStartWidth(BorderSideWidth) [logical_group: BorderWidth, category: Logical],
   "border-inline-end-width": BorderInlineEndWidth(BorderSideWidth) [logical_group: BorderWidth, category: Logical],
 
-  "border-top-left-radius": BorderTopLeftRadius(Size2D<LengthPercentage>, VendorPrefix) / WebKit / Moz [logical_group: BorderRadius, category: Physical],
-  "border-top-right-radius": BorderTopRightRadius(Size2D<LengthPercentage>, VendorPrefix) / WebKit / Moz [logical_group: BorderRadius, category: Physical],
-  "border-bottom-left-radius": BorderBottomLeftRadius(Size2D<LengthPercentage>, VendorPrefix) / WebKit / Moz [logical_group: BorderRadius, category: Physical],
-  "border-bottom-right-radius": BorderBottomRightRadius(Size2D<LengthPercentage>, VendorPrefix) / WebKit / Moz [logical_group: BorderRadius, category: Physical],
-  "border-start-start-radius": BorderStartStartRadius(Size2D<LengthPercentage>) [logical_group: BorderRadius, category: Logical],
-  "border-start-end-radius": BorderStartEndRadius(Size2D<LengthPercentage>) [logical_group: BorderRadius, category: Logical],
-  "border-end-start-radius": BorderEndStartRadius(Size2D<LengthPercentage>) [logical_group: BorderRadius, category: Logical],
-  "border-end-end-radius": BorderEndEndRadius(Size2D<LengthPercentage>) [logical_group: BorderRadius, category: Logical],
+  "border-top-left-radius": BorderTopLeftRadius(Size2D<NonNegative<LengthPercentage>>, VendorPrefix) / WebKit / Moz [logical_group: BorderRadius, category: Physical],
+  "border-top-right-radius": BorderTopRightRadius(Size2D<NonNegative<LengthPercentage>>, VendorPrefix) / WebKit / Moz [logical_group: BorderRadius, category: Physical],
+  "border-bottom-left-radius": BorderBottomLeftRadius(Size2D<NonNegative<LengthPercentage>>, VendorPrefix) / WebKit / Moz [logical_group: BorderRadius, category: Physical],
+  "border-bottom-right-radius": BorderBottomRightRadius(Size2D<NonNegative<LengthPercentage>>, VendorPrefix) / WebKit / Moz [logical_group: BorderRadius, category: Physical],
+  "border-start-start-radius": BorderStartStartRadius(Size2D<NonNegative<LengthPercentage>>) [logical_group: BorderRadius, category: Logical],
+  "border-start-end-radius": BorderStartEndRadius(Size2D<NonNegative<LengthPercentage>>) [logical_group: BorderRadius, category: Logical],
+  "border-end-start-radius": BorderEndStartRadius(Size2D<NonNegative<LengthPercentage>>) [logical_group: BorderRadius, category: Logical],
+  "border-end-end-radius": BorderEndEndRadius(Size2D<NonNegative<LengthPercentage>>) [logical_group: BorderRadius, category: Logical],
   "border-radius": BorderRadius(BorderRadius, VendorPrefix) / WebKit / Moz shorthand: true,
 
   "border-image-source": BorderImageSource(Image<'i>),
-  "border-image-outset": BorderImageOutset(Rect<LengthOrNumber>),
+  "border-image-outset": BorderImageOutset(Rect<NonNegative<LengthOrNumber>>),
   "border-image-repeat": BorderImageRepeat(BorderImageRepeat),
   "border-image-width": BorderImageWidth(Rect<BorderImageSideWidth>),
   "border-image-slice": BorderImageSlice(BorderImageSlice),
@@ -1331,9 +1331,9 @@ define_properties! {
   "flex-direction": FlexDirection(FlexDirection, VendorPrefix) / WebKit / Ms,
   "flex-wrap": FlexWrap(FlexWrap, VendorPrefix) / WebKit / Ms,
   "flex-flow": FlexFlow(FlexFlow, VendorPrefix) / WebKit / Ms shorthand: true,
-  "flex-grow": FlexGrow(CSSNumber, VendorPrefix) / WebKit,
-  "flex-shrink": FlexShrink(CSSNumber, VendorPrefix) / WebKit,
-  "flex-basis": FlexBasis(LengthPercentageOrAuto, VendorPrefix) / WebKit,
+  "flex-grow": FlexGrow(NonNegative<CSSNumber>, VendorPrefix) / WebKit,
+  "flex-shrink": FlexShrink(NonNegative<CSSNumber>, VendorPrefix) / WebKit,
+  "flex-basis": FlexBasis(NonNegative<LengthPercentageOrAuto>, VendorPrefix) / WebKit,
   "flex": Flex(Flex, VendorPrefix) / WebKit / Ms shorthand: true,
   "order": Order(CSSInteger, VendorPrefix) / WebKit,
 
@@ -1356,7 +1356,7 @@ define_properties! {
   "box-direction": BoxDirection(BoxDirection, VendorPrefix) / WebKit / Moz unprefixed: false,
   "box-ordinal-group": BoxOrdinalGroup(CSSInteger, VendorPrefix) / WebKit / Moz unprefixed: false,
   "box-align": BoxAlign(BoxAlign, VendorPrefix) / WebKit / Moz unprefixed: false,
-  "box-flex": BoxFlex(CSSNumber, VendorPrefix) / WebKit / Moz unprefixed: false,
+  "box-flex": BoxFlex(NonNegative<CSSNumber>, VendorPrefix) / WebKit / Moz unprefixed: false,
   "box-flex-group": BoxFlexGroup(CSSInteger, VendorPrefix) / WebKit unprefixed: false,
   "box-pack": BoxPack(BoxPack, VendorPrefix) / WebKit / Moz unprefixed: false,
   "box-lines": BoxLines(BoxLines, VendorPrefix) / WebKit / Moz unprefixed: false,
@@ -1369,9 +1369,9 @@ define_properties! {
   "flex-line-pack": FlexLinePack(FlexLinePack, VendorPrefix) / Ms unprefixed: false,
 
   // Microsoft extensions
-  "flex-positive": FlexPositive(CSSNumber, VendorPrefix) / Ms unprefixed: false,
-  "flex-negative": FlexNegative(CSSNumber, VendorPrefix) / Ms unprefixed: false,
-  "flex-preferred-size": FlexPreferredSize(LengthPercentageOrAuto, VendorPrefix) / Ms unprefixed: false,
+  "flex-positive": FlexPositive(NonNegative<CSSNumber>, VendorPrefix) / Ms unprefixed: false,
+  "flex-negative": FlexNegative(NonNegative<CSSNumber>, VendorPrefix) / Ms unprefixed: false,
+  "flex-preferred-size": FlexPreferredSize(NonNegative<LengthPercentageOrAuto>, VendorPrefix) / Ms unprefixed: false,
 
   "grid-template-columns": GridTemplateColumns(TrackSizing<'i>),
   "grid-template-rows": GridTemplateRows(TrackSizing<'i>),
@@ -1401,14 +1401,14 @@ define_properties! {
   "margin-inline": MarginInline(MarginInline) shorthand: true,
   "margin": Margin(Margin) shorthand: true,
 
-  "padding-top": PaddingTop(LengthPercentageOrAuto) [logical_group: Padding, category: Physical],
-  "padding-bottom": PaddingBottom(LengthPercentageOrAuto) [logical_group: Padding, category: Physical],
-  "padding-left": PaddingLeft(LengthPercentageOrAuto) [logical_group: Padding, category: Physical],
-  "padding-right": PaddingRight(LengthPercentageOrAuto) [logical_group: Padding, category: Physical],
-  "padding-block-start": PaddingBlockStart(LengthPercentageOrAuto) [logical_group: Padding, category: Logical],
-  "padding-block-end": PaddingBlockEnd(LengthPercentageOrAuto) [logical_group: Padding, category: Logical],
-  "padding-inline-start": PaddingInlineStart(LengthPercentageOrAuto) [logical_group: Padding, category: Logical],
-  "padding-inline-end": PaddingInlineEnd(LengthPercentageOrAuto) [logical_group: Padding, category: Logical],
+  "padding-top": PaddingTop(NonNegative<LengthPercentage>) [logical_group: Padding, category: Physical],
+  "padding-bottom": PaddingBottom(NonNegative<LengthPercentage>) [logical_group: Padding, category: Physical],
+  "padding-left": PaddingLeft(NonNegative<LengthPercentage>) [logical_group: Padding, category: Physical],
+  "padding-right": PaddingRight(NonNegative<LengthPercentage>) [logical_group: Padding, category: Physical],
+  "padding-block-start": PaddingBlockStart(NonNegative<LengthPercentage>) [logical_group: Padding, category: Logical],
+  "padding-block-end": PaddingBlockEnd(NonNegative<LengthPercentage>) [logical_group: Padding, category: Logical],
+  "padding-inline-start": PaddingInlineStart(NonNegative<LengthPercentage>) [logical_group: Padding, category: Logical],
+  "padding-inline-end": PaddingInlineEnd(NonNegative<LengthPercentage>) [logical_group: Padding, category: Logical],
   "padding-block": PaddingBlock(PaddingBlock) shorthand: true,
   "padding-inline": PaddingInline(PaddingInline) shorthand: true,
   "padding": Padding(Padding) shorthand: true,
@@ -1425,14 +1425,14 @@ define_properties! {
   "scroll-margin-inline": ScrollMarginInline(ScrollMarginInline) shorthand: true,
   "scroll-margin": ScrollMargin(ScrollMargin) shorthand: true,
 
-  "scroll-padding-top": ScrollPaddingTop(LengthPercentageOrAuto) [logical_group: ScrollPadding, category: Physical],
-  "scroll-padding-bottom": ScrollPaddingBottom(LengthPercentageOrAuto) [logical_group: ScrollPadding, category: Physical],
-  "scroll-padding-left": ScrollPaddingLeft(LengthPercentageOrAuto) [logical_group: ScrollPadding, category: Physical],
-  "scroll-padding-right": ScrollPaddingRight(LengthPercentageOrAuto) [logical_group: ScrollPadding, category: Physical],
-  "scroll-padding-block-start": ScrollPaddingBlockStart(LengthPercentageOrAuto) [logical_group: ScrollPadding, category: Logical],
-  "scroll-padding-block-end": ScrollPaddingBlockEnd(LengthPercentageOrAuto) [logical_group: ScrollPadding, category: Logical],
-  "scroll-padding-inline-start": ScrollPaddingInlineStart(LengthPercentageOrAuto) [logical_group: ScrollPadding, category: Logical],
-  "scroll-padding-inline-end": ScrollPaddingInlineEnd(LengthPercentageOrAuto) [logical_group: ScrollPadding, category: Logical],
+  "scroll-padding-top": ScrollPaddingTop(NonNegative<LengthPercentageOrAuto>) [logical_group: ScrollPadding, category: Physical],
+  "scroll-padding-bottom": ScrollPaddingBottom(NonNegative<LengthPercentageOrAuto>) [logical_group: ScrollPadding, category: Physical],
+  "scroll-padding-left": ScrollPaddingLeft(NonNegative<LengthPercentageOrAuto>) [logical_group: ScrollPadding, category: Physical],
+  "scroll-padding-right": ScrollPaddingRight(NonNegative<LengthPercentageOrAuto>) [logical_group: ScrollPadding, category: Physical],
+  "scroll-padding-block-start": ScrollPaddingBlockStart(NonNegative<LengthPercentageOrAuto>) [logical_group: ScrollPadding, category: Logical],
+  "scroll-padding-block-end": ScrollPaddingBlockEnd(NonNegative<LengthPercentageOrAuto>) [logical_group: ScrollPadding, category: Logical],
+  "scroll-padding-inline-start": ScrollPaddingInlineStart(NonNegative<LengthPercentageOrAuto>) [logical_group: ScrollPadding, category: Logical],
+  "scroll-padding-inline-end": ScrollPaddingInlineEnd(NonNegative<LengthPercentageOrAuto>) [logical_group: ScrollPadding, category: Logical],
   "scroll-padding-block": ScrollPaddingBlock(ScrollPaddingBlock) shorthand: true,
   "scroll-padding-inline": ScrollPaddingInline(ScrollPaddingInline) shorthand: true,
   "scroll-padding": ScrollPadding(ScrollPadding) shorthand: true,
@@ -1449,13 +1449,13 @@ define_properties! {
   "font-palette": FontPalette(DashedIdentReference<'i>),
 
   "transition-property": TransitionProperty(SmallVec<[PropertyId<'i>; 1]>, VendorPrefix) / WebKit / Moz / Ms,
-  "transition-duration": TransitionDuration(SmallVec<[Time; 1]>, VendorPrefix) / WebKit / Moz / Ms,
+  "transition-duration": TransitionDuration(SmallVec<[NonNegative<Time>; 1]>, VendorPrefix) / WebKit / Moz / Ms,
   "transition-delay": TransitionDelay(SmallVec<[Time; 1]>, VendorPrefix) / WebKit / Moz / Ms,
   "transition-timing-function": TransitionTimingFunction(SmallVec<[EasingFunction; 1]>, VendorPrefix) / WebKit / Moz / Ms,
   "transition": Transition(SmallVec<[Transition<'i>; 1]>, VendorPrefix) / WebKit / Moz / Ms shorthand: true,
 
   "animation-name": AnimationName(AnimationNameList<'i>, VendorPrefix) / WebKit / Moz / O,
-  "animation-duration": AnimationDuration(SmallVec<[Time; 1]>, VendorPrefix) / WebKit / Moz / O,
+  "animation-duration": AnimationDuration(SmallVec<[NonNegative<Time>; 1]>, VendorPrefix) / WebKit / Moz / O,
   "animation-timing-function": AnimationTimingFunction(SmallVec<[EasingFunction; 1]>, VendorPrefix) / WebKit / Moz / O,
   "animation-iteration-count": AnimationIterationCount(SmallVec<[AnimationIterationCount; 1]>, VendorPrefix) / WebKit / Moz / O,
   "animation-direction": AnimationDirection(SmallVec<[AnimationDirection; 1]>, VendorPrefix) / WebKit / Moz / O,
@@ -1484,7 +1484,7 @@ define_properties! {
   // https://www.w3.org/TR/2021/CRD-css-text-3-20210422
   "text-transform": TextTransform(TextTransform),
   "white-space": WhiteSpace(WhiteSpace),
-  "tab-size": TabSize(LengthOrNumber, VendorPrefix) / Moz / O,
+  "tab-size": TabSize(NonNegative<LengthOrNumber>, VendorPrefix) / Moz / O,
   "word-break": WordBreak(WordBreak),
   "line-break": LineBreak(LineBreak),
   "hyphens": Hyphens(Hyphens, VendorPrefix) / WebKit / Moz / Ms,
@@ -1546,7 +1546,7 @@ define_properties! {
   "fill-opacity": FillOpacity(AlphaValue),
   "stroke": Stroke(SVGPaint<'i>),
   "stroke-opacity": StrokeOpacity(AlphaValue),
-  "stroke-width": StrokeWidth(LengthPercentage),
+  "stroke-width": StrokeWidth(NonNegative<LengthPercentage>),
   "stroke-linecap": StrokeLinecap(StrokeLinecap),
   "stroke-linejoin": StrokeLinejoin(StrokeLinejoin),
   "stroke-miterlimit": StrokeMiterlimit(CSSNumber),
@@ -1582,7 +1582,7 @@ define_properties! {
   "mask-border-mode": MaskBorderMode(MaskBorderMode),
   "mask-border-slice": MaskBorderSlice(BorderImageSlice),
   "mask-border-width": MaskBorderWidth(Rect<BorderImageSideWidth>),
-  "mask-border-outset": MaskBorderOutset(Rect<LengthOrNumber>),
+  "mask-border-outset": MaskBorderOutset(Rect<NonNegative<LengthOrNumber>>),
   "mask-border-repeat": MaskBorderRepeat(BorderImageRepeat),
   "mask-border": MaskBorder(MaskBorder<'i>) shorthand: true,
 
@@ -1593,7 +1593,7 @@ define_properties! {
   "mask-box-image-source": WebKitMaskBoxImageSource(Image<'i>, VendorPrefix) / WebKit unprefixed: false,
   "mask-box-image-slice": WebKitMaskBoxImageSlice(BorderImageSlice, VendorPrefix) / WebKit unprefixed: false,
   "mask-box-image-width": WebKitMaskBoxImageWidth(Rect<BorderImageSideWidth>, VendorPrefix) / WebKit unprefixed: false,
-  "mask-box-image-outset": WebKitMaskBoxImageOutset(Rect<LengthOrNumber>, VendorPrefix) / WebKit unprefixed: false,
+  "mask-box-image-outset": WebKitMaskBoxImageOutset(Rect<NonNegative<LengthOrNumber>>, VendorPrefix) / WebKit unprefixed: false,
   "mask-box-image-repeat": WebKitMaskBoxImageRepeat(BorderImageRepeat, VendorPrefix) / WebKit unprefixed: false,
 
   // https://drafts.fxtf.org/filter-effects-1/

--- a/src/properties/size.rs
+++ b/src/properties/size.rs
@@ -10,6 +10,7 @@ use crate::printer::Printer;
 use crate::properties::{Property, PropertyId};
 use crate::traits::{IsCompatible, Parse, PropertyHandler, ToCss};
 use crate::values::length::LengthPercentage;
+use crate::values::number::NonNegative;
 use crate::values::ratio::Ratio;
 use crate::vendor_prefix::VendorPrefix;
 #[cfg(feature = "visitor")]
@@ -37,8 +38,8 @@ pub enum Size {
   /// The `auto` keyword.
   Auto,
   /// An explicit length or percentage.
-  #[cfg_attr(feature = "serde", serde(with = "ValueWrapper::<LengthPercentage>"))]
-  LengthPercentage(LengthPercentage),
+  #[cfg_attr(feature = "serde", serde(with = "ValueWrapper::<NonNegative<LengthPercentage>>"))]
+  LengthPercentage(NonNegative<LengthPercentage>),
   /// The `min-content` keyword.
   #[cfg_attr(feature = "serde", serde(with = "PrefixWrapper"))]
   MinContent(VendorPrefix),
@@ -49,8 +50,8 @@ pub enum Size {
   #[cfg_attr(feature = "serde", serde(with = "PrefixWrapper"))]
   FitContent(VendorPrefix),
   /// The `fit-content()` function.
-  #[cfg_attr(feature = "serde", serde(with = "ValueWrapper::<LengthPercentage>"))]
-  FitContentFunction(LengthPercentage),
+  #[cfg_attr(feature = "serde", serde(with = "ValueWrapper::<NonNegative<LengthPercentage>>"))]
+  FitContentFunction(NonNegative<LengthPercentage>),
   /// The `stretch` keyword, or the `-webkit-fill-available` or `-moz-available` prefixed keywords.
   #[cfg_attr(feature = "serde", serde(with = "PrefixWrapper"))]
   Stretch(VendorPrefix),
@@ -89,7 +90,7 @@ impl<'i> Parse<'i> for Size {
       return Ok(Size::FitContentFunction(res));
     }
 
-    let lp = input.try_parse(LengthPercentage::parse)?;
+    let lp = input.try_parse(NonNegative::<LengthPercentage>::parse)?;
     Ok(Size::LengthPercentage(lp))
   }
 }
@@ -170,8 +171,8 @@ pub enum MaxSize {
   /// The `none` keyword.
   None,
   /// An explicit length or percentage.
-  #[cfg_attr(feature = "serde", serde(with = "ValueWrapper::<LengthPercentage>"))]
-  LengthPercentage(LengthPercentage),
+  #[cfg_attr(feature = "serde", serde(with = "ValueWrapper::<NonNegative<LengthPercentage>>"))]
+  LengthPercentage(NonNegative<LengthPercentage>),
   /// The `min-content` keyword.
   #[cfg_attr(feature = "serde", serde(with = "PrefixWrapper"))]
   MinContent(VendorPrefix),
@@ -182,8 +183,8 @@ pub enum MaxSize {
   #[cfg_attr(feature = "serde", serde(with = "PrefixWrapper"))]
   FitContent(VendorPrefix),
   /// The `fit-content()` function.
-  #[cfg_attr(feature = "serde", serde(with = "ValueWrapper::<LengthPercentage>"))]
-  FitContentFunction(LengthPercentage),
+  #[cfg_attr(feature = "serde", serde(with = "ValueWrapper::<NonNegative<LengthPercentage>>"))]
+  FitContentFunction(NonNegative<LengthPercentage>),
   /// The `stretch` keyword, or the `-webkit-fill-available` or `-moz-available` prefixed keywords.
   #[cfg_attr(feature = "serde", serde(with = "PrefixWrapper"))]
   Stretch(VendorPrefix),
@@ -222,7 +223,7 @@ impl<'i> Parse<'i> for MaxSize {
       return Ok(MaxSize::FitContentFunction(res));
     }
 
-    let lp = input.try_parse(LengthPercentage::parse)?;
+    let lp = input.try_parse(NonNegative::<LengthPercentage>::parse)?;
     Ok(MaxSize::LengthPercentage(lp))
   }
 }
@@ -289,9 +290,9 @@ impl IsCompatible for MaxSize {
 
 fn parse_fit_content<'i, 't>(
   input: &mut Parser<'i, 't>,
-) -> Result<LengthPercentage, ParseError<'i, ParserError<'i>>> {
+) -> Result<NonNegative<LengthPercentage>, ParseError<'i, ParserError<'i>>> {
   input.expect_function_matching("fit-content")?;
-  input.parse_nested_block(|input| LengthPercentage::parse(input))
+  input.parse_nested_block(|input| NonNegative::<LengthPercentage>::parse(input))
 }
 
 enum_property! {

--- a/src/properties/svg.rs
+++ b/src/properties/svg.rs
@@ -6,6 +6,7 @@ use crate::printer::Printer;
 use crate::targets::{Browsers, Targets};
 use crate::traits::{FallbackValues, IsCompatible, Parse, ToCss};
 use crate::values::length::LengthPercentage;
+use crate::values::number::NonNegative;
 use crate::values::{color::CssColor, url::Url};
 #[cfg(feature = "visitor")]
 use crate::visitor::Visit;
@@ -140,7 +141,7 @@ pub enum StrokeDasharray {
   /// No dashing is used.
   None,
   /// Specifies a dashing pattern to use.
-  Values(Vec<LengthPercentage>),
+  Values(Vec<NonNegative<LengthPercentage>>),
 }
 
 impl<'i> Parse<'i> for StrokeDasharray {
@@ -150,12 +151,12 @@ impl<'i> Parse<'i> for StrokeDasharray {
     }
 
     input.skip_whitespace();
-    let mut results = vec![LengthPercentage::parse(input)?];
+    let mut results = vec![NonNegative::<LengthPercentage>::parse(input)?];
     loop {
       input.skip_whitespace();
       let comma_location = input.current_source_location();
       let comma = input.try_parse(|i| i.expect_comma()).is_ok();
-      if let Ok(item) = input.try_parse(LengthPercentage::parse) {
+      if let Ok(item) = input.try_parse(NonNegative::<LengthPercentage>::parse) {
         results.push(item);
       } else if comma {
         return Err(comma_location.new_unexpected_token_error(Token::Comma));
@@ -183,7 +184,7 @@ impl ToCss for StrokeDasharray {
           } else {
             dest.write_char(' ')?;
           }
-          value.to_css_unitless(dest)?;
+          value.0.to_css_unitless(dest)?;
         }
         Ok(())
       }

--- a/src/properties/text.rs
+++ b/src/properties/text.rs
@@ -15,6 +15,7 @@ use crate::traits::{FallbackValues, IsCompatible, Parse, PropertyHandler, Shorth
 use crate::values::calc::{Calc, MathFunction};
 use crate::values::color::{ColorFallbackKind, CssColor};
 use crate::values::length::{Length, LengthPercentage, LengthValue};
+use crate::values::number::NonNegative;
 use crate::values::percentage::Percentage;
 use crate::values::string::CSSString;
 use crate::vendor_prefix::VendorPrefix;
@@ -458,7 +459,7 @@ pub enum TextSizeAdjust {
   /// No size adjustment when displaying on a small device.
   None,
   /// When displaying on a small device, the font size is multiplied by this percentage.
-  Percentage(Percentage),
+  Percentage(NonNegative<Percentage>),
 }
 
 bitflags! {
@@ -1373,9 +1374,9 @@ pub struct TextShadow {
   /// The y offset of the text shadow.
   pub y_offset: Length,
   /// The blur radius of the text shadow.
-  pub blur: Length,
+  pub blur: NonNegative<Length>,
   /// The spread distance of the text shadow.
-  pub spread: Length, // added in Level 4 spec
+  pub spread: NonNegative<Length>, // added in Level 4 spec
 }
 
 impl<'i> Parse<'i> for TextShadow {
@@ -1388,9 +1389,14 @@ impl<'i> Parse<'i> for TextShadow {
         let value = input.try_parse::<_, _, ParseError<ParserError<'i>>>(|input| {
           let horizontal = Length::parse(input)?;
           let vertical = Length::parse(input)?;
-          let blur = input.try_parse(Length::parse).unwrap_or(Length::zero());
-          let spread = input.try_parse(Length::parse).unwrap_or(Length::zero());
-          Ok((horizontal, vertical, blur, spread))
+          let blur = input.try_parse(NonNegative::<Length>::parse).ok();
+          // A rejected blur radius must not be reinterpreted as a spread.
+          let spread = if blur.is_some() {
+            input.try_parse(NonNegative::<Length>::parse).unwrap_or(NonNegative::zero())
+          } else {
+            NonNegative::zero()
+          };
+          Ok((horizontal, vertical, blur.unwrap_or(NonNegative::zero()), spread))
         });
 
         if let Ok(value) = value {
@@ -1429,11 +1435,11 @@ impl ToCss for TextShadow {
     dest.write_char(' ')?;
     self.y_offset.to_css(dest)?;
 
-    if self.blur != Length::zero() || self.spread != Length::zero() {
+    if self.blur != NonNegative::zero() || self.spread != NonNegative::zero() {
       dest.write_char(' ')?;
       self.blur.to_css(dest)?;
 
-      if self.spread != Length::zero() {
+      if self.spread != NonNegative::zero() {
         dest.write_char(' ')?;
         self.spread.to_css(dest)?;
       }

--- a/src/properties/transform.rs
+++ b/src/properties/transform.rs
@@ -8,6 +8,7 @@ use crate::macros::enum_property;
 use crate::prefixes::Feature;
 use crate::printer::Printer;
 use crate::traits::{Parse, PropertyHandler, ToCss, Zero};
+use crate::values::number::NonNegative;
 use crate::values::{
   angle::Angle,
   length::{Length, LengthPercentage},
@@ -200,7 +201,7 @@ pub enum Transform {
   /// A skew along the Y axis.
   SkewY(Angle),
   /// A perspective transform.
-  Perspective(Length),
+  Perspective(NonNegative<Length>),
   /// A 2D matrix transform.
   Matrix(Matrix<f32>),
   /// A 3D matrix transform.
@@ -709,7 +710,7 @@ impl Matrix3d<f32> {
       perspective_matrix = perspective_matrix.inverse().unwrap().transpose();
       let perspective = perspective_matrix.multiply_vector(&right_hand_side);
       if perspective[0] == 0.0 && perspective[1] == 0.0 && perspective[3] == 0.0 {
-        transforms.push(Transform::Perspective(Length::px(-1.0 / perspective[2])))
+        transforms.push(Transform::Perspective(NonNegative(Length::px(-1.0 / perspective[2]))))
       } else {
         return None;
       }
@@ -1010,7 +1011,7 @@ impl<'i> Parse<'i> for Transform {
           Ok(Transform::SkewY(angle))
         },
         "perspective" => {
-          let len = Length::parse(input)?;
+          let len = NonNegative::<Length>::parse(input)?;
           Ok(Transform::Perspective(len))
         },
         _ => Err(location.new_unexpected_token_error(
@@ -1360,7 +1361,7 @@ impl Transform {
       Transform::SkewX(x) => return Some(Matrix3d::skew(to_radians!(x), 0.0)),
       Transform::SkewY(y) => return Some(Matrix3d::skew(0.0, to_radians!(y))),
       Transform::Perspective(len) => {
-        if let Some(len) = len.to_px() {
+        if let Some(len) = len.0.to_px() {
           return Some(Matrix3d::perspective(len));
         }
       }
@@ -1420,7 +1421,7 @@ pub enum Perspective {
   /// No perspective transform is applied.
   None,
   /// Distance to the center of projection.
-  Length(Length),
+  Length(NonNegative<Length>),
 }
 
 /// A value for the [translate](https://drafts.csswg.org/css-transforms-2/#propdef-translate) property.

--- a/src/properties/transition.rs
+++ b/src/properties/transition.rs
@@ -11,6 +11,7 @@ use crate::printer::Printer;
 use crate::properties::masking::get_webkit_mask_property;
 use crate::traits::{Parse, PropertyHandler, Shorthand, ToCss, Zero};
 use crate::values::ident::CustomIdent;
+use crate::values::number::NonNegative;
 use crate::values::{easing::EasingFunction, time::Time};
 use crate::vendor_prefix::VendorPrefix;
 #[cfg(feature = "visitor")]
@@ -26,7 +27,7 @@ define_list_shorthand! {
     #[cfg_attr(feature = "serde", serde(borrow))]
     property: TransitionProperty(PropertyId<'i>, VendorPrefix),
     /// The duration of the transition.
-    duration: TransitionDuration(Time, VendorPrefix),
+    duration: TransitionDuration(NonNegative<Time>, VendorPrefix),
     /// The delay before the transition starts.
     delay: TransitionDelay(Time, VendorPrefix),
     /// The easing function for the transition.
@@ -43,7 +44,7 @@ impl<'i> Parse<'i> for Transition<'i> {
 
     loop {
       if duration.is_none() {
-        if let Ok(value) = input.try_parse(Time::parse) {
+        if let Ok(value) = input.try_parse(NonNegative::<Time>::parse) {
           duration = Some(value);
           continue;
         }
@@ -56,7 +57,8 @@ impl<'i> Parse<'i> for Transition<'i> {
         }
       }
 
-      if delay.is_none() {
+      // The first time must be a duration, even if it is invalid.
+      if duration.is_some() && delay.is_none() {
         if let Ok(value) = input.try_parse(Time::parse) {
           delay = Some(value);
           continue;
@@ -75,7 +77,7 @@ impl<'i> Parse<'i> for Transition<'i> {
 
     Ok(Transition {
       property: property.unwrap_or(PropertyId::All),
-      duration: duration.unwrap_or(Time::Seconds(0.0)),
+      duration: duration.unwrap_or(NonNegative(Time::Seconds(0.0))),
       delay: delay.unwrap_or(Time::Seconds(0.0)),
       timing_function: timing_function.unwrap_or(EasingFunction::Ease),
     })
@@ -154,7 +156,7 @@ pub enum ViewTransitionGroup<'i> {
 #[derive(Default)]
 pub(crate) struct TransitionHandler<'i> {
   properties: Option<(SmallVec<[PropertyId<'i>; 1]>, VendorPrefix)>,
-  durations: Option<(SmallVec<[Time; 1]>, VendorPrefix)>,
+  durations: Option<(SmallVec<[NonNegative<Time>; 1]>, VendorPrefix)>,
   delays: Option<(SmallVec<[Time; 1]>, VendorPrefix)>,
   timing_functions: Option<(SmallVec<[EasingFunction; 1]>, VendorPrefix)>,
   has_any: bool,
@@ -210,7 +212,7 @@ impl<'i> PropertyHandler<'i> for TransitionHandler<'i> {
         let properties: SmallVec<[PropertyId; 1]> = merge_properties(val.iter().map(|b| &b.property));
         maybe_flush!(properties, &properties, vp);
 
-        let durations: SmallVec<[Time; 1]> = val.iter().map(|b| b.duration.clone()).collect();
+        let durations: SmallVec<[NonNegative<Time>; 1]> = val.iter().map(|b| b.duration.clone()).collect();
         maybe_flush!(durations, &durations, vp);
 
         let delays: SmallVec<[Time; 1]> = val.iter().map(|b| b.delay.clone()).collect();
@@ -282,7 +284,7 @@ impl<'i> TransitionHandler<'i> {
             let mut delays_iter = delays.iter().cycle().cloned();
             let mut timing_iter = timing_functions.iter().cycle().cloned();
             for property_id in $properties {
-              let duration = durations_iter.next().unwrap_or(Time::Seconds(0.0));
+              let duration = durations_iter.next().unwrap_or(NonNegative(Time::Seconds(0.0)));
               let delay = delays_iter.next().unwrap_or(Time::Seconds(0.0));
               let timing_function = timing_iter.next().unwrap_or(EasingFunction::Ease);
               let transition = Transition {

--- a/src/selector.rs
+++ b/src/selector.rs
@@ -100,10 +100,7 @@ impl<'a, 'i> parcel_selectors::parser::Parser<'i> for SelectorParser<'a, 'i> {
     name: CowRcStr<'i>,
   ) -> Result<PseudoClass<'i>, ParseError<'i, Self::Error>> {
     use PseudoClass::*;
-    let scroll_navigation_controls = self
-      .options
-      .flags
-      .contains(ParserFlags::SCROLL_NAVIGATION_CONTROLS);
+    let scroll_navigation_controls = self.options.flags.contains(ParserFlags::SCROLL_NAVIGATION_CONTROLS);
     let pseudo_class = match_ignore_ascii_case! { &name,
       // https://drafts.csswg.org/selectors-4/#useraction-pseudos
       "hover" => Hover,
@@ -501,7 +498,6 @@ pub enum PseudoClass<'i> {
   /// The [:target-after](https://drafts.csswg.org/css-overflow-5/#selectordef-target-after) pseudo class.
   TargetAfter,
   /// The [:target-within](https://drafts.csswg.org/selectors-4/#the-target-within-pseudo) pseudo class.
-
   TargetWithin,
   /// The [:visited](https://drafts.csswg.org/selectors-4/#visited-pseudo) pseudo class.
   Visited,

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -7,6 +7,7 @@ use crate::printer::Printer;
 use crate::properties::{Property, PropertyId};
 use crate::stylesheet::{ParserOptions, PrinterOptions};
 use crate::targets::{Browsers, Targets};
+use crate::values::number::NumericRange;
 use crate::vendor_prefix::VendorPrefix;
 use cssparser::*;
 
@@ -31,6 +32,16 @@ pub trait Parse<'i>: Sized {
 }
 
 pub(crate) use lightningcss_derive::Parse;
+
+/// Trait for numeric values whose grammar can restrict their allowed range.
+pub trait ParseNumeric<'i>: Parse<'i> {
+  /// Parses a numeric value, checking literals and clamping resolved calculations
+  /// to the given range. Intermediate calculation operands are unrestricted.
+  fn parse_with_range<'t>(
+    input: &mut Parser<'i, 't>,
+    range: NumericRange,
+  ) -> Result<Self, ParseError<'i, ParserError<'i>>>;
+}
 
 impl<'i, T: Parse<'i>> Parse<'i> for Option<T> {
   fn parse<'t>(input: &mut Parser<'i, 't>) -> Result<Self, ParseError<'i, ParserError<'i>>> {

--- a/src/values/angle.rs
+++ b/src/values/angle.rs
@@ -2,14 +2,14 @@
 
 use super::calc::Calc;
 use super::length::serialize_dimension;
-use super::number::CSSNumber;
+use super::number::{CSSNumber, NumericRange};
 use super::percentage::DimensionPercentage;
 use crate::error::{ParserError, PrinterError};
 use crate::printer::Printer;
 use crate::traits::{
   impl_op,
   private::{AddInternal, TryAdd},
-  Map, Op, Parse, Sign, ToCss, Zero,
+  Map, Op, Parse, ParseNumeric, Sign, ToCss, Zero,
 };
 #[cfg(feature = "visitor")]
 use crate::visitor::Visit;
@@ -43,7 +43,16 @@ pub enum Angle {
 
 impl<'i> Parse<'i> for Angle {
   fn parse<'t>(input: &mut Parser<'i, 't>) -> Result<Self, ParseError<'i, ParserError<'i>>> {
-    Self::parse_internal(input, false)
+    Self::parse_with_range(input, NumericRange::All)
+  }
+}
+
+impl<'i> ParseNumeric<'i> for Angle {
+  fn parse_with_range<'t>(
+    input: &mut Parser<'i, 't>,
+    range: NumericRange,
+  ) -> Result<Self, ParseError<'i, ParserError<'i>>> {
+    Self::parse_internal(input, false, range)
   }
 }
 
@@ -52,15 +61,16 @@ impl Angle {
   pub fn parse_with_unitless_zero<'i, 't>(
     input: &mut Parser<'i, 't>,
   ) -> Result<Self, ParseError<'i, ParserError<'i>>> {
-    Self::parse_internal(input, true)
+    Self::parse_internal(input, true, NumericRange::All)
   }
 
   fn parse_internal<'i, 't>(
     input: &mut Parser<'i, 't>,
     allow_unitless_zero: bool,
+    range: NumericRange,
   ) -> Result<Self, ParseError<'i, ParserError<'i>>> {
-    match input.try_parse(Calc::parse) {
-      Ok(Calc::Value(v)) => return Ok(*v),
+    match input.try_parse(Calc::<Self>::parse) {
+      Ok(Calc::Value(v)) => return Ok(v.map(|value| range.clamp(value))),
       // Angles are always compatible, so they will always compute to a value.
       Ok(_) => return Err(input.new_custom_error(ParserError::InvalidValue)),
       _ => {}
@@ -70,6 +80,7 @@ impl Angle {
     let token = input.next()?;
     match *token {
       Token::Dimension { value, ref unit, .. } => {
+        let value = range.check(value, location)?;
         match_ignore_ascii_case! { unit,
           "deg" => Ok(Angle::Deg(value)),
           "grad" => Ok(Angle::Grad(value)),

--- a/src/values/gradient.rs
+++ b/src/values/gradient.rs
@@ -14,6 +14,7 @@ use crate::prefixes::Feature;
 use crate::printer::Printer;
 use crate::targets::{should_compile, Browsers, Targets};
 use crate::traits::{IsCompatible, Parse, ToCss, TrySign, Zero};
+use crate::values::number::NonNegative;
 use crate::vendor_prefix::VendorPrefix;
 #[cfg(feature = "visitor")]
 use crate::visitor::Visit;
@@ -638,7 +639,7 @@ impl Default for EndingShape {
 #[cfg_attr(feature = "jsonschema", derive(schemars::JsonSchema))]
 pub enum Circle {
   /// A circle with a specified radius.
-  Radius(Length),
+  Radius(NonNegative<Length>),
   /// A shape extent keyword.
   Extent(ShapeExtent),
 }
@@ -651,7 +652,7 @@ impl<'i> Parse<'i> for Circle {
       return Ok(Circle::Extent(extent));
     }
 
-    if let Ok(length) = input.try_parse(Length::parse) {
+    if let Ok(length) = input.try_parse(NonNegative::<Length>::parse) {
       // The `circle` keyword is optional if there is only a single length.
       // We are assuming here that Ellipse::parse ran first.
       let _ = input.try_parse(|input| input.expect_ident_matching("circle"));
@@ -663,7 +664,7 @@ impl<'i> Parse<'i> for Circle {
         return Ok(Circle::Extent(extent));
       }
 
-      if let Ok(length) = input.try_parse(Length::parse) {
+      if let Ok(length) = input.try_parse(NonNegative::<Length>::parse) {
         return Ok(Circle::Radius(length));
       }
 
@@ -709,9 +710,9 @@ pub enum Ellipse {
   /// An ellipse with a specified horizontal and vertical radius.
   Size {
     /// The x-radius of the ellipse.
-    x: LengthPercentage,
+    x: NonNegative<LengthPercentage>,
     /// The y-radius of the ellipse.
-    y: LengthPercentage,
+    y: NonNegative<LengthPercentage>,
   },
   /// A shape extent keyword.
   #[cfg_attr(feature = "serde", serde(with = "ValueWrapper::<ShapeExtent>"))]
@@ -730,8 +731,8 @@ impl<'i> Parse<'i> for Ellipse {
       return Ok(Ellipse::Extent(extent));
     }
 
-    if let Ok(x) = input.try_parse(LengthPercentage::parse) {
-      let y = LengthPercentage::parse(input)?;
+    if let Ok(x) = input.try_parse(NonNegative::<LengthPercentage>::parse) {
+      let y = NonNegative::<LengthPercentage>::parse(input)?;
       // The `ellipse` keyword is optional if there are two lengths.
       let _ = input.try_parse(|input| input.expect_ident_matching("ellipse"));
       return Ok(Ellipse::Size { x, y });
@@ -742,8 +743,8 @@ impl<'i> Parse<'i> for Ellipse {
         return Ok(Ellipse::Extent(extent));
       }
 
-      if let Ok(x) = input.try_parse(LengthPercentage::parse) {
-        let y = LengthPercentage::parse(input)?;
+      if let Ok(x) = input.try_parse(NonNegative::<LengthPercentage>::parse) {
+        let y = NonNegative::<LengthPercentage>::parse(input)?;
         return Ok(Ellipse::Size { x, y });
       }
 
@@ -1466,7 +1467,7 @@ impl WebKitGradient {
         // Webkit radial gradients are always circles, not ellipses, and must be specified in pixels.
         let radius = match &radial.shape {
           EndingShape::Circle(Circle::Radius(radius)) => {
-            if let Some(r) = radius.to_px() {
+            if let Some(r) = radius.0.to_px() {
               r
             } else {
               return Err(());

--- a/src/values/length.rs
+++ b/src/values/length.rs
@@ -2,14 +2,14 @@
 
 use super::angle::impl_try_from_angle;
 use super::calc::{Calc, MathFunction};
-use super::number::CSSNumber;
+use super::number::{CSSNumber, NumericRange};
 use super::percentage::DimensionPercentage;
 use crate::error::{ParserError, PrinterError};
 use crate::printer::Printer;
 use crate::targets::Browsers;
 use crate::traits::{
   private::{AddInternal, TryAdd},
-  Map, Parse, Sign, ToCss, TryMap, TryOp, Zero,
+  Map, Parse, ParseNumeric, Sign, ToCss, TryMap, TryOp, Zero,
 };
 use crate::traits::{IsCompatible, TrySign};
 #[cfg(feature = "visitor")]
@@ -49,7 +49,7 @@ impl IsCompatible for LengthPercentage {
 }
 
 /// Either a [`<length-percentage>`](https://www.w3.org/TR/css-values-4/#typedef-length-percentage), or the `auto` keyword.
-#[derive(Debug, Clone, PartialEq, Parse, ToCss)]
+#[derive(Debug, Clone, PartialEq, ToCss)]
 #[cfg_attr(feature = "visitor", derive(Visit))]
 #[cfg_attr(
   feature = "serde",
@@ -63,6 +63,26 @@ pub enum LengthPercentageOrAuto {
   Auto,
   /// A [`<length-percentage>`](https://www.w3.org/TR/css-values-4/#typedef-length-percentage).
   LengthPercentage(LengthPercentage),
+}
+
+impl<'i> Parse<'i> for LengthPercentageOrAuto {
+  fn parse<'t>(input: &mut Parser<'i, 't>) -> Result<Self, ParseError<'i, ParserError<'i>>> {
+    Self::parse_with_range(input, NumericRange::All)
+  }
+}
+
+impl<'i> ParseNumeric<'i> for LengthPercentageOrAuto {
+  fn parse_with_range<'t>(
+    input: &mut Parser<'i, 't>,
+    range: NumericRange,
+  ) -> Result<Self, ParseError<'i, ParserError<'i>>> {
+    if input.try_parse(|input| input.expect_ident_matching("auto")).is_ok() {
+      return Ok(Self::Auto);
+    }
+    Ok(Self::LengthPercentage(LengthPercentage::parse_with_range(
+      input, range,
+    )?))
+  }
 }
 
 impl IsCompatible for LengthPercentageOrAuto {
@@ -104,10 +124,17 @@ macro_rules! define_length_units {
 
     impl<'i> Parse<'i> for LengthValue {
       fn parse<'t>(input: &mut Parser<'i, 't>) -> Result<Self, ParseError<'i, ParserError<'i>>> {
+        Self::parse_with_range(input, NumericRange::All)
+      }
+    }
+
+    impl<'i> ParseNumeric<'i> for LengthValue {
+      fn parse_with_range<'t>(input: &mut Parser<'i, 't>, range: NumericRange) -> Result<Self, ParseError<'i, ParserError<'i>>> {
         let location = input.current_source_location();
         let token = input.next()?;
         match *token {
           Token::Dimension { value, ref unit, .. } => {
+            let value = range.check(value, location)?;
             Ok(match unit {
               $(
                 s if s.eq_ignore_ascii_case(stringify!($name)) => LengthValue::$name(value),
@@ -117,7 +144,7 @@ macro_rules! define_length_units {
           },
           Token::Number { value, .. } => {
             // TODO: quirks mode only?
-            Ok(LengthValue::Px(value))
+            Ok(LengthValue::Px(range.check(value, location)?))
           }
           ref token => return Err(location.new_unexpected_token_error(token.clone())),
         }
@@ -552,13 +579,33 @@ pub enum Length {
 
 impl<'i> Parse<'i> for Length {
   fn parse<'t>(input: &mut Parser<'i, 't>) -> Result<Self, ParseError<'i, ParserError<'i>>> {
+    Self::parse_with_range(input, NumericRange::All)
+  }
+}
+
+impl<'i> ParseNumeric<'i> for Length {
+  fn parse_with_range<'t>(
+    input: &mut Parser<'i, 't>,
+    range: NumericRange,
+  ) -> Result<Self, ParseError<'i, ParserError<'i>>> {
     match input.try_parse(Calc::parse) {
-      Ok(Calc::Value(v)) => return Ok(*v),
+      Ok(Calc::Value(v)) => {
+        if range == NumericRange::All {
+          return Ok(*v);
+        }
+        if let Some(value) = v.try_map(|value| range.clamp(value)) {
+          return Ok(value);
+        }
+        return Ok(Length::Calc(Box::new(Calc::Function(Box::new(MathFunction::Calc(
+          Calc::Value(v),
+        ))))));
+      }
+      Ok(Calc::Number(_)) => return Err(input.new_custom_error(ParserError::InvalidValue)),
       Ok(calc) => return Ok(Length::Calc(Box::new(calc))),
       _ => {}
     }
 
-    let len = LengthValue::parse(input)?;
+    let len = LengthValue::parse_with_range(input, range)?;
     Ok(Length::Value(len))
   }
 }
@@ -807,7 +854,7 @@ impl TrySign for Length {
 impl_try_from_angle!(Length);
 
 /// Either a [`<length>`](https://www.w3.org/TR/css-values-4/#lengths) or a [`<number>`](https://www.w3.org/TR/css-values-4/#numbers).
-#[derive(Debug, Clone, PartialEq, Parse, ToCss)]
+#[derive(Debug, Clone, PartialEq, ToCss)]
 #[cfg_attr(feature = "visitor", derive(Visit))]
 #[cfg_attr(
   feature = "serde",
@@ -821,6 +868,24 @@ pub enum LengthOrNumber {
   Number(CSSNumber),
   /// A length.
   Length(Length),
+}
+
+impl<'i> Parse<'i> for LengthOrNumber {
+  fn parse<'t>(input: &mut Parser<'i, 't>) -> Result<Self, ParseError<'i, ParserError<'i>>> {
+    Self::parse_with_range(input, NumericRange::All)
+  }
+}
+
+impl<'i> ParseNumeric<'i> for LengthOrNumber {
+  fn parse_with_range<'t>(
+    input: &mut Parser<'i, 't>,
+    range: NumericRange,
+  ) -> Result<Self, ParseError<'i, ParserError<'i>>> {
+    if let Ok(value) = input.try_parse(|input| CSSNumber::parse_with_range(input, range)) {
+      return Ok(Self::Number(value));
+    }
+    Ok(Self::Length(Length::parse_with_range(input, range)?))
+  }
 }
 
 impl Default for LengthOrNumber {

--- a/src/values/number.rs
+++ b/src/values/number.rs
@@ -5,8 +5,88 @@ use super::calc::Calc;
 use crate::error::{ParserError, PrinterError};
 use crate::printer::Printer;
 use crate::traits::private::AddInternal;
-use crate::traits::{Map, Op, Parse, Sign, ToCss, Zero};
+use crate::traits::{IsCompatible, Map, Op, Parse, ParseNumeric, Sign, ToCss, TrySign, Zero};
+#[cfg(feature = "visitor")]
+use crate::visitor::Visit;
 use cssparser::*;
+
+/// Describes what values are allowed when parsing a numeric value.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NumericRange {
+  /// All values are allowed.
+  All,
+  /// Only values >= 0 are allowed.
+  NonNegative,
+}
+
+impl NumericRange {
+  /// Checks whether a value is allowed.
+  pub fn check(
+    &self,
+    value: f32,
+    location: SourceLocation,
+  ) -> Result<f32, ParseError<'static, ParserError<'static>>> {
+    match self {
+      NumericRange::All => Ok(value),
+      NumericRange::NonNegative if value >= 0.0 => Ok(value),
+      _ => Err(location.new_custom_error(ParserError::InvalidValue)),
+    }
+  }
+
+  /// Clamps the value to the valid range.
+  pub fn clamp(&self, value: f32) -> f32 {
+    match self {
+      NumericRange::All => value,
+      NumericRange::NonNegative => value.max(0.0),
+    }
+  }
+}
+
+/// A numeric value in a grammar position that only allows non-negative values.
+///
+/// Negative literals are rejected. Calculations are clamped when their result
+/// can be resolved, or preserved for the browser to clamp after resolution.
+/// This wrapper constrains parsing; its contents may still be modified directly.
+#[derive(Debug, Clone, Copy, PartialEq, PartialOrd, Default)]
+#[cfg_attr(feature = "visitor", derive(Visit))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize), serde(transparent))]
+#[cfg_attr(feature = "jsonschema", derive(schemars::JsonSchema))]
+#[cfg_attr(feature = "into_owned", derive(static_self::IntoOwned))]
+pub struct NonNegative<T>(pub T);
+
+impl<'i, T: ParseNumeric<'i>> Parse<'i> for NonNegative<T> {
+  fn parse<'t>(input: &mut Parser<'i, 't>) -> Result<Self, ParseError<'i, ParserError<'i>>> {
+    T::parse_with_range(input, NumericRange::NonNegative).map(Self)
+  }
+}
+
+impl<T: ToCss> ToCss for NonNegative<T> {
+  fn to_css<W: std::fmt::Write>(&self, dest: &mut Printer<W>) -> Result<(), PrinterError> {
+    self.0.to_css(dest)
+  }
+}
+
+impl<T: IsCompatible> IsCompatible for NonNegative<T> {
+  fn is_compatible(&self, browsers: crate::targets::Browsers) -> bool {
+    self.0.is_compatible(browsers)
+  }
+}
+
+impl<T: Zero> Zero for NonNegative<T> {
+  fn zero() -> Self {
+    Self(T::zero())
+  }
+
+  fn is_zero(&self) -> bool {
+    self.0.is_zero()
+  }
+}
+
+impl<T: TrySign> TrySign for NonNegative<T> {
+  fn try_sign(&self) -> Option<f32> {
+    self.0.try_sign()
+  }
+}
 
 /// A CSS [`<number>`](https://www.w3.org/TR/css-values-4/#numbers) value.
 ///
@@ -16,16 +96,26 @@ pub type CSSNumber = f32;
 
 impl<'i> Parse<'i> for CSSNumber {
   fn parse<'t>(input: &mut Parser<'i, 't>) -> Result<Self, ParseError<'i, ParserError<'i>>> {
+    Self::parse_with_range(input, NumericRange::All)
+  }
+}
+
+impl<'i> ParseNumeric<'i> for CSSNumber {
+  fn parse_with_range<'t>(
+    input: &mut Parser<'i, 't>,
+    range: NumericRange,
+  ) -> Result<Self, ParseError<'i, ParserError<'i>>> {
     match input.try_parse(Calc::parse) {
-      Ok(Calc::Value(v)) => return Ok(*v),
-      Ok(Calc::Number(n)) => return Ok(n),
+      Ok(Calc::Value(v)) => return Ok(range.clamp(*v)),
+      Ok(Calc::Number(n)) => return Ok(range.clamp(n)),
       // Numbers are always compatible, so they will always compute to a value.
       Ok(_) => return Err(input.new_custom_error(ParserError::InvalidValue)),
       _ => {}
     }
 
+    let location = input.current_source_location();
     let number = input.expect_number()?;
-    Ok(number)
+    range.check(number, location)
   }
 }
 
@@ -115,8 +205,19 @@ pub type CSSInteger = i32;
 
 impl<'i> Parse<'i> for CSSInteger {
   fn parse<'t>(input: &mut Parser<'i, 't>) -> Result<Self, ParseError<'i, ParserError<'i>>> {
+    Self::parse_with_range(input, NumericRange::All)
+  }
+}
+
+impl<'i> ParseNumeric<'i> for CSSInteger {
+  fn parse_with_range<'t>(
+    input: &mut Parser<'i, 't>,
+    range: NumericRange,
+  ) -> Result<Self, ParseError<'i, ParserError<'i>>> {
     // TODO: calc??
+    let location = input.current_source_location();
     let integer = input.expect_integer()?;
+    range.check(integer as f32, location)?;
     Ok(integer)
   }
 }

--- a/src/values/percentage.rs
+++ b/src/values/percentage.rs
@@ -2,11 +2,13 @@
 
 use super::angle::{impl_try_from_angle, Angle};
 use super::calc::{Calc, MathFunction};
-use super::number::CSSNumber;
+use super::number::{CSSNumber, NumericRange};
 use crate::error::{ParserError, PrinterError};
 use crate::printer::Printer;
 use crate::traits::private::AddInternal;
-use crate::traits::{impl_op, private::TryAdd, Op, Parse, Sign, ToCss, TryMap, TryOp, TrySign, Zero};
+use crate::traits::{
+  impl_op, private::TryAdd, Op, Parse, ParseNumeric, Sign, ToCss, TryMap, TryOp, TrySign, Zero,
+};
 #[cfg(feature = "visitor")]
 use crate::visitor::Visit;
 use cssparser::*;
@@ -24,15 +26,25 @@ pub struct Percentage(pub CSSNumber);
 
 impl<'i> Parse<'i> for Percentage {
   fn parse<'t>(input: &mut Parser<'i, 't>) -> Result<Self, ParseError<'i, ParserError<'i>>> {
-    match input.try_parse(Calc::parse) {
-      Ok(Calc::Value(v)) => return Ok(*v),
-      // Percentages are always compatible, so they will always compute to a value.
-      Ok(_) => unreachable!(),
+    Self::parse_with_range(input, NumericRange::All)
+  }
+}
+
+impl<'i> ParseNumeric<'i> for Percentage {
+  fn parse_with_range<'t>(
+    input: &mut Parser<'i, 't>,
+    range: NumericRange,
+  ) -> Result<Self, ParseError<'i, ParserError<'i>>> {
+    match input.try_parse(Calc::<Self>::parse) {
+      Ok(Calc::Value(v)) => return Ok(Percentage(range.clamp(v.0))),
+      // A percentage calculation must resolve to a percentage, not a number.
+      Ok(_) => return Err(input.new_custom_error(ParserError::InvalidValue)),
       _ => {}
     }
 
+    let location = input.current_source_location();
     let percent = input.expect_percentage()?;
-    Ok(Percentage(percent))
+    Ok(Percentage(range.check(percent, location)?))
   }
 }
 
@@ -143,7 +155,7 @@ impl_op!(Percentage, std::ops::Add, add);
 impl_try_from_angle!(Percentage);
 
 /// Either a `<number>` or `<percentage>`.
-#[derive(Debug, Clone, PartialEq, Parse, ToCss)]
+#[derive(Debug, Clone, PartialEq, ToCss)]
 #[cfg_attr(feature = "visitor", derive(Visit))]
 #[cfg_attr(
   feature = "serde",
@@ -157,6 +169,24 @@ pub enum NumberOrPercentage {
   Number(CSSNumber),
   /// A percentage.
   Percentage(Percentage),
+}
+
+impl<'i> Parse<'i> for NumberOrPercentage {
+  fn parse<'t>(input: &mut Parser<'i, 't>) -> Result<Self, ParseError<'i, ParserError<'i>>> {
+    Self::parse_with_range(input, NumericRange::All)
+  }
+}
+
+impl<'i> ParseNumeric<'i> for NumberOrPercentage {
+  fn parse_with_range<'t>(
+    input: &mut Parser<'i, 't>,
+    range: NumericRange,
+  ) -> Result<Self, ParseError<'i, ParserError<'i>>> {
+    if let Ok(value) = input.try_parse(|input| CSSNumber::parse_with_range(input, range)) {
+      return Ok(Self::Number(value));
+    }
+    Ok(Self::Percentage(Percentage::parse_with_range(input, range)?))
+  }
 }
 
 impl std::convert::Into<CSSNumber> for &NumberOrPercentage {
@@ -193,7 +223,7 @@ pub enum DimensionPercentage<D> {
 
 impl<
     'i,
-    D: Parse<'i>
+    D: ParseNumeric<'i>
       + std::ops::Mul<CSSNumber, Output = D>
       + TryAdd<D>
       + Clone
@@ -208,17 +238,57 @@ impl<
   > Parse<'i> for DimensionPercentage<D>
 {
   fn parse<'t>(input: &mut Parser<'i, 't>) -> Result<Self, ParseError<'i, ParserError<'i>>> {
+    Self::parse_with_range(input, NumericRange::All)
+  }
+}
+
+impl<
+    'i,
+    D: ParseNumeric<'i>
+      + std::ops::Mul<CSSNumber, Output = D>
+      + TryAdd<D>
+      + Clone
+      + TryOp
+      + TryMap
+      + Zero
+      + TrySign
+      + TryFrom<Angle>
+      + TryInto<Angle>
+      + PartialOrd<D>
+      + std::fmt::Debug,
+  > ParseNumeric<'i> for DimensionPercentage<D>
+{
+  fn parse_with_range<'t>(
+    input: &mut Parser<'i, 't>,
+    range: NumericRange,
+  ) -> Result<Self, ParseError<'i, ParserError<'i>>> {
     match input.try_parse(Calc::parse) {
-      Ok(Calc::Value(v)) => return Ok(*v),
+      Ok(Calc::Value(v)) => {
+        if range == NumericRange::All {
+          return Ok(*v);
+        }
+        if let Some(value) = v.try_map(|value| range.clamp(value)) {
+          return Ok(value);
+        }
+        if matches!(&*v, DimensionPercentage::Percentage(Percentage(value)) if *value >= 0.0) {
+          return Ok(*v);
+        }
+        // A negative percentage cannot be emitted as a literal in this range.
+        // Preserve the math boundary rather than clamp it before its basis is known.
+        return Ok(DimensionPercentage::Calc(Box::new(Calc::Function(Box::new(
+          MathFunction::Calc(Calc::Value(v)),
+        )))));
+      }
+      Ok(Calc::Number(_)) => return Err(input.new_custom_error(ParserError::InvalidValue)),
       Ok(calc) => return Ok(DimensionPercentage::Calc(Box::new(calc))),
       _ => {}
     }
 
-    if let Ok(length) = input.try_parse(|input| D::parse(input)) {
+    if let Ok(length) = input.try_parse(|input| D::parse_with_range(input, range)) {
       return Ok(DimensionPercentage::Dimension(length));
     }
 
-    if let Ok(percent) = input.try_parse(|input| Percentage::parse(input)) {
+    if let Ok(percent) = input.try_parse(|input| Percentage::parse_with_range(input, range)) {
       return Ok(DimensionPercentage::Percentage(percent));
     }
 

--- a/src/values/ratio.rs
+++ b/src/values/ratio.rs
@@ -1,6 +1,6 @@
 //! CSS ratio values.
 
-use super::number::CSSNumber;
+use super::number::{CSSNumber, NonNegative};
 use crate::error::{ParserError, PrinterError};
 use crate::printer::Printer;
 use crate::traits::{Parse, ToCss};
@@ -16,15 +16,15 @@ use cssparser::*;
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "jsonschema", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "into_owned", derive(static_self::IntoOwned))]
-pub struct Ratio(pub CSSNumber, pub CSSNumber);
+pub struct Ratio(pub NonNegative<CSSNumber>, pub NonNegative<CSSNumber>);
 
 impl<'i> Parse<'i> for Ratio {
   fn parse<'t>(input: &mut Parser<'i, 't>) -> Result<Self, ParseError<'i, ParserError<'i>>> {
-    let first = CSSNumber::parse(input)?;
+    let first = NonNegative::<CSSNumber>::parse(input)?;
     let second = if input.try_parse(|input| input.expect_delim('/')).is_ok() {
-      CSSNumber::parse(input)?
+      NonNegative::<CSSNumber>::parse(input)?
     } else {
-      1.0
+      NonNegative(1.0)
     };
 
     Ok(Ratio(first, second))
@@ -34,9 +34,9 @@ impl<'i> Parse<'i> for Ratio {
 impl Ratio {
   /// Parses a ratio where both operands are required.
   pub fn parse_required<'i, 't>(input: &mut Parser<'i, 't>) -> Result<Self, ParseError<'i, ParserError<'i>>> {
-    let first = CSSNumber::parse(input)?;
+    let first = NonNegative::<CSSNumber>::parse(input)?;
     input.expect_delim('/')?;
-    let second = CSSNumber::parse(input)?;
+    let second = NonNegative::<CSSNumber>::parse(input)?;
     Ok(Ratio(first, second))
   }
 }
@@ -47,7 +47,7 @@ impl ToCss for Ratio {
     W: std::fmt::Write,
   {
     self.0.to_css(dest)?;
-    if self.1 != 1.0 {
+    if self.1 .0 != 1.0 {
       dest.delim('/', true)?;
       self.1.to_css(dest)?;
     }
@@ -59,6 +59,6 @@ impl std::ops::Add<CSSNumber> for Ratio {
   type Output = Self;
 
   fn add(self, other: CSSNumber) -> Ratio {
-    Ratio(self.0 + other, self.1)
+    Ratio(NonNegative(self.0 .0 + other), self.1)
   }
 }

--- a/src/values/resolution.rs
+++ b/src/values/resolution.rs
@@ -1,11 +1,11 @@
 //! CSS resolution values.
 
 use super::length::serialize_dimension;
-use super::number::CSSNumber;
+use super::number::{CSSNumber, NumericRange};
 use crate::compat::Feature;
 use crate::error::{ParserError, PrinterError};
 use crate::printer::Printer;
-use crate::traits::{Parse, ToCss};
+use crate::traits::{Parse, ParseNumeric, ToCss};
 #[cfg(feature = "visitor")]
 use crate::visitor::Visit;
 use cssparser::*;
@@ -32,10 +32,20 @@ pub enum Resolution {
 
 impl<'i> Parse<'i> for Resolution {
   fn parse<'t>(input: &mut Parser<'i, 't>) -> Result<Self, ParseError<'i, ParserError<'i>>> {
+    Self::parse_with_range(input, NumericRange::All)
+  }
+}
+
+impl<'i> ParseNumeric<'i> for Resolution {
+  fn parse_with_range<'t>(
+    input: &mut Parser<'i, 't>,
+    range: NumericRange,
+  ) -> Result<Self, ParseError<'i, ParserError<'i>>> {
     // TODO: calc?
     let location = input.current_source_location();
     match *input.next()? {
       Token::Dimension { value, ref unit, .. } => {
+        let value = range.check(value, location)?;
         match_ignore_ascii_case! { unit,
           "dpi" => Ok(Resolution::Dpi(value)),
           "dpcm" => Ok(Resolution::Dpcm(value)),

--- a/src/values/shape.rs
+++ b/src/values/shape.rs
@@ -8,6 +8,7 @@ use crate::macros::enum_property;
 use crate::printer::Printer;
 use crate::properties::border_radius::BorderRadius;
 use crate::traits::{Parse, ToCss};
+use crate::values::number::NonNegative;
 #[cfg(feature = "visitor")]
 use crate::visitor::Visit;
 use cssparser::*;
@@ -69,7 +70,7 @@ pub struct Circle {
 #[cfg_attr(feature = "jsonschema", derive(schemars::JsonSchema))]
 pub enum ShapeRadius {
   /// An explicit length or percentage.
-  LengthPercentage(LengthPercentage),
+  LengthPercentage(NonNegative<LengthPercentage>),
   /// The length from the center to the closest side of the box.
   ClosestSide,
   /// The length from the center to the farthest side of the box.

--- a/src/values/time.rs
+++ b/src/values/time.rs
@@ -2,11 +2,11 @@
 
 use super::angle::impl_try_from_angle;
 use super::calc::Calc;
-use super::number::CSSNumber;
+use super::number::{CSSNumber, NumericRange};
 use crate::error::{ParserError, PrinterError};
 use crate::printer::Printer;
 use crate::traits::private::AddInternal;
-use crate::traits::{impl_op, Map, Op, Parse, Sign, ToCss, Zero};
+use crate::traits::{impl_op, Map, Op, Parse, ParseNumeric, Sign, ToCss, Zero};
 #[cfg(feature = "visitor")]
 use crate::visitor::Visit;
 use cssparser::*;
@@ -58,8 +58,17 @@ impl Zero for Time {
 
 impl<'i> Parse<'i> for Time {
   fn parse<'t>(input: &mut Parser<'i, 't>) -> Result<Self, ParseError<'i, ParserError<'i>>> {
-    match input.try_parse(Calc::parse) {
-      Ok(Calc::Value(v)) => return Ok(*v),
+    Self::parse_with_range(input, NumericRange::All)
+  }
+}
+
+impl<'i> ParseNumeric<'i> for Time {
+  fn parse_with_range<'t>(
+    input: &mut Parser<'i, 't>,
+    range: NumericRange,
+  ) -> Result<Self, ParseError<'i, ParserError<'i>>> {
+    match input.try_parse(Calc::<Self>::parse) {
+      Ok(Calc::Value(v)) => return Ok(v.map(|value| range.clamp(value))),
       // Time is always compatible, so they will always compute to a value.
       Ok(_) => return Err(input.new_custom_error(ParserError::InvalidValue)),
       _ => {}
@@ -68,6 +77,7 @@ impl<'i> Parse<'i> for Time {
     let location = input.current_source_location();
     match *input.next()? {
       Token::Dimension { value, ref unit, .. } => {
+        let value = range.check(value, location)?;
         match_ignore_ascii_case! { unit,
           "s" => Ok(Time::Seconds(value)),
           "ms" => Ok(Time::Milliseconds(value)),


### PR DESCRIPTION
Fixes #1000. Also fixes over 600 web platform tests (run against #1328).

Properties that only allow non-negative values are now wrapped in the `NonNegative` helper type, e.g. `NonNegative<Length>`. This rejects invalid negative values during parsing (though we still fall back to preserving the raw css tokens). For known calc expressions that resolve to negative values e.g. `calc(-10px)`, these are still syntactically valid, but are now clamped to zero.