### PR TITLE
fix: handle unparseable @container conditions with error_recovery

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -674,6 +674,12 @@ impl<'a, 'b, 'i, T: crate::traits::AtRuleParser<'i>> AtRuleParser<'i> for Nested
             if name.is_some() && input.is_exhausted() {
               // name only, no condition - allowed by new syntax
               AtRulePrelude::Container(name, None)
+            } else if self.options.error_recovery {
+              // When error recovery is enabled, use Unknown for unparseable conditions
+              // instead of propagating the error. This allows the CSS to be parsed
+              // despite unsupported @container syntax (e.g., future scroll-state queries).
+              self.options.warn(e);
+              AtRulePrelude::Container(name, Some(ContainerCondition::Unknown(TokenList::parse(input, &self.options, 0)?)))
             } else {
               // condition parsing failed (e.g., empty brackets or invalid tokens)
               return Err(e);


### PR DESCRIPTION
## Summary

When parsing `@container <name> { ... }` (named container query with no condition), the lightningcss parser fails with "Unexpected end of input" because the `{` token is not recognized as a valid container condition.

This affects Turbopack (used by Next.js) which uses `error_recovery: true` in its CSS parsing configuration.

## Root Cause

In `src/parser.rs`, the `@container` case has this error handling:

```rust
Err(e) => {
  if name.is_some() && input.is_exhausted() {
    // name only, no condition - allowed by new syntax
    AtRulePrelude::Container(name, None)
  } else {
    return Err(e);  // <-- This is the problem
  }
}
```

When `input.is_exhausted()` is false (i.e., there's a `{` token waiting), it returns an error instead of checking `error_recovery`.

## Fix

Check `self.options.error_recovery` before returning the error. When error recovery is enabled, use `ContainerCondition::Unknown` for unparseable conditions:

```rust
Err(e) => {
  if name.is_some() && input.is_exhausted() {
    AtRulePrelude::Container(name, None)
  } else if self.options.error_recovery {
    self.options.warn(e);
    AtRulePrelude::Container(name, Some(
      ContainerCondition::Unknown(TokenList::parse(input, &self.options, 0)?)
    ))
  } else {
    return Err(e);
  }
}
```

## Testing

The fix allows CSS like this to be parsed without error:

```css
@supports (container-type: inline-size scroll-state) {
  @container scroll-content {
    .foo { max-width: 100cqw; }
  }
}
```

This CSS is generated by real-world libraries like `nhsuk-frontend`.
